### PR TITLE
Cache PPTX head checks and handle errors

### DIFF
--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -8,6 +8,7 @@ import { parseChordPro, stepsBetween, transposeSym } from '../utils/chordpro'
 import { listSets, getSet, saveSet, deleteSet, duplicateSet } from '../utils/sets'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
+import { headOk } from '../utils/headCache'
 
 // Lazy pdf exporter
 let pdfLibPromise
@@ -40,10 +41,8 @@ export default function Setlist(){
         const s = items.find(it=> it.id===sel.id)
         if(!s) continue
         const url = `${import.meta.env.BASE_URL}pptx/${s.id}.pptx`
-        try{
-          const res = await fetch(url, { method: 'HEAD' })
-          if(res.ok) found[s.id] = true
-        }catch{}
+        const ok = await headOk(url, s.id)
+        if(ok) found[s.id] = true
       }
       if(!cancelled) setPptxMap(found)
     }

--- a/src/components/SongView.jsx
+++ b/src/components/SongView.jsx
@@ -6,6 +6,7 @@ import indexData from '../data/index.json'
 import { DownloadIcon, TransposeIcon, MediaIcon, EyeIcon } from './Icons'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
+import { headOk } from '../utils/headCache'
 
 // Lazy-loaded heavy modules
 let pdfLibPromise
@@ -76,9 +77,14 @@ export default function SongView(){
     const base = ((import.meta.env.BASE_URL || '/').replace(/\/+$/, '') + '/')
     const url = `${base}pptx/${slug}.pptx`
     setPptxUrl(url)
-    fetch(url, { method: 'HEAD' })
-      .then(r => { if (r.ok) setHasPptx(true) })
-      .catch(()=>{})
+    let cancelled = false
+    async function check(){
+      const ok = await headOk(url, entry.id)
+      if (cancelled || !ok) return
+      setHasPptx(true)
+    }
+    check()
+    return () => { cancelled = true }
   }, [entry])
 
   // keyboard shortcuts: c toggle chords, [ down, ] up

--- a/src/utils/headCache.js
+++ b/src/utils/headCache.js
@@ -1,0 +1,17 @@
+// src/utils/headCache.js
+// Cache results of HEAD requests by key to avoid repeat network calls
+const headCache = new Map()
+
+export async function headOk(url, key) {
+  const k = key || url
+  if (headCache.has(k)) return headCache.get(k)
+  try {
+    const res = await fetch(url, { method: 'HEAD' })
+    if (!res.ok) { headCache.set(k, false); return false }
+    headCache.set(k, true)
+    return true
+  } catch {
+    headCache.set(k, false)
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- Wrap PPTX existence checks in cached HEAD fetch helper
- Skip state updates when HEAD request fails
- Reuse cached results to prevent repeated 404s

## Testing
- `node node_modules/vitest/vitest.mjs run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd5b985dc8327b7d10212fecb853d