### PR TITLE
Show PPTX download only when slides exist

### DIFF
--- a/src/__tests__/songview.pptx.test.jsx
+++ b/src/__tests__/songview.pptx.test.jsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import SongView from '../components/SongView.jsx'
+
+function mockFetch(hasPptx) {
+  const chordpro = '{title:Test}\n{youtube: https://youtu.be/abcdefghijk}\n[C]Line'
+  vi.stubGlobal('fetch', (url) => {
+    if (String(url).includes('.chordpro')) {
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(chordpro) })
+    }
+    if (String(url).includes('.pptx')) {
+      return Promise.resolve({ ok: hasPptx })
+    }
+    return Promise.resolve({ ok: true, text: () => Promise.resolve('') })
+  })
+}
+
+describe('SongView PPTX button', () => {
+  beforeEach(() => {
+    const orig = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag, ...args) => {
+      if (tag === 'canvas') {
+        return { getContext: () => ({ font: '', measureText: () => ({ width: 0 }) }) }
+      }
+      return orig(tag, ...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  test('shows PPTX download when available', async () => {
+    mockFetch(true)
+    render(
+      <MemoryRouter initialEntries={['/song/build-my-life']}>
+        <Routes>
+          <Route path="/song/:id" element={<SongView />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(await screen.findByRole('link', { name: /download pptx/i })).toBeInTheDocument()
+  })
+
+  test('hides PPTX download when missing', async () => {
+    mockFetch(false)
+    render(
+      <MemoryRouter initialEntries={['/song/build-my-life']}>
+        <Routes>
+          <Route path="/song/:id" element={<SongView />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    await screen.findByText(/reference video/i)
+    await waitFor(() => {
+      expect(screen.queryByRole('link', { name: /download pptx/i })).toBeNull()
+    })
+  })
+})

--- a/src/components/SongView.jsx
+++ b/src/components/SongView.jsx
@@ -134,6 +134,12 @@ if(!entry){
   const baseKey = parsed?.meta?.key || parsed?.meta?.originalkey || entry.originalKey || 'C'
   const steps = stepsBetween(baseKey, toKey)
 
+  const pptxButton = hasPptx ? (
+    <a className="btn" href={pptxUrl} download>
+      Download PPTX
+    </a>
+  ) : null
+
   const buildSong = () => ({
     title,
     key: toKey,
@@ -268,10 +274,8 @@ if(!entry){
             {parsed?.meta?.youtube && (
               <div className="media__card" style={{marginTop:10}}>
                 <div className="media__label">Reference Video</div>
-                {hasPptx && (
-                  <div style={{marginBottom:10}}>
-                    <a className="btn" href={pptxUrl} download>Download PPTX</a>
-                  </div>
+                {pptxButton && (
+                  <div style={{marginBottom:10}}>{pptxButton}</div>
                 )}
                 {(() => {
                  const ytId = extractYouTubeId(parsed.meta.youtube)
@@ -298,10 +302,10 @@ if(!entry){
               </div>
             )}
 
-            {!parsed?.meta?.youtube && hasPptx && (
+            {!parsed?.meta?.youtube && pptxButton && (
               <div className="media__card" style={{marginTop:10}}>
                 <div className="media__label">Lyric Slides (PPTX)</div>
-                <a className="btn" href={pptxUrl} download>Download PPTX</a>
+                {pptxButton}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Render PPTX download button only when a PPTX file is detected
- Test SongView to ensure PPTX link appears only when slides exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bd6a7b2188327827e60c1ec7c6818