### PR TITLE
Make Home results scrollable and keep search bar visible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,11 +27,11 @@ export default function App(){
 
 function Layout(){
   return (
-    <>
+    <div className="App">
       <NavBar />
-      <main id="main">
+      <main id="main" className="Route">
         <Outlet />
       </main>
-    </>
+    </div>
   )
 }

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -9,6 +9,7 @@ export default function Home(){
 
   // -------- Search & filters --------
   const [q, setQ] = useState('')
+  const searchRef = useRef(null)
   const qLower = q.trim().toLowerCase()
   const allTags = useMemo(() => {
     const set = new Set()
@@ -117,6 +118,18 @@ export default function Home(){
   }, [items, fuse, qLower, lyricsOn, lyricsCache, selectedTags.join(','), tagMode])
 
 
+  useEffect(() => {
+    function onKeyDown(e){
+      if(e.key === '/' && document.activeElement !== searchRef.current){
+        e.preventDefault()
+        searchRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    searchRef.current?.focus()
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
   // UI helpers
   function toggleTag(t){
     setSelectedTags(prev => prev.includes(t) ? prev.filter(x => x!==t) : [...prev, t])
@@ -124,77 +137,82 @@ export default function Home(){
   function clearTags(){ setSelectedTags([]) }
 
   return (
-    <div className="container">
-      <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
-        <h1>GraceChords</h1>
-        {/* Removed redundant Setlist link (NavBar already has it) */}
-      </div>
-
-      <div className="card" style={{display:'grid', gap:10}}>
-        <label htmlFor="search">Search</label>
-        <div className="row" style={{gap:8, alignItems:'center'}}>
-          <input
-            id="search"
-            value={q}
-            onChange={e=> setQ(e.target.value)}
-            placeholder="Search title/tags/authors…"
-            style={{flex:1}}
-          />
-          <label className="row" style={{gap:8, alignItems:'center'}}>
-            <input
-              type="checkbox"
-              checked={lyricsOn}
-              onChange={e=> setLyricsOn(e.target.checked)}
-            />
-            <span className="meta">Lyrics contain</span>
-          </label>
+    <div className="HomePage container">
+      <div className="HomeHeader">
+        <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+          <h1>GraceChords</h1>
+          {/* Removed redundant Setlist link (NavBar already has it) */}
         </div>
 
-        <div className="row">
-          {/* Tags: multi-select + Any/All */}
-          <div className="tagbar">
-            <button className={`badge ${selectedTags.length===0 ? 'active':''}`} onClick={clearTags}>All</button>
-            {allTags.map(t => (
-              <button
-                key={t}
-                className={`badge ${selectedTags.includes(t) ? 'active':''}`}
-                onClick={()=> toggleTag(t)}
-              >{t}</button>
-            ))}
+        <div className="card" style={{display:'grid', gap:10}}>
+          <label htmlFor="search">Search</label>
+          <div className="row" style={{gap:8, alignItems:'center'}}>
+            <input
+              id="search"
+              ref={searchRef}
+              value={q}
+              onChange={e=> setQ(e.target.value)}
+              placeholder="Search title/tags/authors…"
+              style={{flex:1}}
+            />
+            <label className="row" style={{gap:8, alignItems:'center'}}>
+              <input
+                type="checkbox"
+                checked={lyricsOn}
+                onChange={e=> setLyricsOn(e.target.checked)}
+              />
+              <span className="meta">Lyrics contain</span>
+            </label>
           </div>
-          <div style={{display:'flex', gap:8, alignItems:'center'}}>
-            <span className="meta">Match</span>
-            <button
-              className={`btn ${tagMode==='any' ? 'primary':''}`}
-              onClick={()=> setTagMode('any')}
-              title="Match songs with any selected tag"
-            >Any</button>
-            <button
-              className={`btn ${tagMode==='all' ? 'primary':''}`}
-              onClick={()=> setTagMode('all')}
-              title="Match songs with all selected tags"
-            >All</button>
+
+          <div className="row">
+            {/* Tags: multi-select + Any/All */}
+            <div className="tagbar">
+              <button className={`badge ${selectedTags.length===0 ? 'active':''}`} onClick={clearTags}>All</button>
+              {allTags.map(t => (
+                <button
+                  key={t}
+                  className={`badge ${selectedTags.includes(t) ? 'active':''}`}
+                  onClick={()=> toggleTag(t)}
+                >{t}</button>
+              ))}
+            </div>
+            <div style={{display:'flex', gap:8, alignItems:'center'}}>
+              <span className="meta">Match</span>
+              <button
+                className={`btn ${tagMode==='any' ? 'primary':''}`}
+                onClick={()=> setTagMode('any')}
+                title="Match songs with any selected tag"
+              >Any</button>
+              <button
+                className={`btn ${tagMode==='all' ? 'primary':''}`}
+                onClick={()=> setTagMode('all')}
+                title="Match songs with all selected tags"
+              >All</button>
+            </div>
           </div>
         </div>
       </div>
 
       {/* Results grid (directory only) */}
-      <div className="grid" style={{marginTop:10}}>
-        {results.map(s => {
-          return (
-            <div key={s.id} className="card">
-              <div className="row">
-                <div>
-                  <Link to={`/song/${s.id}`} style={{fontWeight:600}}>{s.title}</Link>
-                  <div className="meta">
-                    {s.originalKey || '—'}
-                    {s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}
+      <div className="HomeResults" role="region" aria-label="Song results">
+        <div className="grid" style={{marginTop:10}}>
+          {results.map(s => {
+            return (
+              <div key={s.id} className="card">
+                <div className="row">
+                  <div>
+                    <Link to={`/song/${s.id}`} style={{fontWeight:600}}>{s.title}</Link>
+                    <div className="meta">
+                      {s.originalKey || '—'}
+                      {s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,6 +41,8 @@
 /* ========== Global ========== */
 * { box-sizing: border-box }
 html, body, #root { height: 100% }
+.App { min-height: 100dvh; display: flex; flex-direction: column; }
+.Route { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 html, body { background: var(--bg); color: var(--text); }
 
 body{
@@ -138,6 +140,20 @@ input,select,textarea{
 }
 .badge.active{ background:#dbeafe; border-color:#bfdbfe }
 .tagbar{ display:flex; flex-wrap:wrap; gap:8px }
+
+/* ========== Home page layout ========== */
+.HomePage{ display:flex; flex-direction:column; flex:1 1 auto; min-height:0; }
+.HomeHeader{
+  position:sticky; top:0; z-index:5;
+  background: var(--bg, #0b0b0b);
+  padding-block:0.5rem;
+}
+.HomeResults{
+  flex:1 1 auto;
+  min-height:0;
+  overflow:auto;
+  -webkit-overflow-scrolling:touch;
+}
 
 /* ========== Top nav ========== */
 .topnav{


### PR DESCRIPTION
## Summary
- Use flex layout in App to give routes full height
- Split Home into sticky search header and scrollable results
- Focus search on load and when pressing `/`

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_689ab6ecc57083278ab42b85eaf9e5aa