### PR TITLE
Align Songbook builder with Setlist layout

### DIFF
--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -165,22 +165,22 @@ export default function Songbook() {
   // Render
   if (items.length === 0) {
     return (
-      <div className="SongbookPage">
-        <section className="SongPicker">
-          <div className="SongPickerHeader">
+      <div className="BuilderPage">
+        <section className="BuilderLeft">
+          <header className="BuilderHeader">
             <h3>No songs found</h3>
             <p className="Small">The song index is empty or failed to load.</p>
-          </div>
+          </header>
         </section>
       </div>
     )
   }
 
   return (
-    <div className="SongbookPage">
+    <div className="BuilderPage">
       {/* LEFT: Picker */}
-      <section className="SongPicker">
-        <div className="SongPickerHeader">
+      <section className="BuilderLeft">
+        <header className="BuilderHeader">
           <div className="Row" style={{ gap: '1rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
             <div className="Field" style={{ minWidth: 220 }}>
               <label htmlFor="sb-search">Search:</label>
@@ -239,10 +239,10 @@ export default function Songbook() {
             </div>
 
             <div className="Field" style={{ marginLeft: 'auto', gap: '.5rem' }}>
-              <button className="Button" onClick={selectAllFiltered} disabled={!filteredCount}>
+              <button className="btn" onClick={selectAllFiltered} disabled={!filteredCount}>
                 Select all ({filteredCount} filtered)
               </button>
-              <button className="Button" onClick={clearAll} disabled={!selectedCount}>
+              <button className="btn" onClick={clearAll} disabled={!selectedCount}>
                 Clear
               </button>
             </div>
@@ -251,12 +251,10 @@ export default function Songbook() {
           <div className="Row Small" style={{ marginTop: '.5rem' }}>
             <strong>{selectedCount}</strong> selected
           </div>
-          <div className="Hr" />
-        </div>
+        </header>
 
-        {/* Only this section scrolls; two-column grid handled by your CSS */}
-        <div className="SongPickerScroll" role="region" aria-label="Song list">
-          <div className="SongGrid">
+        <div className="BuilderScroll" role="region" aria-label="Song list">
+          <ul className="BuilderList">
             {filtered.map((s) => {
               const checked = selectedIds.has(s.id)
               const authorsLine = Array.isArray(s.authors)
@@ -264,69 +262,71 @@ export default function Songbook() {
                 : s.authors || ''
               const tagLine = Array.isArray(s.tags) ? s.tags.join(', ') : s.tags || ''
               return (
-                <label key={s.id} className="SongCard">
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={(e) => toggleOne(s.id, e.target.checked)}
-                    aria-label={`Select ${s.title}`}
-                  />
-                  <div className="SongInfo">
-                    <div className="SongTitle">{s.title}</div>
-                    <div className="SongMeta">
-                      {authorsLine || '—'}
-                      {tagLine ? ` • ${tagLine}` : ''}
-                      {s.country ? ` • ${s.country}` : ''}
+                <li key={s.id} className="BuilderRow">
+                  <label className="RowMain">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => toggleOne(s.id, e.target.checked)}
+                      aria-label={`Select ${s.title}`}
+                    />
+                    <div className="RowText">
+                      <div className="RowTitle">{s.title}</div>
+                      <div className="RowMeta">
+                        {authorsLine || '—'}
+                        {tagLine ? ` • ${tagLine}` : ''}
+                        {s.country ? ` • ${s.country}` : ''}
+                      </div>
                     </div>
-                  </div>
-                </label>
+                  </label>
+                </li>
               )
             })}
-          </div>
+          </ul>
         </div>
       </section>
 
       {/* RIGHT: Preview / Export */}
-      <aside className="SongPreview">
-        <div className="Row" style={{ justifyContent: 'space-between' }}>
-          <div className="Field">
-            <input
-              id="sb-toc"
-              type="checkbox"
-              checked={includeTOC}
-              onChange={(e) => setIncludeTOC(e.target.checked)}
-            />
-            <label htmlFor="sb-toc">Include table of contents</label>
-          </div>
+      <aside className="BuilderRight">
+        <div className="RightSection">
+          <div className="Row" style={{ justifyContent: 'space-between', flexWrap: 'wrap' }}>
+            <div className="Field">
+              <input
+                id="sb-toc"
+                type="checkbox"
+                checked={includeTOC}
+                onChange={(e) => setIncludeTOC(e.target.checked)}
+              />
+              <label htmlFor="sb-toc">Include table of contents</label>
+            </div>
 
-          <div className="Field">
-            <label htmlFor="sb-cover">Cover page (image):</label>
-            <input
-              id="sb-cover"
-              className="CoverInput"
-              type="file"
-              accept="image/*"
-              onChange={onCoverFile}
-            />
-          </div>
+            <div className="Field">
+              <label htmlFor="sb-cover">Cover page (image):</label>
+              <input
+                id="sb-cover"
+                className="CoverInput"
+                type="file"
+                accept="image/*"
+                onChange={onCoverFile}
+              />
+            </div>
 
-          <div className="Field" style={{ marginLeft: 'auto' }}>
-            <button
-              className="Button"
-              onClick={handleExport}
-              onMouseEnter={prefetchPdf}
-              onFocus={prefetchPdf}
-              disabled={!selectedEntries.length || busy}
-              title={!selectedEntries.length ? 'Select some songs first' : 'Export PDF'}
-            >
-              {busy ? 'Exporting…' : `Export PDF (${selectedEntries.length})`}
-            </button>
+            <div className="Field" style={{ marginLeft: 'auto' }}>
+              <button
+                className="btn"
+                onClick={handleExport}
+                onMouseEnter={prefetchPdf}
+                onFocus={prefetchPdf}
+                disabled={!selectedEntries.length || busy}
+                title={!selectedEntries.length ? 'Select some songs first' : 'Export PDF'}
+              >
+                {busy ? 'Exporting…' : `Export PDF (${selectedEntries.length})`}
+              </button>
+            </div>
           </div>
         </div>
 
-        <div className="Hr" />
-
-        <div className="PreviewScroll" role="region" aria-label="Selected songs">
+        <div className="RightSection RightScroll" role="region" aria-label="Selected songs">
           <ol className="List" style={{ listStyle: 'decimal inside' }}>
             {selectedEntries.map((s) => (
               <li key={s.id}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -250,62 +250,38 @@ html, body, #root { height: 100%; }
 .App { min-height: 100dvh; display: flex; flex-direction: column; }
 .Route, .RouteRoot { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 
-/* Songbook layout: two panes */
-.SongbookPage {
-  max-width: 1200px;
-  margin-inline: auto;
+/* Builder layout shared by Setlist and Songbook */
+.BuilderPage {
+  max-width: var(--builder-max, 1200px);
+  margin: 0 auto;
   padding-inline: 1rem;
   display: grid;
   grid-template-columns: 1.5fr 1fr;
   gap: 1rem;
   flex: 1 1 auto;
-  min-height: 0;          /* critical for inner scrolling */
+  min-height: 0;
 }
+@media (max-width: 1024px) { .BuilderPage { grid-template-columns: 1fr; } }
 
-/* Left panel: header + scroll area */
-.SongPicker { display:flex; flex-direction:column; min-height:0; }
+/* Left pane */
+.BuilderLeft { display: flex; flex-direction: column; min-height: 0; }
+.BuilderHeader { position: sticky; top: 0; z-index: 5; background: var(--bg, Canvas); padding: .75rem 0; }
+.BuilderScroll { flex: 1 1 auto; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch; }
 
-.SongPickerHeader {
-  position: sticky; top: 0; z-index: 5;
-  background: var(--bg, Canvas);
-  padding-block: .5rem;
-}
-
-.SongPickerScroll {
-  flex:1 1 auto; min-height:0;
-  overflow:auto; -webkit-overflow-scrolling:touch;
-}
-
-/* Two-column grid of cards on desktop; single column on small screens */
-.SongGrid { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:.75rem; }
-
-@media (max-width: 1024px) { .SongbookPage { grid-template-columns: 1fr; } }
-@media (max-width: 1024px) { .SongGrid { grid-template-columns: 1fr; } }
-
-/* Card styling */
-.SongCard {
-  display:grid; grid-template-columns:auto 1fr; align-items:start; gap:.5rem;
-  padding:.75rem .8rem; border-radius:.75rem;
-  border:1px solid var(--border, rgba(0,0,0,.12));
-  background: var(--surface, #f5f5f7);
-}
+/* List rows */
+.BuilderList { list-style: none; margin: 0; padding: 0; display: grid; gap: .5rem; }
+.BuilderRow { border: 1px solid var(--border, rgba(0,0,0,.1)); border-radius: 12px; background: var(--surface, #f8f9fb); }
+.RowMain { display: grid; grid-template-columns: auto 1fr; gap: .75rem; padding: .75rem 1rem; align-items: start; }
+.RowText { min-width: 0; }
+.RowTitle { font-weight: 600; line-height: 1.25; }
+.RowMeta  { opacity: .85; font-size: .9rem; margin-top: .125rem; }
 @media (prefers-color-scheme: dark) {
-  .SongCard {
-    border-color: var(--border, rgba(255,255,255,.14));
-    background: var(--surface, rgba(255,255,255,.06));
-  }
+  .BuilderRow { border-color: rgba(255,255,255,.14); background: rgba(255,255,255,.06); }
 }
 
-.SongCard input[type="checkbox"] {
-  margin-top: .25rem;
-}
-
-.SongInfo { min-width: 0; }
-.SongTitle { font-weight: 600; line-height: 1.25; }
-.SongMeta  { color: var(--muted, #9aa0a6); font-size: .875rem; margin-top: .25rem; }
-
-/* Right panel (preview) just in case it also needs to scroll */
-.SongPreview { min-height:0; display:flex; flex-direction:column; }
-.PreviewScroll { flex:1 1 auto; min-height:0; overflow:auto; }
+/* Right pane */
+.BuilderRight { min-height: 0; display: flex; flex-direction: column; gap: .75rem; }
+.RightSection { padding: .25rem 0; }
+.RightScroll { flex: 1 1 auto; min-height: 0; overflow: auto; }
 
 


### PR DESCRIPTION
## Summary
- Rework Songbook component structure to mirror Setlist builder with left-side filters and right-side preview/export
- Introduce shared Builder styles for consistent pane layout and row visuals

## Testing
- `npm test` *(fails: SongView PPTX button test)*

------
https://chatgpt.com/codex/tasks/task_e_689bf208b22483278f19bd745daf1608