### PR TITLE
Fix grammar in lyrics filter label

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -146,7 +146,7 @@ export default function Home(){
               checked={lyricsOn}
               onChange={e=> setLyricsOn(e.target.checked)}
             />
-            <span className="meta">Lyrics contains</span>
+            <span className="meta">Lyrics contain</span>
           </label>
         </div>
 


### PR DESCRIPTION
## Summary
- fix checkbox label grammar for lyrics search option

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_689a80c0a59c832791df7bed3fdc9b87