### PR TITLE
feat: add multi-song drafts with zip export

### DIFF
--- a/src/utils/zip.js
+++ b/src/utils/zip.js
@@ -1,0 +1,14 @@
+export async function downloadZip(files, opts = {}) {
+  const JSZip = (await import('jszip')).default
+  const zip = new JSZip()
+  for (const f of files || []) {
+    if (!f || !f.path) continue
+    zip.file(f.path, f.content)
+  }
+  const blob = await zip.generateAsync({ type: 'blob' })
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = opts.name || 'download.zip'
+  a.click()
+  URL.revokeObjectURL(a.href)
+}


### PR DESCRIPTION
## Summary
- allow admin to save multiple song drafts with optional localStorage persistence
- export all drafts as a ZIP containing only `.chordpro` files
- add generic `downloadZip` utility

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_689bc98589408327bc599e9bc00d9343