### PR TITLE
Fail wiki sync in CI

### DIFF
--- a/scripts/syncWiki.mjs
+++ b/scripts/syncWiki.mjs
@@ -114,6 +114,6 @@ async function currentBranch(repoDir) {
   console.log("[wiki-sync] Done.");
 })().catch((err) => {
   console.error("[wiki-sync] ERROR:", err?.stack || err?.message || String(err));
-  // Don't fail the pipeline on a wiki hiccup by default — change to 1 if you want hard failures.
-  process.exit(0);
+  // Fail the pipeline in CI environments; otherwise, don't hard-fail on wiki hiccups.
+  process.exit(process.env.CI ? 1 : 0);
 });


### PR DESCRIPTION
## Summary
- exit with failure in CI when wiki sync errors

## Testing
- `npm test` *(fails: Expected null Received <a class="btn" download="" href="/pptx/build-my-life.pptx">Download PPTX</a>)*

------
https://chatgpt.com/codex/tasks/task_e_689c0183d0d4832787a499cced77eb00