### PR TITLE
Fix wiki sync workflow

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -12,8 +12,6 @@ on:
 
 jobs:
   sync:
-    # Skip job entirely if there are no files under public/wiki/**
-    if: ${{ hashFiles('public/wiki/**') != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +19,7 @@ jobs:
         with:
           node-version: '20'
       - name: Sync to GitHub Wiki
+        if: ${{ hashFiles('public/wiki/**') != '' }}
         run: node scripts/syncWiki.mjs
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- move `hashFiles` check to step level to avoid invalid workflow expression

## Testing
- `node node_modules/vitest/vitest.mjs run`


------
https://chatgpt.com/codex/tasks/task_e_689c9fb91aac8327a4a9242c0bcd124f