### PR TITLE
Fix setlist panel height for small viewports

### DIFF
--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -250,7 +250,7 @@ export default function Setlist(){
           <div style={{marginTop:8}}>
             <strong>Add songs</strong>
             <input value={q} onChange={e=> setQ(e.target.value)} placeholder="Search..." style={{display:'block', width:'100%', marginTop:6}} />
-            <div style={{maxHeight:300, overflow:'auto', marginTop:6}}>
+            <div style={{minHeight:0, maxHeight:300, overflow:'auto', marginTop:6}}>
               {results.map(s=> (
                 <div key={s.id} className="row" style={{padding:'6px 0'}}>
                   <div style={{flex:1}}>
@@ -266,7 +266,7 @@ export default function Setlist(){
 
         <div>
           <strong>Current setlist ({list.length})</strong>
-          <div style={{maxHeight:360, overflow:'auto', marginTop:6}}>
+          <div style={{minHeight:0, maxHeight:360, overflow:'auto', marginTop:6}}>
             {list.map((sel)=>{
               const s = items.find(it=> it.id===sel.id)
               if(!s) return null


### PR DESCRIPTION
## Summary
- allow setlist song search and current list panels to shrink within their container by setting `minHeight:0`

## Testing
- `npm run test:run`
- *(failed: Timeout verifying scroll with Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_689bd5e4339c8327867f909b79f58020