### PR TITLE
Add 404 page to support SPA routing on GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GraceChords</title>
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <style>
+      #offline-badge {
+        position: fixed;
+        bottom: 1rem;
+        right: 1rem;
+        background: #4caf50;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+        font-family: sans-serif;
+        border-radius: 4px;
+        z-index: 1000;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <div id="offline-badge" hidden>Available offline</div>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.ready.then(() => {
+            document.getElementById('offline-badge').hidden = false;
+          });
+        });
+      }
+    </script>
+    <script type="module" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GraceChords</title>
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <style>
+      #offline-badge {
+        position: fixed;
+        bottom: 1rem;
+        right: 1rem;
+        background: #4caf50;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+        font-family: sans-serif;
+        border-radius: 4px;
+        z-index: 1000;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <div id="offline-badge" hidden>Available offline</div>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.ready.then(() => {
+            document.getElementById('offline-badge').hidden = false;
+          });
+        });
+      }
+    </script>
+    <script type="module" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,10 @@ export default defineConfig({
   plugins: [
     react(),
     viteStaticCopy({
-      targets: [{ src: 'src/sw.js', dest: '' }]
+      targets: [
+        { src: 'src/sw.js', dest: '' },
+        { src: '404.html', dest: '' }
+      ]
     })
   ],
   build: { outDir: 'docs', chunkSizeWarningLimit: 1200 },


### PR DESCRIPTION
## Summary
- duplicate `index.html` as `404.html`
- copy `404.html` into `docs` during build so direct URL reloads work

## Testing
- `npm test`
- `npm run build`
- `curl -L -I https://gracechords.com/#/song/abba` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bd58afc1c8327b995019bcc785091