### PR TITLE
docs: add wiki and sync workflow

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,21 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/wiki/**'
+      - '.github/workflows/wiki-sync.yml'
+      - 'scripts/syncWiki.mjs'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/syncWiki.mjs
+        env:
+          WIKI_PUSH_TOKEN: ${{ secrets.WIKI_PUSH_TOKEN }}

--- a/docs/wiki/Admin-Tool.md
+++ b/docs/wiki/Admin-Tool.md
@@ -1,0 +1,13 @@
+# Admin Tool
+
+A lightweight editor for creating ChordPro files.
+
+## Use
+- Navigate to `/admin` and enter the password
+- Compose or paste text, preview the render, and export
+- Select multiple songs to download as a ZIP of `.chordpro`
+
+## Password
+Set `VITE_ADMIN_PASSWORD` in `.env` for deploys. Without it, a default password allows access. Keep this tool private.
+
+See [[ChordPro-Guide]] for formatting tips. After adding songs, run [[Index-Building]].

--- a/docs/wiki/ChordPro-Guide.md
+++ b/docs/wiki/ChordPro-Guide.md
@@ -1,0 +1,23 @@
+# ChordPro Guide
+
+GraceChords reads standard ChordPro with a few conventions. Helpful when using the [[Admin-Tool]].
+
+## Headers
+Headers are case-insensitive. Sentence case is acceptable:
+```
+{title: Glorious King}
+{artist: Example Band}
+{key: G}
+{tags: Easter, Fast}
+{authors: Jane Doe}
+{country: US}
+```
+
+## Lines
+- Place chords in square brackets within lyrics: `You [G]are the [D]light`
+- Leave chord-less lines blank; they render as spacing
+
+## Tips
+- Use `{comment:}` for notes to players
+- Avoid trailing spaces; they affect layout
+- Keep tags short; they fuel [[Search-and-Tags]]

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,0 +1,21 @@
+# Contributing
+
+We welcome fixes and new songs. Start with [[Getting-Started]] and [[Project-Structure]].
+
+## Workflow
+1. Create a feature branch
+2. Run tests
+   ```bash
+   npm test
+   ```
+3. Commit with clear messages and open a pull request
+
+## Coding Standards
+- Prefer functional React components
+- Run Prettier or ESLint if available in your editor
+- Keep `docs/CNAME` and built assets out of commits unless needed
+
+## Wiki Sync
+`node scripts/syncWiki.mjs` pushes `docs/wiki` to `GraceChords.wiki`. Set a `WIKI_PUSH_TOKEN` (fine-grained PAT with wiki write access) as an environment variable or repository secret.
+
+Thanks for contributing!

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,22 @@
+# Getting Started
+
+These steps set up a local build of [[GraceChords|Home]].
+
+## Prerequisites
+- Node.js 18+
+- npm
+
+## Install and Run
+```bash
+npm i
+npm run dev
+```
+The dev server runs at http://localhost:5173.
+
+## Build for GitHub Pages
+```bash
+npm run build
+```
+The production bundle lands in `docs/`. GitHub Pages serves that folder on `main`. Keep `docs/CNAME` so the custom domain persists.
+
+See [[Project-Structure]] for more detail.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,21 @@
+# GraceChords
+
+GraceChords is a React + Vite single-page app for worship song charts. It builds to `docs/` using a HashRouter and is hosted at [gracechords.com](https://gracechords.com).
+
+## Key Features
+- ChordPro files live under `public/songs`
+- Fuse.js search with optional tag filters
+- Export single songs or bundles as PDF
+- Optional PPTX lyric slides per song
+- Setlists saved in `localStorage`
+
+## Quick Links
+- [[Getting-Started]]
+- [[Project-Structure]]
+- [[ChordPro-Guide]]
+- [[SongView]]
+- [[Setlists]]
+- [[PDF-and-Printing]]
+- [[Slides-(PPTX)]]
+- [[Troubleshooting]]
+- [[Contributing]]

--- a/docs/wiki/Index-Building.md
+++ b/docs/wiki/Index-Building.md
@@ -1,0 +1,23 @@
+# Index Building
+
+`scripts/buildIndex.mjs` scans `public/songs/*.chordpro` and writes `src/data/index.json`.
+
+## Run
+```bash
+npm run build-index
+```
+
+## Extracted Metadata
+- `id` (from `{id:}` or sanitized title)
+- `title`
+- `key`
+- `tags`
+- `authors`
+- `country`
+
+## Common Errors
+- Missing song file
+- Malformed header line
+- File not saved with `.chordpro`
+
+Re-run after editing songs so [[Search-and-Tags]] stays updated.

--- a/docs/wiki/PDF-and-Printing.md
+++ b/docs/wiki/PDF-and-Printing.md
@@ -1,0 +1,18 @@
+# PDF and Printing
+
+The PDF engine keeps charts clean and rehearsal-ready. Exports are available from [[SongView]], [[Setlists]], and [[Songbook-Builder]].
+
+## Layout
+- Adaptive 1–2 column planner
+- **Never split a section:** a verse or chorus moves as a whole
+- Embedded fonts: `Noto Sans` for lyrics, `Noto Sans Mono` for chords
+
+## Multi-song Export
+- [[Setlists]] bundle multiple songs into one PDF
+- Choose 1 or 2 columns before exporting
+- Songbook builder adds title and table of contents
+
+## Troubleshooting Page Breaks
+- Long sections may overflow; add a `{comment: repeat}` and split
+- If fonts fail to embed, ensure `docs/fonts/` is deployed
+- PDFs rely on browser PDF viewer; print issues often stem from its settings

--- a/docs/wiki/Project-Structure.md
+++ b/docs/wiki/Project-Structure.md
@@ -1,0 +1,19 @@
+# Project Structure
+
+Understanding where things live helps when contributing. See [[Getting-Started]] for setup.
+
+```
+/ (repo root)
+├── src/        React components, routes, utils
+├── public/     Static assets and `songs/*.chordpro`
+├── docs/       Built site served by GitHub Pages
+├── scripts/    Node helpers like `buildIndex.mjs`
+└── docs/wiki/  This wiki's source files
+```
+
+Key directories under `src/`:
+- `components/` — route pages such as `Home`, `SongView`, `Setlist`, `Admin`
+- `data/` — generated index of songs
+- `utils/` — parsing, PDF helpers, etc.
+
+Static songs are stored in `public/songs/`. During `npm run build` they copy to `docs/songs/`.

--- a/docs/wiki/Search-and-Tags.md
+++ b/docs/wiki/Search-and-Tags.md
@@ -1,0 +1,14 @@
+# Search and Tags
+
+The home page uses Fuse.js for fuzzy search across titles, authors, and tags.
+
+## Tips
+- Click a tag chip to filter results
+- Search is case-insensitive and ignores punctuation
+- Tags must be defined in the song's header `{tags: youth, upbeat}`
+
+## Limitations
+- No stemming or plural awareness
+- Tag filtering matches any tag, not all
+
+For indexed fields see [[Index-Building]].

--- a/docs/wiki/Setlists.md
+++ b/docs/wiki/Setlists.md
@@ -1,0 +1,14 @@
+# Setlists
+
+Plan services by collecting songs into a setlist.
+
+## Basics
+- Use **Add to Setlist** from [[SongView]] or the search results
+- Drag to reorder; click to remove
+- Lists persist in `localStorage`
+
+## Export
+- Bundle the list as a combined PDF or PPTX
+- Print a simple list of titles and keys
+
+Setlists feed into [[Songbook-Builder]] for longer compilations.

--- a/docs/wiki/Slides-(PPTX).md
+++ b/docs/wiki/Slides-(PPTX).md
@@ -1,0 +1,14 @@
+# Slides (PPTX)
+
+Place optional lyric slides at `public/pptx/<slug>.pptx`. Example: `public/pptx/glorious-king.pptx`.
+
+## In SongView
+When a matching file exists, [[SongView]] shows a **Download PPTX** button above the video panel.
+
+## Bundles
+[[Setlists]] can export a ZIP of all PPTX files referenced in the list. Missing files are skipped.
+
+## File-Size Tips
+- Compress background images
+- Keep fonts embedded
+- For repeated slides, prefer copy/paste over duplicates

--- a/docs/wiki/SongView.md
+++ b/docs/wiki/SongView.md
@@ -1,0 +1,11 @@
+# SongView
+
+Displays a single song with interactive tools.
+
+## Features
+- Transpose using the dropdown or `[` and `]` keys
+- Toggle chords with the **Chords** checkbox or press `c`
+- Show/hide media panel for video or audio references
+- Export current key as PDF or JPG
+
+From here you can add songs to [[Setlists]] or jump back to the [[Home]] search.

--- a/docs/wiki/Songbook-Builder.md
+++ b/docs/wiki/Songbook-Builder.md
@@ -1,0 +1,10 @@
+# Songbook Builder
+
+Generate a printable songbook from a [[Setlists|Setlist]].
+
+## Output
+- Songs alphabetized and numbered
+- Optional cover image at the start
+- Auto-generated table of contents
+
+Useful for retreats or distribution where a bundle PDF isn't enough.

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,0 +1,18 @@
+# Troubleshooting
+
+Common snags and quick fixes.
+
+## GitHub Pages 404
+Ensure the app uses a HashRouter and links start with `/#/`. A missing hash leads to 404s.
+
+## CNAME Disappearing
+GitHub Pages may erase `docs/CNAME` on force pushes. Restore the file and push again.
+
+## Fonts Not Embedding
+Confirm `docs/fonts/` exists after `npm run build`. Browsers may block cross-origin fonts.
+
+## PDF Page Splits
+Long sections might force a new page. Use `{comment: repeat}` or break the section.
+
+## Missing PPTX
+Place files under `public/pptx/` with the song slug. [[Slides-(PPTX)]] explains the naming.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,16 @@
+* [[Home]]
+* Setup
+  * [[Getting-Started]]
+  * [[Project-Structure]]
+* Guides
+  * [[ChordPro-Guide]]
+  * [[PDF-and-Printing]]
+  * [[Slides-(PPTX)]]
+  * [[SongView]]
+  * [[Setlists]]
+  * [[Songbook-Builder]]
+  * [[Admin-Tool]]
+  * [[Search-and-Tags]]
+  * [[Index-Building]]
+  * [[Troubleshooting]]
+* [[Contributing]]

--- a/scripts/syncWiki.mjs
+++ b/scripts/syncWiki.mjs
@@ -1,0 +1,34 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { execSync } from 'node:child_process'
+
+const token = process.env.WIKI_PUSH_TOKEN
+const repoUrl = token
+  ? `https://${token}@github.com/rwm6857/GraceChords.wiki.git`
+  : 'https://github.com/rwm6857/GraceChords.wiki.git'
+const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gracechords-wiki-'))
+
+execSync(`git clone ${repoUrl} ${tmp}`, { stdio: 'inherit' })
+
+const srcDir = path.join(process.cwd(), 'docs', 'wiki')
+const files = (await fs.readdir(srcDir)).filter(f => f.endsWith('.md'))
+for (const file of files) {
+  await fs.copyFile(path.join(srcDir, file), path.join(tmp, file))
+}
+
+if (!token) {
+  console.log('WIKI_PUSH_TOKEN not set; dry run. Files to sync:')
+  files.forEach(f => console.log(' -', f))
+  process.exit(0)
+}
+
+execSync('git config user.name "wiki-sync"', { cwd: tmp })
+execSync('git config user.email "actions@users.noreply.github.com"', { cwd: tmp })
+execSync('git add .', { cwd: tmp })
+try {
+  execSync('git commit -m "Sync wiki"', { cwd: tmp, stdio: 'inherit' })
+  execSync('git push', { cwd: tmp, stdio: 'inherit' })
+} catch (e) {
+  console.log('No wiki changes to commit')
+}


### PR DESCRIPTION
## Summary
- document project in GitHub Wiki markdown files
- add `scripts/syncWiki.mjs` to push docs/wiki to GraceChords.wiki
- automate wiki sync on pushes to main when docs change

## Testing
- `npm test` *(fails: Invalid hook call in routing smoke tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a9a5ffda083278f61a6ec6b154787