### PR TITLE
Ensure VERSE sections parsed from ChordPro

### DIFF
--- a/src/__tests__/chordpro.utils.test.js
+++ b/src/__tests__/chordpro.utils.test.js
@@ -69,6 +69,22 @@ describe('parseChordPro', () => {
 
     if (topBlocks) {
       blocks = topBlocks
+        .map(b => {
+          const arr = []
+          if (b.section) arr.push({ type: 'section', header: b.section })
+          ;(b.lines || []).forEach(ln => {
+            arr.push({
+              type: 'line',
+              lyrics: ln.plain || ln.text || '',
+              chords: (ln.chords || ln.chordPositions || []).map(c => ({
+                index: typeof c.index === 'number' ? c.index : 0,
+                sym: c.sym
+              }))
+            })
+          })
+          return arr
+        })
+        .flat()
     } else if (Array.isArray(lb)) {
       blocks = lb
         .map(b => {
@@ -125,11 +141,14 @@ describe('parseChordPro', () => {
       expect(hasSomeStructure || true).toBe(true)
     }
 
-    // Soft: if sections are present, at least one looks like VERSE
+    // Expect a section header when [VERSE] is present in the source
     const sections = blocks.filter(b => b.type === 'section')
-    if (sections.length) {
-      const hasVerse = sections.some(s => /verse/i.test(s.header || ''))
-      expect(hasVerse).toBe(true)
-    }
+    expect(sections.length).toBeGreaterThan(0)
+
+    // Verify at least one section header equals "VERSE" (case-insensitive)
+    const hasVerse = sections.some(
+      s => typeof s.header === 'string' && s.header.trim().toUpperCase() === 'VERSE'
+    )
+    expect(hasVerse).toBe(true)
   })
 })

--- a/src/utils/chordpro.js
+++ b/src/utils/chordpro.js
@@ -4,7 +4,7 @@ export function parseChordPro(text){
   for(const raw of lines){
     const m=raw.match(metaRe); if(m){ meta[m[1].trim().toLowerCase()] = m[2].trim(); continue }
     if(raw.trim()===''){ if(current.lines.length) blocks.push(current); current={section:'',lines:[]}; continue }
-    const secMatch=raw.match(/^\s*(?:##?\s*|\[)([^#\]]+?)(?:\])?\s*$/); if(secMatch && !raw.includes('[')){ if(current.lines.length) blocks.push(current); current={section:secMatch[1].trim(),lines:[]}; continue }
+    const secMatch=raw.match(/^\s*(?:##?\s*|\[)([^#\]]+?)(?:\])?\s*$/); if(secMatch && (!raw.includes('[') || /^\s*\[[^#\]]+\]\s*$/.test(raw))){ if(current.lines.length) blocks.push(current); current={section:secMatch[1].trim(),lines:[]}; continue }
     const { plain, chords } = extractChords(raw); current.lines.push({ text: plain, chords })
   } if(current.lines.length) blocks.push(current); return { meta, blocks }
 }


### PR DESCRIPTION
## Summary
- Normalize parsed blocks into explicit section and line entries
- Parse bracketed lines like `[VERSE]` as section headers
- Assert presence of VERSE section in chordpro parser tests

## Testing
- `npm run test:run` *(fails: Cannot read properties of null (reading 'useRef'))*
- `npx vitest run src/__tests__/chordpro.utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a80f4c7f48327a0f5cf5f70fe35d6