### PR TITLE
Parallelize bundle download and show progress

### DIFF
--- a/src/components/Bundle.jsx
+++ b/src/components/Bundle.jsx
@@ -9,6 +9,7 @@ export default function Bundle(){
   const [selection, setSelection] = useState({})
   const [entries, setEntries] = useState([])
   const [loading, setLoading] = useState(false)
+  const [progress, setProgress] = useState(0)
 
   useEffect(()=>{
     try{ const raw = localStorage.getItem('bundleSelection'); setSelection(raw? JSON.parse(raw):{}) }catch{}
@@ -24,10 +25,10 @@ export default function Bundle(){
 
   async function handleDownload(){
     setLoading(true)
+    setProgress(0)
     try{
-      const songs = []
-      for(const it of entries){
-        try {
+      const promises = entries.map(it =>
+        (async () => {
           const toKey = selection[it.id]?.toKey || it.originalKey || 'C'
           const res = await fetch(`${import.meta.env.BASE_URL}songs/${it.filename}`)
           if(!res.ok) throw new Error(`Missing file ${it.filename}`)
@@ -42,17 +43,26 @@ export default function Bundle(){
               chordPositions: (ln.chords||[]).map(c => ({ sym: transposeSym(c.sym, steps), index: c.index }))
             }))
           }))
-          songs.push({ title: parsed.meta.title || it.title, key: toKey, lyricsBlocks: blocks })
-        } catch(err){
-          console.error(err)
-          showToast(`Failed to process ${it.filename}`)
-        }
-      }
+          return { title: parsed.meta.title || it.title, key: toKey, lyricsBlocks: blocks }
+        })()
+          .catch(err => {
+            console.error(err)
+            showToast(`Failed to process ${it.filename}`)
+            throw err
+          })
+          .finally(() => setProgress(p => p + 1))
+      )
+
+      const results = await Promise.allSettled(promises)
+      const songs = results.filter(r => r.status === 'fulfilled').map(r => r.value)
       if(songs.length){
         const { downloadMultiSongPdf } = await loadPdfLib()
         await downloadMultiSongPdf(songs, { lyricSizePt: 16, chordSizePt: 16 })
       }
-    } finally { setLoading(false) }
+    } finally {
+      setLoading(false)
+      setProgress(0)
+    }
   }
 
   if(entries.length===0){
@@ -85,7 +95,7 @@ export default function Bundle(){
       </div>
       <div style={{display:'flex', gap:8, marginTop:10}}>
         <button className="btn" onClick={()=>{ localStorage.removeItem('bundleSelection'); navigate('/') }}>Clear</button>
-        <button className="btn primary" disabled={loading} onClick={handleDownload}>{loading? 'Preparing…':'Download PDF ('+entries.length+')'}</button>
+        <button className="btn primary" disabled={loading} onClick={handleDownload}>{loading? `Preparing ${progress}/${entries.length}…`:'Download PDF ('+entries.length+')'}</button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- fetch bundle songs concurrently with `Promise.allSettled`
- track settled requests to update progress indicator

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading 'useRef'))*
- `node --input-type=module benchmark script`

------
https://chatgpt.com/codex/tasks/task_e_689c00657330832787b889aefd09f836