### PR TITLE
Add length guard to extractYouTubeId

### DIFF
--- a/src/components/SongView.jsx
+++ b/src/components/SongView.jsx
@@ -334,7 +334,9 @@ if(!entry){
 /* ---------- Helpers ---------- */
 
 function extractYouTubeId(input = '') {
-  const s = String(input).trim()
+  const raw = String(input)
+  if (raw.length > 200) return null
+  const s = raw.trim()
   const ID = /^[a-zA-Z0-9_-]{11}$/
   if (ID.test(s)) return s
 


### PR DESCRIPTION
## Summary
- limit YouTube ID extractor input to 200 characters before parsing

## Testing
- `node node_modules/vitest/vitest.mjs` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689c011a7b14832796f329d9605af33e