### PR TITLE
Use env-based admin password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_ADMIN_PW=your-password
+

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-VITE_ADMIN_PW=your-password
+VITE_ADMIN_PW=10401040
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,14 @@ npm run build
 Routing uses hash fragments (`/#/...`) so deep links work on static hosting.
 
 ## Admin & Index Generation
-Open `/#/admin` (password **10401040**) to author songs in ChordPro and download a bundle containing the song and updated index. Add files to `public/songs/` and merge `src/data/index.json`, or rebuild automatically:
+Set the admin password via an environment variable and open `/#/admin` to author songs in ChordPro and download a bundle containing the song and updated index. Add files to `public/songs/` and merge `src/data/index.json`, or rebuild automatically:
+
 ```bash
+VITE_ADMIN_PW=your-password # in .env
 npm run build-index
 ```
+
+Add `VITE_ADMIN_PW` to a local `.env` file for development and configure the same variable as a GitHub repository secret so builds receive it.
 
 ## PDF Fonts
 Place the following fonts in `public/fonts/` to embed them in exported PDFs:

--- a/docs/wiki/Admin-Tool.md
+++ b/docs/wiki/Admin-Tool.md
@@ -3,7 +3,7 @@ Draft and preview songs directly in the browser.
 ## At a glance
 - Compose ChordPro text with live preview
 - Export the result as `.chordpro`
-- Password protected via `VITE_ADMIN_PASSWORD`
+- Password protected via `VITE_ADMIN_PW`
 - Currently edits one song at a time
 
 1. Navigate to `/admin` and enter the password.

--- a/public/wiki/Admin-Tool.md
+++ b/public/wiki/Admin-Tool.md
@@ -3,7 +3,7 @@ Draft and preview songs directly in the browser.
 ## At a glance
 - Compose ChordPro text with live preview
 - Export the result as `.chordpro`
-- Password protected via `VITE_ADMIN_PASSWORD`
+- Password protected via `VITE_ADMIN_PW`
 - Currently edits one song at a time
 
 1. Navigate to `/admin` and enter the password.

--- a/src/__tests__/admin.login.test.jsx
+++ b/src/__tests__/admin.login.test.jsx
@@ -1,0 +1,36 @@
+import { describe, test, expect, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+describe('Admin login', () => {
+    beforeAll(() => {
+      HTMLCanvasElement.prototype.getContext = () => ({
+        measureText: () => ({ width: 0, actualBoundingBoxAscent: 0 })
+      })
+    })
+
+  test('login fails with incorrect password', async () => {
+    import.meta.env.VITE_ADMIN_PW = 'secret'
+    const { default: Admin } = await import('../components/Admin.jsx')
+    render(<Admin />)
+
+    const input = screen.getByPlaceholderText(/password/i)
+    await userEvent.type(input, 'wrong')
+    await userEvent.click(screen.getByRole('button', { name: /enter/i }))
+
+    expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument()
+  })
+
+  test('login succeeds with correct password', async () => {
+    import.meta.env.VITE_ADMIN_PW = 'secret'
+    const { default: Admin } = await import('../components/Admin.jsx')
+    render(<Admin />)
+
+    const input = screen.getByPlaceholderText(/password/i)
+    await userEvent.type(input, 'secret')
+    await userEvent.click(screen.getByRole('button', { name: /enter/i }))
+
+    expect(await screen.findByRole('button', { name: /add to drafts/i })).toBeInTheDocument()
+  })
+})
+

--- a/src/components/Admin.jsx
+++ b/src/components/Admin.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { KEYS, parseChordPro } from '../utils/chordpro'
 import { downloadZip } from '../utils/zip'
 
-const PASSWORD = '10401040'
+const PASSWORD = import.meta.env.VITE_ADMIN_PW
 
 const INITIAL_TEXT = `{title: }
 {key: }


### PR DESCRIPTION
## Summary
- load admin password from `VITE_ADMIN_PW`
- document `VITE_ADMIN_PW` and add sample `.env`
- test admin login success and failure

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_689bd59e77d48327bc753a493ce58017