### PR TITLE
Expose PDF plan for reuse in JPG export

### DIFF
--- a/src/__tests__/planSongLayout.compare.test.js
+++ b/src/__tests__/planSongLayout.compare.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { planSongLayout } from '../utils/pdf-plan'
+import { jsPDF } from 'jspdf'
+
+describe('planSongLayout regression', () => {
+  it('matches jsPDF plan with simple length-based measure', () => {
+    const song = {
+      title: 'Test',
+      key: 'C',
+      lyricsBlocks: [
+        {
+          section: 'Verse 1',
+          lines: [
+            { plain: 'short line', chordPositions: [{ index: 0, sym: 'C' }] },
+            { plain: 'another line', chordPositions: [] }
+          ]
+        }
+      ]
+    }
+
+    const doc = new jsPDF({ unit: 'pt', format: 'letter' })
+    const makeLyricPdf = (pt) => (text) => {
+      doc.setFont('Helvetica', 'normal')
+      doc.setFontSize(pt)
+      return doc.getTextWidth(text || '')
+    }
+    const makeChordPdf = (pt) => (text) => {
+      doc.setFont('Courier', 'bold')
+      doc.setFontSize(pt)
+      return doc.getTextWidth(text || '')
+    }
+    const planPdf = planSongLayout(song, { lyricFamily: 'Helvetica', chordFamily: 'Courier' }, makeLyricPdf, makeChordPdf)
+
+    const makeLyricSimple = (pt) => (text) => (text || '').length * pt * 0.5
+    const makeChordSimple = (pt) => (text) => (text || '').length * pt * 0.5
+    const planSimple = planSongLayout(song, { lyricFamily: 'Helvetica', chordFamily: 'Courier' }, makeLyricSimple, makeChordSimple)
+
+    expect(planSimple).toEqual(planPdf)
+  })
+})

--- a/src/components/SongView.jsx
+++ b/src/components/SongView.jsx
@@ -28,6 +28,7 @@ export default function SongView(){
   const [jpgDisabled, setJpgDisabled] = useState(false)
   const [pdfPlanPromiseState, setPdfPlanPromise] = useState(pdfPlanPromise)
   const jpgAlerted = useRef(false)
+  const lastPlan = useRef(null)
 
   const loadPdfPlan = () => {
     if (!pdfPlanPromise) {
@@ -179,6 +180,7 @@ if(!entry){
     const makeLyric = (pt) => (text) => { ctx.font = `${pt}px ${fonts.lyricFamily}`; return ctx.measureText(text || '').width }
     const makeChord = (pt) => (text) => { ctx.font = `bold ${pt}px ${fonts.chordFamily}`; return ctx.measureText(text || '').width }
     const plan = planSongLayout(song, { lyricFamily: fonts.lyricFamily, chordFamily: fonts.chordFamily }, makeLyric, makeChord)
+    lastPlan.current = plan
     const ok = plan.layout.pages.length <= 1
     if (!ok && showAlert && !jpgAlerted.current) {
       alert('JPG export supports single-page songs only for now.')
@@ -196,14 +198,15 @@ if(!entry){
 
   async function handleDownloadPdf(){
     const { downloadSingleSongPdf } = await loadPdfLib()
-    await downloadSingleSongPdf(buildSong(), { lyricSizePt: 16, chordSizePt: 16 })
+    const res = await downloadSingleSongPdf(buildSong(), { lyricSizePt: 16, chordSizePt: 16 })
+    lastPlan.current = res?.plan || null
   }
 
   async function handleDownloadJpg(){
     const ok = await checkJpgSupport(true)
     if (!ok) return
     const { downloadSingleSongJpg } = await loadImageLib()
-    await downloadSingleSongJpg(buildSong(), { slug: entry.filename.replace(/\.chordpro$/, '') })
+    await downloadSingleSongJpg(buildSong(), { slug: entry.filename.replace(/\.chordpro$/, ''), plan: lastPlan.current })
   }
 
   

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -60,17 +60,21 @@ export async function downloadSingleSongJpg(song, options = {}) {
   const heightIn = options.heightInches || 11
   const pxWidth = Math.round(widthIn * dpi)
   const pxHeight = Math.round(heightIn * dpi)
-  const { lyricFamily, chordFamily } = await ensureCanvasFonts()
-  const measureCtx = document.createElement('canvas').getContext('2d')
-  const makeMeasureLyricAt = (pt) => (text) => {
-    measureCtx.font = `${pt}px ${lyricFamily}`
-    return measureCtx.measureText(text || '').width
+  const fonts = await ensureCanvasFonts()
+  const { lyricFamily, chordFamily } = fonts
+  let plan = options.plan
+  if (!plan) {
+    const measureCtx = document.createElement('canvas').getContext('2d')
+    const makeMeasureLyricAt = (pt) => (text) => {
+      measureCtx.font = `${pt}px ${lyricFamily}`
+      return measureCtx.measureText(text || '').width
+    }
+    const makeMeasureChordAt = (pt) => (text) => {
+      measureCtx.font = `bold ${pt}px ${chordFamily}`
+      return measureCtx.measureText(text || '').width
+    }
+    plan = planSongLayout(song, { lyricFamily, chordFamily }, makeMeasureLyricAt, makeMeasureChordAt)
   }
-  const makeMeasureChordAt = (pt) => (text) => {
-    measureCtx.font = `bold ${pt}px ${chordFamily}`
-    return measureCtx.measureText(text || '').width
-  }
-  const plan = planSongLayout(song, { lyricFamily, chordFamily }, makeMeasureLyricAt, makeMeasureChordAt)
   if (plan.layout.pages.length > 1) {
     return { error: 'MULTI_PAGE', plan }
   }

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -166,6 +166,7 @@ export async function downloadSingleSongPdf(song, options) {
   const plan = await planFitOnOnePage(doc, normalizeSongInput(song), base)
   drawSongIntoDoc(doc, song, { ...base, ...plan })
   doc.save(`${(base.title).replace(/\s+/g, '_')}.pdf`)
+  return { plan }
 }
 
 export async function downloadMultiSongPdf(songs, options){


### PR DESCRIPTION
## Summary
- allow `downloadSingleSongPdf` to return the layout plan
- JPG exporter can reuse a provided plan
- Song view caches the last plan and passes it to JPG export
- add regression test ensuring `planSongLayout` is stable

## Testing
- `npm test` *(fails: Invalid hook call errors and missing vitest packages)*

------
https://chatgpt.com/codex/tasks/task_e_689c00c65a2c832791263a3b72fde6cd