### PR TITLE
Handle Escape key in home search input

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -135,6 +135,10 @@ export default function Home(){
           break
         }
       }
+    } else if(e.key === 'Escape') {
+      e.preventDefault()
+      setQ('')
+      searchRef.current?.focus()
     } else if(e.key === 'ArrowDown') {
       e.preventDefault()
       if(results.length === 0) return


### PR DESCRIPTION
## Summary
- Clear the search query and refocus the input when Escape is pressed in the home page search box

## Testing
- `npm install`
- `node node_modules/vitest/vitest.mjs run` *(fails: 2 failed, 27 passed)*


------
https://chatgpt.com/codex/tasks/task_e_689c008621308327888e3272f5abc87f