### PR TITLE
docs: mention CNAME/404 and warn workflow

### DIFF
--- a/.github/workflows/build-to-docs.yml
+++ b/.github/workflows/build-to-docs.yml
@@ -21,6 +21,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build  # writes to /docs
+      # WARNING: ensure docs/CNAME and 404.html are preserved
 
       # Commit the newly built files back into /docs on main
       - name: Commit and push /docs

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Generate the static site into `docs/` and push to the `main` branch to serve via
 npm run build
 # commit & push -> serve from /docs
 ```
+Keep `docs/CNAME` (custom domain) and the root `404.html` (SPA fallback) when deploying.
 
 Routing uses hash fragments (`/#/...`) so deep links work on static hosting.
 


### PR DESCRIPTION
## Summary
- document that docs/CNAME and a root 404.html must be kept when deploying
- warn in build workflow to preserve these files

## Testing
- `node node_modules/vitest/dist/cli.js run` *(fails: Invalid hook call, 3 tests failed)*
- `python -m markdown README.md > /tmp/README.html && rg -n 'CNAME' /tmp/README.html`


------
https://chatgpt.com/codex/tasks/task_e_689bd6165fd08327925703e1f2431e64