### PR TITLE
feat: polish Home directory layout

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -194,7 +194,7 @@ export default function Home(){
   optionRefs.current = []
 
   return (
-    <div className="HomePage container">
+    <div className="HomePage">
       <div className="HomeHeader">
         <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
           <h1>GraceChords</h1>
@@ -253,37 +253,37 @@ export default function Home(){
       </div>
 
       {/* Results list */}
-      <ul
-        className="HomeResults grid"
-        role="listbox"
+      <div
+        className="HomeResults"
+        role="region"
         aria-label="Song results"
         ref={resultsRef}
         onKeyDown={onResultsKeyDown}
-        style={{ marginTop: 10 }}
       >
-        {results.map((s, i) => (
-          <li
-            key={s.id}
-            role="option"
-            ref={el => (optionRefs.current[i] = el)}
-            tabIndex={i === activeIndex ? 0 : -1}
-            aria-selected={i === activeIndex}
-            className="card"
-          >
-            <div className="row">
-              <div>
-                <Link to={`/song/${s.id}`} style={{ fontWeight: 600 }}>
-                  {s.title}
-                </Link>
-                <div className="meta">
-                  {s.originalKey || '—'}
-                  {s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}
+        <div className="HomeGrid" role="listbox">
+          {results.map((s, i) => (
+            <Link
+              key={s.id}
+              to={`/song/${s.id}`}
+              role="option"
+              ref={el => (optionRefs.current[i] = el)}
+              tabIndex={i === activeIndex ? 0 : -1}
+              aria-selected={i === activeIndex}
+              className="HomeCard"
+            >
+              <div className="row">
+                <div>
+                  <div style={{ fontWeight: 600 }}>{s.title}</div>
+                  <div className="meta">
+                    {s.originalKey || '—'}
+                    {s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}
+                  </div>
                 </div>
               </div>
-            </div>
-          </li>
-        ))}
-      </ul>
+            </Link>
+          ))}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,17 +142,65 @@ input,select,textarea{
 .tagbar{ display:flex; flex-wrap:wrap; gap:8px }
 
 /* ========== Home page layout ========== */
-.HomePage{ display:flex; flex-direction:column; flex:1 1 auto; min-height:0; }
+.HomePage{
+  max-width:1280px;
+  margin-inline:auto;
+  padding-inline:1rem;
+  display:flex;
+  flex-direction:column;
+  flex:1 1 auto;
+  min-height:0;
+}
 .HomeHeader{
   position:sticky; top:0; z-index:5;
-  background: var(--bg, #0b0b0b);
-  padding-block:0.5rem;
+  background: var(--bg, Canvas);
+  padding-block:1rem;
 }
+/* Only the results scroll */
 .HomeResults{
   flex:1 1 auto;
   min-height:0;
   overflow:auto;
   -webkit-overflow-scrolling:touch;
+}
+
+.HomeGrid{
+  display:grid;
+  gap:0.875rem;
+  grid-template-columns:1fr;
+  margin-top:10px;
+}
+
+@media (min-width:900px){
+  .HomeGrid{ grid-template-columns:repeat(2,minmax(0,1fr)); }
+}
+@media (min-width:1200px){
+  .HomeGrid{ grid-template-columns:repeat(3,minmax(0,1fr)); }
+}
+@media (min-width:1500px){
+  .HomeGrid{ grid-template-columns:repeat(4,minmax(0,1fr)); }
+}
+
+/* Remove bullets and tidy lists */
+.HomeGrid, .HomeGrid ul, .HomeGrid li{
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+.HomeGrid li::marker, .HomeGrid li::before{
+  content:none !important;
+}
+
+.HomeCard{
+  border:1px solid var(--border, rgba(0,0,0,.12));
+  background: var(--surface, #f5f5f7);
+  border-radius:12px;
+  padding:.75rem 1rem;
+  display:block;
+  text-decoration:none;
+}
+@media (prefers-color-scheme: dark){
+  .HomeCard{ border-color:rgba(255,255,255,.14); background:rgba(255,255,255,.06); }
 }
 
 /* ========== Top nav ========== */


### PR DESCRIPTION
## Summary
- restructure Home page into sticky header and scrolling results region
- implement responsive 1-4 column grid and card styling
- remove list bullets and ensure results grid aligns with search tools

## Testing
- `npm test` *(fails: Invalid hook call in react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_689bef732e688327833a571d1bcb3ebb