### PR TITLE
Handle multi-author indexing for song filters

### DIFF
--- a/scripts/buildIndex.mjs
+++ b/scripts/buildIndex.mjs
@@ -12,7 +12,7 @@ for(const filename of files){
   const text = await fs.readFile(full, 'utf8')
   const meta = parseMeta(text)
   const id = (meta.id || (meta.title||'').toLowerCase().replace(/[^a-z0-9]+/g,'-')).replace(/(^-|-$)/g,'')
-  items.push({ id, title: meta.title || id || filename.replace(/\.chordpro$/,''), filename, originalKey: meta.key || '', tags: (meta.tags||'').split(',').map(s=>s.trim()).filter(Boolean), authors: meta.authors||'', country: meta.country||'' })
+    items.push({ id, title: meta.title || id || filename.replace(/\.chordpro$/,''), filename, originalKey: meta.key || '', tags: (meta.tags||'').split(/[,;]/).map(s=>s.trim()).filter(Boolean), authors: (meta.authors||'').split(/[,;]/).map(s=>s.trim()).filter(Boolean), country: meta.country||'' })
 }
 items.sort((a,b)=> a.title.localeCompare(b.title, undefined, {sensitivity:'base'}))
 await fs.mkdir(path.dirname(outFile), { recursive: true })

--- a/src/__tests__/songbook.filters.test.jsx
+++ b/src/__tests__/songbook.filters.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Songbook from '../components/Songbook.jsx'
+
+describe('Songbook filters', () => {
+  test('filters multi-author songs by each author', async () => {
+    render(<Songbook />)
+    const authorSelect = await screen.findByLabelText(/author/i)
+
+    await userEvent.selectOptions(authorSelect, 'Matt Redman')
+    expect(await screen.findByText('Blessed Be Your Name')).toBeInTheDocument()
+    expect(await screen.findByText('Build My Life')).toBeInTheDocument()
+    expect(screen.queryByText('Abba')).not.toBeInTheDocument()
+
+    await userEvent.selectOptions(authorSelect, 'Brett Younker')
+    expect(await screen.findByText('Build My Life')).toBeInTheDocument()
+    expect(screen.queryByText('Blessed Be Your Name')).not.toBeInTheDocument()
+  })
+})

--- a/src/data/index.json
+++ b/src/data/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-08-12T02:19:54.946Z",
+  "generatedAt": "2025-08-13T00:19:57.136Z",
   "items": [
     {
       "id": "abba",
@@ -10,7 +10,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -21,7 +21,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -32,7 +32,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -44,7 +44,9 @@
         "Hymn",
         "Slow"
       ],
-      "authors": "John Newton",
+      "authors": [
+        "John Newton"
+      ],
       "country": "UK"
     },
     {
@@ -55,7 +57,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -66,7 +68,9 @@
       "tags": [
         "Fast"
       ],
-      "authors": "Matt Redman",
+      "authors": [
+        "Matt Redman"
+      ],
       "country": "UK"
     },
     {
@@ -78,7 +82,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -90,7 +94,13 @@
         "Slow",
         "Worship"
       ],
-      "authors": "Brett Younker; Karl Martin; Kirby Kaple; Matt Redman; Pat Barrett",
+      "authors": [
+        "Brett Younker",
+        "Karl Martin",
+        "Kirby Kaple",
+        "Matt Redman",
+        "Pat Barrett"
+      ],
       "country": "US"
     },
     {
@@ -101,7 +111,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -113,7 +123,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Uzbekistan"
     },
     {
@@ -124,7 +134,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -133,7 +143,7 @@
       "filename": "creation-is-awaiting.chordpro",
       "originalKey": "A",
       "tags": [],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -145,7 +155,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -156,7 +166,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -168,7 +178,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Egypt"
     },
     {
@@ -180,7 +190,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -192,7 +202,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -203,7 +213,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -215,7 +225,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Indonesia"
     },
     {
@@ -227,7 +237,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "China"
     },
     {
@@ -238,7 +248,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -250,7 +260,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "India"
     },
     {
@@ -261,7 +271,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -272,7 +282,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -283,7 +293,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -295,7 +305,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Iran"
     },
     {
@@ -307,7 +317,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "China"
     },
     {
@@ -318,7 +328,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -329,7 +339,9 @@
       "tags": [
         "Fast"
       ],
-      "authors": "Darlene Zschech",
+      "authors": [
+        "Darlene Zschech"
+      ],
       "country": "USA"
     },
     {
@@ -340,7 +352,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -352,7 +364,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "China"
     },
     {
@@ -363,7 +375,7 @@
       "tags": [
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -375,7 +387,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "China"
     },
     {
@@ -386,7 +398,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -398,7 +410,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -410,7 +422,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -421,7 +433,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -432,7 +444,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -443,7 +455,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -455,7 +467,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "India"
     },
     {
@@ -466,7 +478,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -477,7 +489,7 @@
       "tags": [
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Japan"
     },
     {
@@ -488,7 +500,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -499,7 +511,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -511,7 +523,7 @@
         "Fast",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Israel"
     },
     {
@@ -523,7 +535,9 @@
         "Long",
         "Test"
       ],
-      "authors": "David (arr. GraceChords)",
+      "authors": [
+        "David (arr. GraceChords)"
+      ],
       "country": "Israel"
     },
     {
@@ -534,7 +548,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Germany"
     },
     {
@@ -545,7 +559,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -556,7 +570,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -567,7 +581,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -578,7 +592,7 @@
       "tags": [
         "Fast"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -590,7 +604,7 @@
         "Slow",
         "Nations"
       ],
-      "authors": "",
+      "authors": [],
       "country": "China"
     },
     {
@@ -601,7 +615,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "USA"
     },
     {
@@ -612,7 +626,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     },
     {
@@ -623,7 +637,7 @@
       "tags": [
         "Slow"
       ],
-      "authors": "",
+      "authors": [],
       "country": "Korea"
     }
   ]


### PR DESCRIPTION
## Summary
- Emit `authors` and `tags` as arrays in the index builder.
- Refresh song index JSON with array-based authors and tags.
- Add Songbook filter test covering multi-author songs.

## Testing
- `node scripts/buildIndex.mjs`
- `npm run test:run` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689bd5fc2a9c8327a356e74f677592e8