### PR TITLE
Add docs nav link and wiki diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ Files committed under `public/` are served directly by GitHub Pages, so adding a
 
 ## Next Steps
 Explore utilities in `src/utils` for chord transposition and PDF generation, check `scripts/buildIndex.mjs` for index creation, and extend Vitest tests to safeguard future refactors.
+
+## GitHub Wiki
+
+Author or edit Markdown pages under `public/wiki/` (e.g., `Home.md`, `_Sidebar.md`, etc.).
+Set the repo secret `WIKI_PUSH_TOKEN` (a classic PAT with `repo` scope) to allow pushes to `GraceChords.wiki`.
+Trigger sync by pushing changes under `public/wiki/**` (workflow runs) or run locally:
+
+```bash
+WIKI_PUSH_TOKEN=<your_PAT> node scripts/syncWiki.mjs
+```
+
+If pages don’t appear, run the diagnostic:
+
+```bash
+node scripts/verifyWikiSetup.mjs
+```

--- a/scripts/verifyWikiSetup.mjs
+++ b/scripts/verifyWikiSetup.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/*
+ * Diagnostic script for GitHub Wiki syncing.
+ * Checks wiki source presence, token, and remote repo accessibility.
+ * Always exits 0.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFile as _execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(_execFile);
+
+function log(status, message) {
+  console.log(`[${status}] ${message}`);
+}
+
+(async () => {
+  const root = process.cwd();
+  const wikiDir = path.join(root, 'public', 'wiki');
+  let hasWiki = false;
+  try {
+    const entries = await fs.readdir(wikiDir);
+    if (entries.includes('Home.md') && entries.includes('_Sidebar.md')) {
+      hasWiki = true;
+    }
+  } catch {}
+  if (hasWiki) {
+    log('PASS', 'public/wiki contains Home.md and _Sidebar.md');
+  } else {
+    log('FAIL', 'public/wiki missing or lacks Home.md/_Sidebar.md');
+  }
+
+  async function repoSlug() {
+    if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+    try {
+      const { stdout } = await execFile('git', ['config', '--get', 'remote.origin.url']);
+      const m = stdout.trim().match(/github\.com[:/](.+?)(\.git)?$/);
+      if (m) return m[1];
+    } catch {}
+    return path.basename(root);
+  }
+
+  const slug = await repoSlug();
+  const wikiRepo = `https://github.com/${slug}.wiki.git`;
+  log('INFO', `Wiki repo URL: ${wikiRepo}`);
+
+  let wikiEnabled = false;
+  try {
+    await execFile('git', ['ls-remote', wikiRepo], { stdio: 'ignore' });
+    wikiEnabled = true;
+  } catch {
+    wikiEnabled = false;
+  }
+  if (wikiEnabled) {
+    log('PASS', 'Repository wiki appears to be enabled');
+  } else {
+    log('FAIL', 'Wiki repo not reachable. Enable it in GitHub Settings > General > Features > Wiki');
+  }
+
+  if (process.env.WIKI_PUSH_TOKEN) {
+    log('PASS', 'WIKI_PUSH_TOKEN is set');
+  } else {
+    log('FAIL', 'WIKI_PUSH_TOKEN not set; sync will run in DRY RUN mode');
+  }
+
+  console.log('Run: node scripts/syncWiki.mjs to perform the sync (DRY RUN without WIKI_PUSH_TOKEN).');
+})().catch((err) => {
+  console.error(err);
+}).finally(() => {
+  process.exit(0);
+});

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -32,6 +32,14 @@ export default function NavBar(){
               </span>
             </Link>
             <Link to="/songbook" className={`topnav__link ${isActive('/songbook') ? 'active':''}`}>Songbook</Link>
+            <a
+              href="https://github.com/rwm6857/GraceChords/wiki"
+              className="topnav__link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Docs
+            </a>
             {/* Toggle lives OUTSIDE links */}
             <button
               className="iconbtn"


### PR DESCRIPTION
## Summary
- add Docs link in navigation to open GitHub Wiki in new tab
- add diagnostic script for verifying wiki sync setup
- document Wiki setup and sync instructions in README

## Testing
- `npm test`
- `node scripts/verifyWikiSetup.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689bcb29c72c8327a4c82d7bd1e42a6a