### PR TITLE
feat: include commit sha in service worker cache

### DIFF
--- a/.github/workflows/build-to-docs.yml
+++ b/.github/workflows/build-to-docs.yml
@@ -21,6 +21,8 @@ jobs:
 
       - run: npm ci
       - run: npm run build  # writes to /docs
+        env:
+          VITE_COMMIT_SHA: ${{ github.sha }}
       # WARNING: ensure docs/CNAME and 404.html are preserved
 
       # Commit the newly built files back into /docs on main

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,4 +1,6 @@
-const CACHE_NAME = 'gracechords-v1';
+// Include the current commit SHA in the cache name so that each deploy
+// invalidates previously cached assets and clients fetch the latest files.
+const CACHE_NAME = `gracechords-${import.meta.env.VITE_COMMIT_SHA || 'dev'}`;
 const STATIC_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- include commit SHA in service worker cache key
- propagate commit SHA during docs build

## Testing
- `npm test` *(fails: Invalid hook call)*
- `VITE_COMMIT_SHA=test npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c00ed5c2c8327a6400a361bc16d16