### PR TITLE
Prefetch heavy routes on hover

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,9 +3,9 @@ import { Routes, Route, Link, Outlet } from 'react-router-dom'
 import Home from './components/Home'
 import SongView from './components/SongView'
 import Admin from './components/Admin'
-import Setlist from './components/Setlist'
+const Setlist = React.lazy(() => import('./components/Setlist'))
 import Bundle from './components/Bundle'
-import Songbook from './components/Songbook'
+const Songbook = React.lazy(() => import('./components/Songbook'))
 import NavBar from './components/NavBar'
 import ErrorBoundary from './components/ErrorBoundary'
 import Toast from './components/Toast'
@@ -14,17 +14,19 @@ import './styles.css'
 export default function App(){
   return (
     <ErrorBoundary>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/song/:id" element={<SongView />} />
-          <Route path="/setlist" element={<Setlist />} />
-          <Route path="/bundle" element={<Bundle />} />
-          <Route path="/songbook" element={<Songbook />} />
-        </Route>
-        <Route path="/admin" element={<Admin />} />
-        <Route path="*" element={<div className="container"><h3>Not found</h3><Link to="/">Back</Link></div>} />
-      </Routes>
+      <React.Suspense fallback={<div className="container"><h3>Loading...</h3></div>}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/song/:id" element={<SongView />} />
+            <Route path="/setlist" element={<Setlist />} />
+            <Route path="/bundle" element={<Bundle />} />
+            <Route path="/songbook" element={<Songbook />} />
+          </Route>
+          <Route path="/admin" element={<Admin />} />
+          <Route path="*" element={<div className="container"><h3>Not found</h3><Link to="/">Back</Link></div>} />
+        </Routes>
+      </React.Suspense>
       <Toast />
     </ErrorBoundary>
   )

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -26,12 +26,22 @@ export default function NavBar(){
           <Link to="/" className="brand">GraceChords</Link>
           <div className="topnav__links">
             <Link to="/" className={`topnav__link ${isActive('/') ? 'active':''}`}>Home</Link>
-            <Link to="/setlist" className={`topnav__link ${isActive('/setlist') ? 'active':''}`}>
+            <Link
+              to="/setlist"
+              className={`topnav__link ${isActive('/setlist') ? 'active':''}`}
+              onMouseEnter={() => import('./Setlist')}
+            >
               <span style={{display:'inline-flex',alignItems:'center',gap:6}}>
                 <SetlistIcon /> Setlist
               </span>
             </Link>
-            <Link to="/songbook" className={`topnav__link ${isActive('/songbook') ? 'active':''}`}>Songbook</Link>
+            <Link
+              to="/songbook"
+              className={`topnav__link ${isActive('/songbook') ? 'active':''}`}
+              onMouseEnter={() => import('./Songbook')}
+            >
+              Songbook
+            </Link>
             <a
               href="https://github.com/rwm6857/GraceChords/wiki"
               className="topnav__link"


### PR DESCRIPTION
## Summary
- lazy load Setlist and Songbook routes and suspend while loading
- prefetch Setlist and Songbook modules when their links are hovered

## Testing
- `npm test` *(fails: Invalid hook call in HashRouter)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd6c06cd48327a554a9ae942f55eb