### PR TITLE
Handle bracketed section headers in parseChordPro

### DIFF
--- a/src/__tests__/chordpro.utils.test.js
+++ b/src/__tests__/chordpro.utils.test.js
@@ -132,4 +132,13 @@ describe('parseChordPro', () => {
       expect(hasVerse).toBe(true)
     }
   })
+
+  it('identifies bracketed lines as sections and not chords', () => {
+    const src = `\n[VERSE]\n[G]Hello\n[CHORUS]\nWorld`;
+    const parsed = parseChordPro(src);
+    expect(parsed.blocks.map(b => b.section)).toEqual(['VERSE', 'CHORUS']);
+    const firstLine = parsed.blocks[0].lines[0];
+    expect(firstLine.text).toBe('Hello');
+    expect(firstLine.chords[0].sym).toBe('G');
+  })
 })

--- a/src/utils/chordpro.js
+++ b/src/utils/chordpro.js
@@ -4,7 +4,15 @@ export function parseChordPro(text){
   for(const raw of lines){
     const m=raw.match(metaRe); if(m){ meta[m[1].trim().toLowerCase()] = m[2].trim(); continue }
     if(raw.trim()===''){ if(current.lines.length) blocks.push(current); current={section:'',lines:[]}; continue }
-    const secMatch=raw.match(/^\s*(?:##?\s*|\[)([^#\]]+?)(?:\])?\s*$/); if(secMatch && !raw.includes('[')){ if(current.lines.length) blocks.push(current); current={section:secMatch[1].trim(),lines:[]}; continue }
+    const secMatch=raw.match(/^\s*(?:##?\s*|\[)([^#\]]+?)(?:\])?\s*$/);
+    if(secMatch){
+      const tag=secMatch[1].trim();
+      const bracketOnly=/^\s*\[[^\]]+\]\s*$/.test(raw);
+      const chordLike=/^[A-G][#b]?(?:m|maj|min|dim|aug|sus|add)?\d*(?:\/[A-G][#b]?)?$/i.test(tag);
+      if(!raw.includes('[') || (bracketOnly && !chordLike)){
+        if(current.lines.length) blocks.push(current); current={section:tag,lines:[]}; continue
+      }
+    }
     const { plain, chords } = extractChords(raw); current.lines.push({ text: plain, chords })
   } if(current.lines.length) blocks.push(current); return { meta, blocks }
 }


### PR DESCRIPTION
## Summary
- allow `[VERSE]` style bracketed lines to count as section headers in `parseChordPro`
- add regression test ensuring bracket-only lines are treated as sections, not chords

## Testing
- `node node_modules/vitest/vitest.mjs src/__tests__/chordpro.utils.test.js`
- `node node_modules/vitest/vitest.mjs` *(fails: Cannot read properties of null (reading 'useRef'))*

------
https://chatgpt.com/codex/tasks/task_e_689a810621188327b4de8cc19f1bb700