### PR TITLE
Fix fetch cache error handling

### DIFF
--- a/src/__tests__/fetchCache.test.js
+++ b/src/__tests__/fetchCache.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchTextCached } from '../utils/fetchCache.js'
+
+describe('fetchTextCached', () => {
+  it('retries fetching after a failure', async () => {
+    const url = '/test.txt'
+    const originalFetch = globalThis.fetch
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('ok')
+      })
+    globalThis.fetch = fetchMock
+
+    await expect(fetchTextCached(url)).rejects.toThrow('fail')
+    await expect(fetchTextCached(url)).resolves.toBe('ok')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    globalThis.fetch = originalFetch
+  })
+})
+

--- a/src/utils/fetchCache.js
+++ b/src/utils/fetchCache.js
@@ -3,7 +3,16 @@ const textCache = new Map() // url -> Promise<string>
 
 export function fetchTextCached(url) {
   if (textCache.has(url)) return textCache.get(url)
-  const p = fetch(url).then(r => r.text())
+  const p = fetch(url)
+    .then(r => {
+      if (!r.ok) throw new Error(`Failed to fetch ${url}: ${r.status} ${r.statusText}`)
+      return r.text()
+    })
+    .catch(err => {
+      // Don't cache failures so callers can retry
+      textCache.delete(url)
+      throw err
+    })
   textCache.set(url, p)
   return p
 }


### PR DESCRIPTION
## Summary
- avoid caching failed fetch responses and throw error when response not ok
- add test covering retry logic for fetch cache

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_689a7b7d71548327a310f1408b1a8954