### PR TITLE
Ensure logical heading hierarchy across routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ export default function App(){
             <Route path="/songbook" element={<Songbook />} />
           </Route>
           <Route path="/admin" element={<Admin />} />
-          <Route path="*" element={<div className="container"><h3>Not found</h3><Link to="/">Back</Link></div>} />
+          <Route path="*" element={<div className="container"><h1>Not found</h1><Link to="/">Back</Link></div>} />
         </Routes>
       </React.Suspense>
       <Toast />

--- a/src/components/Admin.jsx
+++ b/src/components/Admin.jsx
@@ -23,7 +23,7 @@ export default function Admin(){
   if(!ok){
     return (
       <div className="container" style={{maxWidth:480}}>
-        <h2>Admin</h2>
+        <h1>Admin</h1>
         <p>Enter password to continue.</p>
         <label htmlFor="adminPw" className="sr-only">Password</label>
         <input
@@ -87,7 +87,7 @@ function AdminPanel(){
 
   return (
     <div className="container">
-      <h2>Admin</h2>
+      <h1>Admin</h1>
 
       {/* Metadata form */}
       <div className="card" style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:10}}>

--- a/src/components/Bundle.jsx
+++ b/src/components/Bundle.jsx
@@ -56,14 +56,14 @@ export default function Bundle(){
   }
 
   if(entries.length===0){
-    return <div className="container"><h2>Bundle</h2><p>No songs selected.</p><Link to="/" className="btn">← Back</Link></div>
+    return <div className="container"><h1>Bundle</h1><p>No songs selected.</p><Link to="/" className="btn">← Back</Link></div>
   }
 
   return (
     <div className="container">
       <div className="songpage__top">
         <Link to="/" className="back">← Back</Link>
-        <h2 style={{margin:0}}>Build PDF Bundle</h2>
+        <h1 style={{margin:0}}>Build PDF Bundle</h1>
       </div>
       <div className="card" style={{display:'grid', gap:10}}>
         {entries.map(it=>{

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -15,7 +15,7 @@ export default class ErrorBoundary extends React.Component {
     if(this.state.error){
       return (
         <div className="container" style={{padding:'2rem'}}>
-          <h2>Something went wrong.</h2>
+          <h1>Something went wrong.</h1>
           <p><a href="#" onClick={e=>{e.preventDefault(); window.location.reload();}}>Reload</a></p>
         </div>
       );

--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -204,7 +204,7 @@ export default function Setlist(){
     <div className="container">
       <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
         <div><Link to="/" className="back">← Back</Link></div>
-        <h2 style={{margin:0}}>Setlist Builder</h2>
+        <h1 style={{margin:0}}>Setlist Builder</h1>
         <div />
       </div>
 
@@ -306,7 +306,7 @@ export default function Setlist(){
 
           {/* Print-only minimal outline */}
           <div className="print-only" style={{marginTop:16}}>
-            <h1 style={{fontSize:'20pt', margin:'0 0 8pt 0'}}>{name}</h1>
+            <h2 style={{fontSize:'20pt', margin:'0 0 8pt 0'}}>{name}</h2>
             <ol style={{fontSize:'12pt', lineHeight:1.4, paddingLeft:'1.2em'}}>
               {list.map(sel => {
                 const s = items.find(it=> it.id===sel.id)

--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -168,7 +168,7 @@ export default function Songbook() {
       <div className="BuilderPage">
         <section className="BuilderLeft">
           <header className="BuilderHeader">
-            <h3>No songs found</h3>
+            <h1>No songs found</h1>
             <p className="Small">The song index is empty or failed to load.</p>
           </header>
         </section>
@@ -181,6 +181,7 @@ export default function Songbook() {
       {/* LEFT: Picker */}
       <section className="BuilderLeft">
         <header className="BuilderHeader">
+          <h1 style={{ margin: 0 }}>Songbook Builder</h1>
           <div className="Row" style={{ gap: '1rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
             <div className="Field" style={{ minWidth: 220 }}>
               <label htmlFor="sb-search">Search:</label>


### PR DESCRIPTION
## Summary
- align 404 route and error boundary with `<h1>` headings
- promote page-level headings in Bundle, Setlist, Songbook, and Admin
- add top heading to Songbook builder and adjust print heading in Setlist

## Testing
- `npm test -- --run` *(fails: SongView PPTX button > shows PPTX download when available)*

------
https://chatgpt.com/codex/tasks/task_e_689c00dd232c832796527c01c6f09c46