### PR TITLE
refactor pdf layout engine and unify exporters

### DIFF
--- a/src/__tests__/pdf.layout.snapshot.test.js
+++ b/src/__tests__/pdf.layout.snapshot.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getLayoutMetrics, computeLayout } from '../utils/pdf-plan'
+import { getLayoutMetrics } from '../utils/pdfLayout'
 
 // ---------- Fixtures ----------
 

--- a/src/__tests__/pdf.planner.test.js
+++ b/src/__tests__/pdf.planner.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { planForTest, getLayoutMetrics } from '../utils/pdf-plan'
+import { planForTest, getLayoutMetrics } from '../utils/pdfLayout'
 
 // Helpers to build lines/blocks
 const line = (len, ch='x') => ({ plain: ch.repeat(len), chordPositions: [] })

--- a/src/__tests__/pdf.widow-orphan.test.js
+++ b/src/__tests__/pdf.widow-orphan.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getLayoutMetrics } from '../utils/pdf-plan'
+import { getLayoutMetrics } from '../utils/pdfLayout'
 
 const mkLines = (n) => Array.from({ length: n }, (_, i) => ({ plain: `line ${i+1}`, chordPositions: [] }))
 const mkSection = (label, n) => ({ section: label, lines: mkLines(n) })

--- a/src/__tests__/planSongLayout.compare.test.js
+++ b/src/__tests__/planSongLayout.compare.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { planSongLayout } from '../utils/pdf-plan'
+import { planSongLayout } from '../utils/pdfLayout'
 import { jsPDF } from 'jspdf'
 
 describe('planSongLayout regression', () => {

--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -157,13 +157,14 @@ export default function Setlist(){
             chordPositions: (ln.chords||[]).map(c => ({ sym: transposeSym(c.sym, steps), index: c.index }))
           }))
         }))
-        songs.push({ title: parsed.meta?.title || s.title, key: sel.toKey || baseKey, lyricsBlocks: blocks })
+        const slug = s.filename.replace(/\.chordpro$/, '')
+        songs.push({ title: parsed.meta?.title || s.title || slug, key: sel.toKey || baseKey, lyricsBlocks: blocks })
       } catch(err){
         console.error(err)
         showToast(`Failed to process ${s.filename}`)
       }
     }
-    if(songs.length) await downloadMultiSongPdf(songs, { lyricSizePt: 16, chordSizePt: 16 })
+    if(songs.length) await downloadMultiSongPdf(songs)
   }
 
   function prefetchPdf(){ loadPdfLib() }

--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -113,7 +113,7 @@ export default function Songbook() {
     if (!selectedEntries.length) return
     setBusy(true)
     try {
-      const { downloadSongbookPdf, downloadMultiSongPdf } = await loadPdfLib()
+      const { downloadSongbookPdf } = await loadPdfLib()
       const songs = []
       for (const it of selectedEntries) {
         try {
@@ -127,8 +127,9 @@ export default function Songbook() {
               chordPositions: (ln.chords || []).map((c) => ({ sym: c.sym, index: c.index })),
             })),
           }))
+          const slug = it.filename.replace(/\.chordpro$/, '')
           songs.push({
-            title: parsed.meta.title || it.title,
+            title: parsed.meta.title || it.title || slug,
             key: parsed.meta.key || parsed.meta.originalkey || it.originalKey || 'C',
             lyricsBlocks: blocks,
           })
@@ -138,11 +139,7 @@ export default function Songbook() {
         }
       }
       if (songs.length) {
-        if (typeof downloadSongbookPdf === 'function') {
-          await downloadSongbookPdf(songs, { includeTOC, cover })
-        } else {
-          await downloadMultiSongPdf(songs, { lyricSizePt: 16, chordSizePt: 16 })
-        }
+        await downloadSongbookPdf(songs, { includeTOC, coverImageDataUrl: cover })
       }
     } finally {
       setBusy(false)

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -1,5 +1,5 @@
 // src/utils/image.js
-import { planSongLayout } from './pdf-plan'
+import { chooseBestLayout } from './pdfLayout'
 import { ensureCanvasFonts } from './fonts'
 export { ensureCanvasFonts } from './fonts'
 
@@ -73,7 +73,8 @@ export async function downloadSingleSongJpg(song, options = {}) {
       measureCtx.font = `bold ${pt}px ${chordFamily}`
       return measureCtx.measureText(text || '').width
     }
-    plan = planSongLayout(song, { lyricFamily, chordFamily }, makeMeasureLyricAt, makeMeasureChordAt)
+    const res = chooseBestLayout(song, { lyricFamily, chordFamily }, makeMeasureLyricAt, makeMeasureChordAt)
+    plan = res.plan
   }
   if (plan.layout.pages.length > 1) {
     return { error: 'MULTI_PAGE', plan }

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,11 +1,9 @@
-// src/utils/pdf.js
 import { ensureFontsEmbedded } from './fonts'
-import { planSongLayout, computeLayout, normalizeSongInput, DEFAULT_LAYOUT_OPT } from './pdf-plan'
+import { planSongLayout, chooseBestLayout, normalizeSongInput, DEFAULT_LAYOUT_OPT } from './pdfLayout'
 
 // Debug switch: open DevTools and run localStorage.setItem('pdfDebug','1') to see guides
 const PDF_DEBUG = typeof window !== 'undefined'
   && (() => { try { return localStorage.getItem('pdfDebug') === '1' } catch { return false } })()
-
 
 /* -----------------------------------------------------------
  * Lazy jsPDF
@@ -16,69 +14,66 @@ async function newPDF() {
 }
 
 /* -----------------------------------------------------------
- * Helpers
+ * Planner wrapper bound to jsPDF doc/fonts
  * --------------------------------------------------------- */
-
-/** Create a lyrics-width measurer bound to a jsPDF doc + font settings */
-function makeLyricMeasurer(doc, lyricFamily, lyricPt) {
-  return (text) => {
-    doc.setFont(lyricFamily, 'normal')
-    doc.setFontSize(lyricPt)
-    return doc.getTextWidth(text || '')
-  }
-}
-
-
-/* -----------------------------------------------------------
- * DRAWING (consumes computeLayout)
- * --------------------------------------------------------- */
-function drawSongIntoDoc(doc, songIn, opt) {
-  const lFam = String(opt.lyricFamily || 'Helvetica')
-  const cFam = String(opt.chordFamily || 'Courier')
+function planWithDoc(doc, song, baseOpt) {
   const pageW = doc.internal.pageSize.getWidth()
   const pageH = doc.internal.pageSize.getHeight()
-  const o = { ...DEFAULT_LAYOUT_OPT, ...opt, pageWidth: pageW, pageHeight: pageH }
+  const oBase = { ...DEFAULT_LAYOUT_OPT, ...baseOpt, pageWidth: pageW, pageHeight: pageH }
+  const makeLyric = (pt) => (text) => {
+    doc.setFont(oBase.lyricFamily, 'normal')
+    doc.setFontSize(pt)
+    return doc.getTextWidth(text || '')
+  }
+  const makeChord = (pt) => (text) => {
+    doc.setFont(oBase.chordFamily, 'bold')
+    doc.setFontSize(pt)
+    return doc.getTextWidth(text || '')
+  }
+  return chooseBestLayout(song, oBase, makeLyric, makeChord)
+}
 
-  const margin = o.margin
-  const headerTitlePt = Math.max(22, o.lyricSizePt + 6)
-  const headerKeyPt   = Math.max(12, o.lyricSizePt - 2)
+/* -----------------------------------------------------------
+ * DRAWING (consumes planned layout)
+ * --------------------------------------------------------- */
+function drawPlannedSong(doc, plan, { title, key }) {
+  const lFam = String(plan.lyricFamily || 'Helvetica')
+  const cFam = String(plan.chordFamily || 'Courier')
+  const pageW = doc.internal.pageSize.getWidth()
+  const pageH = doc.internal.pageSize.getHeight()
 
-  // Header
-  doc.setFont(lFam, 'bold');   doc.setFontSize(headerTitlePt)
-  doc.text(o.title, margin, margin + 24)
-  doc.setFont(lFam, 'italic'); doc.setFontSize(headerKeyPt)
-  doc.text(`Key: ${o.key || '—'}`, margin, margin + 40)
-
-  // Layout + draw
-  const measure = makeLyricMeasurer(doc, lFam, o.lyricSizePt)
-  const layout = computeLayout(songIn, o, measure)
-
+  const margin = plan.margin
+  const headerTitlePt = Math.max(22, plan.lyricSizePt + 6)
+  const headerKeyPt   = Math.max(12, plan.lyricSizePt - 2)
   const lineGap = 4
-  const sectionSize = o.lyricSizePt
-  const sectionTopPad = Math.round(o.lyricSizePt * 0.85)
-  const contentStartY = margin + o.headerOffsetY
+  const sectionSize = plan.lyricSizePt
+  const sectionTopPad = Math.round(plan.lyricSizePt * 0.85)
+  const contentStartY = margin + plan.headerOffsetY
   const contentW = pageW - margin * 2
-  const colW = o.columns === 2 ? (contentW - o.gutter) / 2 : contentW
+  const colW = plan.columns === 2 ? (contentW - plan.gutter) / 2 : contentW
 
-  layout.pages.forEach((p, pIdx) => {
+  plan.layout.pages.forEach((p, pIdx) => {
     if (pIdx > 0) doc.addPage()
-     // Debug overlay: draw column boxes + plan footer
-     if (PDF_DEBUG) {
-       doc.setDrawColor(180)
-       // Column 1 box
-       doc.rect(margin, contentStartY, colW, pageH - margin - contentStartY)
-       if (o.columns === 2) {
-         // Column 2 box
-         doc.rect(margin + colW + o.gutter, contentStartY, colW, pageH - margin - contentStartY)
-       }
-       // Footer with chosen plan
-       doc.setFont(lFam, 'normal'); doc.setFontSize(9)
-       doc.text(
-         `Plan: ${o.columns} col • size ${o.lyricSizePt}pt • family ${o.lyricFamily}/${o.chordFamily}`,
-         margin,
-         pageH - (margin * 0.6)
-       )
-     }
+    // Header
+    doc.setFont(lFam, 'bold');   doc.setFontSize(headerTitlePt)
+    doc.text(title, margin, margin + 24)
+    doc.setFont(lFam, 'italic'); doc.setFontSize(headerKeyPt)
+    doc.text(`Key: ${key || '—'}`, margin, margin + 40)
+
+    if (PDF_DEBUG) {
+      doc.setDrawColor(180)
+      doc.rect(margin, contentStartY, colW, pageH - margin - contentStartY)
+      if (plan.columns === 2) {
+        doc.rect(margin + colW + plan.gutter, contentStartY, colW, pageH - margin - contentStartY)
+      }
+      doc.setFont(lFam, 'normal'); doc.setFontSize(9)
+      doc.text(
+        `Plan: ${plan.columns} col • size ${plan.lyricSizePt}pt • family ${plan.lyricFamily}/${plan.chordFamily}`,
+        margin,
+        pageH - (margin * 0.6)
+      )
+    }
+
     p.columns.forEach((col) => {
       let x = col.x
       let y = contentStartY
@@ -90,13 +85,13 @@ function drawSongIntoDoc(doc, songIn, opt) {
           y += sectionSize + 4
         } else if (b.type === 'line') {
           if (b.chords?.length) {
-            doc.setFont(cFam, 'bold'); doc.setFontSize(o.chordSizePt)
+            doc.setFont(cFam, 'bold'); doc.setFontSize(plan.chordSizePt)
             for (const c of b.chords) doc.text(c.sym, x + c.x, y)
-            y += o.chordSizePt + lineGap / 2
+            y += plan.chordSizePt + lineGap / 2
           }
-          doc.setFont(lFam, 'normal'); doc.setFontSize(o.lyricSizePt)
+          doc.setFont(lFam, 'normal'); doc.setFontSize(plan.lyricSizePt)
           doc.text(b.lyrics, x, y)
-          y += o.lyricSizePt + lineGap
+          y += plan.lyricSizePt + lineGap
         }
       }
     })
@@ -104,52 +99,25 @@ function drawSongIntoDoc(doc, songIn, opt) {
 }
 
 /* -----------------------------------------------------------
- * Fit planner (width + height; shrink-to-fit ≥12pt)
+ * Exposed helpers
  * --------------------------------------------------------- */
-async function planFitOnOnePage(doc, songIn, baseOpt = {}) {
-  const pageW = doc.internal.pageSize.getWidth();
-  const pageH = doc.internal.pageSize.getHeight();
-  const oBase = { ...DEFAULT_LAYOUT_OPT, ...baseOpt, pageWidth: pageW, pageHeight: pageH };
+export { planSongLayout } from './pdfLayout'
 
-  let fams = {};
-  try { fams = await ensureFontsEmbedded(doc) } catch {}
-  const lyricFamily = fams.lyricFamily || oBase.lyricFamily || 'Helvetica';
-  const chordFamily = fams.chordFamily || oBase.chordFamily || 'Courier';
-
-  const makeMeasureLyricAt = (pt) => (text) => {
-    doc.setFont(lyricFamily, 'normal'); doc.setFontSize(pt);
-    return doc.getTextWidth(text || '');
-  };
-  const makeMeasureChordAt = (pt) => (text) => {
-    doc.setFont(chordFamily, 'bold'); doc.setFontSize(pt);
-    return doc.getTextWidth(text || '');
-  };
-
-  const plan = planSongLayout(songIn, { ...oBase, lyricFamily, chordFamily }, makeMeasureLyricAt, makeMeasureChordAt);
-  return plan;
-}
-
-
-/* -----------------------------------------------------------
- * PUBLIC APIS
- * --------------------------------------------------------- */
-export async function songToPdfDoc(song, options){
+export async function chooseBestLayoutAuto(song, baseOpt = {}) {
   const doc = await newPDF()
   let fams = {}
   try { fams = await ensureFontsEmbedded(doc) } catch {}
-  const plan = await planFitOnOnePage(doc, normalizeSongInput(song), {
-    lyricSizePt: Math.max(12, options?.lyricSizePt || 16),
-    chordSizePt: Math.max(12, options?.chordSizePt || 16),
-    title: options?.title || song.title || 'Untitled',
-    key: options?.key || song.key || 'C',
-    margin: 36,
-    lyricFamily: fams.lyricFamily || 'Helvetica',
-    chordFamily: fams.chordFamily || 'Courier'
-  })
-  drawSongIntoDoc(doc, song, { ...plan, title: plan.title || (options?.title || song.title), key: plan.key || (options?.key || song.key) })
-  return doc
+  const o = {
+    lyricFamily: fams.lyricFamily || baseOpt.lyricFamily || 'Helvetica',
+    chordFamily: fams.chordFamily || baseOpt.chordFamily || 'Courier',
+    ...baseOpt,
+  }
+  return planWithDoc(doc, normalizeSongInput(song), o)
 }
 
+/* -----------------------------------------------------------
+ * Single-song PDF
+ * --------------------------------------------------------- */
 export async function downloadSingleSongPdf(song, options) {
   const doc = await newPDF()
   let fams = {}
@@ -157,19 +125,25 @@ export async function downloadSingleSongPdf(song, options) {
   const base = {
     lyricSizePt: Math.max(12, options?.lyricSizePt || 16),
     chordSizePt: Math.max(12, options?.chordSizePt || 16),
-    title: options?.title || (song.title || 'Untitled'),
-    key: options?.key || (song.key || 'C'),
     margin: 36,
     lyricFamily: fams.lyricFamily || 'Helvetica',
-    chordFamily: fams.chordFamily || 'Courier'
+    chordFamily: fams.chordFamily || 'Courier',
+    columns: options?.columns === 2 ? 2 : 1,
   }
-  const plan = await planFitOnOnePage(doc, normalizeSongInput(song), base)
-  drawSongIntoDoc(doc, song, { ...base, ...plan })
-  doc.save(`${(base.title).replace(/\s+/g, '_')}.pdf`)
+  const norm = normalizeSongInput(song)
+  const { plan } = planWithDoc(doc, norm, base)
+  const title = song.title || norm.title || 'Untitled'
+  const key = song.key || norm.key || 'C'
+  drawPlannedSong(doc, plan, { title, key })
+  doc.setProperties({ title: `${title} – GraceChords` })
+  doc.save(`${title.replace(/\s+/g, '_')}.pdf`)
   return { plan }
 }
 
-export async function downloadMultiSongPdf(songs, options){
+/* -----------------------------------------------------------
+ * Multi-song PDF (setlists / songbooks)
+ * --------------------------------------------------------- */
+export async function downloadMultiSongPdf(songs, options = {}) {
   const doc = await newPDF()
   let fams = {}
   try { fams = await ensureFontsEmbedded(doc) } catch {}
@@ -178,105 +152,97 @@ export async function downloadMultiSongPdf(songs, options){
     chordSizePt: Math.max(12, options?.chordSizePt || 16),
     margin: 36,
     lyricFamily: fams.lyricFamily || 'Helvetica',
-    chordFamily: fams.chordFamily || 'Courier'
-  }
-  let first = true
-  for (const s of songs) {
-    if (!first) doc.addPage()
-    first = false
-    const songNorm = normalizeSongInput(s)
-    const plan = await planFitOnOnePage(doc, songNorm, { ...baseOpt, title: s.title || 'Untitled', key: s.key || 'C' })
-    drawSongIntoDoc(doc, s, { ...baseOpt, ...plan, title: s.title || 'Untitled', key: s.key || 'C' })
-  }
-  doc.save('GraceChords_Selection.pdf')
-}
-
-export async function downloadSongbookPdf(songs, options = {}) {
-  const doc = await newPDF();
-  let fams = {};
-  try { fams = await ensureFontsEmbedded(doc); } catch {}
-  const baseOpt = {
-    lyricSizePt: Math.max(12, options?.lyricSizePt || 16),
-    chordSizePt: Math.max(12, options?.chordSizePt || 16),
-    margin: 36,
-    lyricFamily: fams.lyricFamily || 'Helvetica',
     chordFamily: fams.chordFamily || 'Courier',
-    columns: options?.columns === 2 ? 2 : 1
-  };
+    columns: options?.columns === 2 ? 2 : 1,
+  }
+  const includeTOC = !!options?.includeTOC
+  const cover = options?.coverImageDataUrl
 
-  const includeTOC = !!options?.includeTOC;
-  const cover = options?.cover;
+  const planned = songs.map((s, idx) => {
+    const norm = normalizeSongInput(s)
+    const { plan } = planWithDoc(doc, norm, baseOpt)
+    const title = s.title || norm.title || 'Untitled'
+    const key = s.key || norm.key || 'C'
+    return {
+      raw: s,
+      plan,
+      title,
+      key,
+      num: s._songbookNum || idx + 1,
+      origTitle: s._origTitle || title,
+    }
+  })
 
-  // Pre-compute layout pages for each song
-  const measure = makeLyricMeasurer(doc, baseOpt.lyricFamily, baseOpt.lyricSizePt);
-  const planned = songs.map((s) => ({
-    raw: s,
-    norm: normalizeSongInput(s),
-    layout: computeLayout(s, { ...baseOpt }, measure)
-  }));
-
-  const startPage = 1 + (cover ? 1 : 0) + (includeTOC ? 1 : 0);
-  let curPage = startPage;
-  const tocEntries = planned.map((p, i) => {
-    const entry = { num: i + 1, title: p.norm.title || 'Untitled', page: curPage };
-    p.start = curPage;
-    curPage += p.layout.pages.length;
-    return entry;
-  });
-
-  const pageW = doc.internal.pageSize.getWidth();
-  const pageH = doc.internal.pageSize.getHeight();
+  const pageW = doc.internal.pageSize.getWidth()
+  const pageH = doc.internal.pageSize.getHeight()
+  const margin = baseOpt.margin
+  const lineH = 16
+  const linesPerPage = Math.floor((pageH - margin * 2 - 40) / lineH)
+  const tocPages = includeTOC ? Math.ceil(planned.length / linesPerPage) : 0
+  let curPage = 1 + (cover ? 1 : 0) + tocPages
+  const tocEntries = planned.map((p) => {
+    const entry = { num: p.num, title: p.origTitle, page: curPage }
+    curPage += p.plan.layout.pages.length
+    return entry
+  })
 
   // Cover page
   if (cover) {
-    try {
-      doc.addImage(cover, 'JPEG', 0, 0, pageW, pageH, undefined, 'FAST');
-    } catch {}
-    if (includeTOC || planned.length) doc.addPage();
+    try { doc.addImage(cover, 'JPEG', 0, 0, pageW, pageH, undefined, 'FAST') } catch {}
+    if (includeTOC || planned.length) doc.addPage()
   }
 
-  // TOC
+  // Table of contents
   if (includeTOC) {
-    const margin = baseOpt.margin;
-    doc.setFont(baseOpt.lyricFamily, 'bold');
-    doc.setFontSize(24);
-    doc.text('Table of Contents', pageW / 2, margin + 20, { align: 'center' });
-    doc.setFont(baseOpt.lyricFamily, 'normal');
-    doc.setFontSize(12);
-    let y = margin + 40;
-    const lineH = 16;
-    const right = pageW - margin;
-    tocEntries.forEach((e) => {
-      if (y > pageH - margin) { doc.addPage(); y = margin; }
-      const leftText = `${e.num} ${e.title}`;
-      doc.text(leftText, margin, y);
-      const pageStr = String(e.page);
-      const textW = doc.getTextWidth(leftText);
-      const pageWdt = doc.getTextWidth(pageStr);
-      const dotsW = right - margin - textW - pageWdt - 4;
+    doc.setFont(baseOpt.lyricFamily, 'bold'); doc.setFontSize(24)
+    doc.text('Table of Contents', pageW / 2, margin + 20, { align: 'center' })
+    doc.setFont(baseOpt.lyricFamily, 'normal'); doc.setFontSize(12)
+    let y = margin + 40
+    tocEntries.forEach((e, i) => {
+      if (i > 0 && i % linesPerPage === 0) { doc.addPage(); y = margin }
+      const leftText = `${e.num} ${e.title}`
+      doc.text(leftText, margin, y)
+      const pageStr = String(e.page)
+      const right = pageW - margin
+      const textW = doc.getTextWidth(leftText)
+      const pageWdt = doc.getTextWidth(pageStr)
+      const dotsW = right - margin - textW - pageWdt - 4
       if (dotsW > 0) {
-        const dot = doc.getTextWidth('.');
-        const dots = '.'.repeat(Math.max(0, Math.floor(dotsW / dot)));
-        doc.text(dots, margin + textW + 2, y);
+        const dot = doc.getTextWidth('.')
+        const dots = '.'.repeat(Math.max(0, Math.floor(dotsW / dot)))
+        doc.text(dots, margin + textW + 2, y)
       }
-      doc.text(pageStr, right, y, { align: 'right' });
-      y += lineH;
-    });
-    if (planned.length) doc.addPage();
+      doc.text(pageStr, right, y, { align: 'right' })
+      y += lineH
+    })
+    if (planned.length) doc.addPage()
   }
 
   // Songs
   planned.forEach((p, idx) => {
-    drawSongIntoDoc(doc, p.raw, {
-      ...baseOpt,
-      title: `${idx + 1}. ${p.norm.title || 'Untitled'}`,
-      key: p.norm.key || 'C',
-      columns: baseOpt.columns
-    });
-    if (idx < planned.length - 1) doc.addPage();
-  });
+    if (idx > 0) doc.addPage()
+    drawPlannedSong(doc, p.plan, { title: p.title, key: p.key })
+  })
 
-  const name = `songbook-${new Date().toISOString().slice(0,10).replace(/-/g,'')}.pdf`;
-  doc.save(name);
+  doc.setProperties({ title: options?.docTitle || 'GraceChords Setlist' })
+  doc.save(options?.fileName || 'GraceChords_Selection.pdf')
 }
 
+/* -----------------------------------------------------------
+ * Songbook wrapper
+ * --------------------------------------------------------- */
+export async function downloadSongbookPdf(songs, { includeTOC, coverImageDataUrl } = {}) {
+  const numbered = songs.map((s, i) => ({
+    ...s,
+    title: `${i + 1}. ${s.title}`,
+    _songbookNum: i + 1,
+    _origTitle: s.title,
+  }))
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+  await downloadMultiSongPdf(numbered, {
+    includeTOC,
+    coverImageDataUrl,
+    docTitle: 'GraceChords Songbook',
+    fileName: `songbook-${date}.pdf`,
+  })
+}


### PR DESCRIPTION
## Summary
- refactor PDF layout planner and expose chooseBestLayout for auto columns & font fit
- unify single, multi-song, and songbook exports under shared engine with proper metadata
- adjust SongView, Setlist, Songbook, and image exporter to use new planner and titles

## Testing
- `npm test` *(fails: sh: 1: vitest: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689c7e80f00c832795e46a534ffd6db1