### PR TITLE
Align Songbook visuals with Setlist; reuse Home card styles

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import Fuse from 'fuse.js'
 import indexData from '../data/index.json'
 import { KEYS } from '../utils/chordpro'
+import SongCard from './ui/SongCard'
 
 export default function Home(){
   const items = indexData?.items || []
@@ -278,26 +279,22 @@ export default function Home(){
         onKeyDown={onResultsKeyDown}
       >
         {!fuse ? <div>Loading search…</div> : (
-          <div className="HomeGrid" role="listbox" aria-label="Song results">
+          <div className="gc-list" role="listbox" aria-label="Song results">
             {results.map((s, i) => (
               <Link
                 key={s.id}
                 to={`/song/${s.id}`}
                 role="option"
-                ref={el => (optionRefs.current[i] = el)}
+                ref={(el) => (optionRefs.current[i] = el)}
                 tabIndex={i === activeIndex ? 0 : -1}
                 aria-selected={i === activeIndex}
-                className={`HomeCard ${i === activeIndex ? 'active' : ''}`}
+                style={{ textDecoration: 'none', display: 'block' }}
               >
-                <div className="row">
-                  <div>
-                    <div style={{ fontWeight: 600 }}>{s.title}</div>
-                    <div className="meta">
-                      {s.originalKey || '—'}
-                      {s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}
-                    </div>
-                  </div>
-                </div>
+                <SongCard
+                  title={s.title}
+                  subtitle={s.originalKey || '—'}
+                  tags={s.tags || []}
+                />
               </Link>
             ))}
           </div>

--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -5,6 +5,7 @@ import indexData from '../data/index.json'
 import { KEYS } from '../utils/chordpro'
 import { ArrowUp, ArrowDown, RemoveIcon, DownloadIcon } from './Icons'
 import { parseChordPro, stepsBetween, transposeSym } from '../utils/chordpro'
+import SongCard from './ui/SongCard'
 import { listSets, getSet, saveSet, deleteSet, duplicateSet } from '../utils/sets'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
@@ -279,41 +280,81 @@ async function exportPdf() {
           <div style={{marginTop:8}}>
             <strong>Add songs</strong>
             <input value={q} onChange={e=> setQ(e.target.value)} placeholder="Search..." style={{display:'block', width:'100%', marginTop:6}} />
-            <div style={{minHeight:0, maxHeight:300, overflow:'auto', marginTop:6}}>
-              {!fuse ? <div>Loading search…</div> : results.map(s=> (
-                <div key={s.id} className="row" style={{padding:'6px 0'}}>
-                  <div style={{flex:1}}>
-                    <div style={{fontWeight:600}}>{s.title}</div>
-                    <div className="meta">{s.originalKey || ''}{s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}</div>
-                  </div>
-                  <button className="btn" onClick={()=> addSong(s)}>Add</button>
-                </div>
-              ))}
-            </div>
+          <div style={{minHeight:0, maxHeight:300, overflow:'auto', marginTop:6}}>
+            {!fuse ? (
+              <div>Loading search…</div>
+            ) : (
+              <div className="gc-list">
+                {results.map((s) => (
+                  <SongCard
+                    key={s.id}
+                    title={s.title}
+                    subtitle={s.originalKey || ''}
+                    tags={s.tags || []}
+                    rightSlot={
+                      <button className="btn" onClick={() => addSong(s)}>
+                        Add
+                      </button>
+                    }
+                  />
+                ))}
+              </div>
+            )}
+          </div>
           </div>
         </div>
 
         <div>
           <strong>Current setlist ({list.length})</strong>
           <div style={{minHeight:0, maxHeight:360, overflow:'auto', marginTop:6}}>
-            {list.map((sel)=>{
-              const s = items.find(it=> it.id===sel.id)
-              if(!s) return null
-              return (
-                <div key={sel.id} className="row" style={{padding:'6px 0'}}>
-                  <div style={{flex:1}}>
-                    <div style={{fontWeight:600}}>{s.title}</div>
-                    <div className="meta">Original: {s.originalKey || '—'}</div>
-                  </div>
-                  <select value={sel.toKey} onChange={e=> changeKey(sel.id, e.target.value)}>
-                    {KEYS.map(k=> <option key={k} value={k}>{k}</option>)}
-                  </select>
-                  <button className="btn" onClick={()=> move(sel.id,'up')} title="Move up"><ArrowUp /></button>
-                  <button className="btn" onClick={()=> move(sel.id,'down')} title="Move down"><ArrowDown /></button>
-                  <button className="btn" onClick={()=> removeSong(sel.id)} title="Remove"><RemoveIcon /></button>
-                </div>
-              )
-            })}
+            <div className="gc-list">
+              {list.map((sel) => {
+                const s = items.find((it) => it.id === sel.id)
+                if (!s) return null
+                return (
+                  <SongCard
+                    key={sel.id}
+                    title={s.title}
+                    subtitle={`Original: ${s.originalKey || '—'}`}
+                    rightSlot={
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <select
+                          value={sel.toKey}
+                          onChange={(e) => changeKey(sel.id, e.target.value)}
+                        >
+                          {KEYS.map((k) => (
+                            <option key={k} value={k}>
+                              {k}
+                            </option>
+                          ))}
+                        </select>
+                        <button
+                          className="btn"
+                          onClick={() => move(sel.id, 'up')}
+                          title="Move up"
+                        >
+                          <ArrowUp />
+                        </button>
+                        <button
+                          className="btn"
+                          onClick={() => move(sel.id, 'down')}
+                          title="Move down"
+                        >
+                          <ArrowDown />
+                        </button>
+                        <button
+                          className="btn"
+                          onClick={() => removeSong(sel.id)}
+                          title="Remove"
+                        >
+                          <RemoveIcon />
+                        </button>
+                      </div>
+                    }
+                  />
+                )
+              })}
+            </div>
           </div>
           <div style={{display:'flex', gap:8, marginTop:8}}>
             <button

--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -5,6 +5,7 @@ import { parseChordPro } from '../utils/chordpro'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
 import Busy from './Busy'
+import SongCard from './ui/SongCard'
 
 // Lazy pdf exporters
 let pdfLibPromise
@@ -266,35 +267,33 @@ export default function Songbook() {
         </header>
 
         <div className="BuilderScroll" role="region" aria-label="Song list">
-          <ul className="BuilderList">
+          <div className="gc-list">
             {filtered.map((s) => {
               const checked = selectedIds.has(s.id)
               const authorsLine = Array.isArray(s.authors)
                 ? s.authors.join(', ')
                 : s.authors || ''
-              const tagLine = Array.isArray(s.tags) ? s.tags.join(', ') : s.tags || ''
+              const tagsArr = Array.isArray(s.tags) ? s.tags : s.tags ? [s.tags] : []
+              const subtitle = `${authorsLine || '—'}${s.country ? ` • ${s.country}` : ''}`
               return (
-                <li key={s.id} className="BuilderRow">
-                  <label className="RowMain">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => toggleOne(s.id, e.target.checked)}
-                      aria-label={`Select ${s.title}`}
-                    />
-                    <div className="RowText">
-                      <div className="RowTitle">{s.title}</div>
-                      <div className="RowMeta">
-                        {authorsLine || '—'}
-                        {tagLine ? ` • ${tagLine}` : ''}
-                        {s.country ? ` • ${s.country}` : ''}
-                      </div>
-                    </div>
-                  </label>
-                </li>
+                <label key={s.id} style={{ display: 'block' }}>
+                  <SongCard
+                    title={s.title}
+                    subtitle={subtitle}
+                    tags={tagsArr}
+                    leftSlot={
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => toggleOne(s.id, e.target.checked)}
+                        aria-label={`Select ${s.title}`}
+                      />
+                    }
+                  />
+                </label>
               )
             })}
-          </ul>
+          </div>
         </div>
       </section>
 

--- a/src/components/ui/SongCard.jsx
+++ b/src/components/ui/SongCard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import '../../styles/cards.css';
+
+export default function SongCard({
+  title,
+  subtitle,
+  tags = [],
+  leftSlot = null,
+  rightSlot = null,
+  onClick,
+}) {
+  const interactive = onClick ? { onClick, role: 'button', tabIndex: 0 } : {};
+  return (
+    <div className="gc-card" {...interactive}>
+      {leftSlot}
+      <div style={{ minWidth: 0 }}>
+        <div className="gc-card__title">{title}</div>
+        {subtitle && <div className="gc-card__meta">{subtitle}</div>}
+        {tags.length > 0 && (
+          <div className="gc-card__meta" style={{ marginTop: 6 }}>
+            {tags.map((t) => (
+              <span key={t} className="gc-card__tag">
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="gc-card__spacer" />
+      {rightSlot}
+    </div>
+  );
+}
+

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,73 @@
+:root {
+  --gc-card-radius: 12px;
+  --gc-card-pad-y: 0.75rem;
+  --gc-card-pad-x: 1rem;
+}
+
+.gc-card {
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--gc-card-radius);
+  padding: var(--gc-card-pad-y) var(--gc-card-pad-x);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  transition: border-color 0.15s ease;
+}
+
+.gc-card:hover {
+  border-color: var(--primary);
+}
+
+.gc-card__title {
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.gc-card__meta {
+  opacity: 0.85;
+  font-size: 0.9rem;
+  margin-top: 0.125rem;
+}
+
+.gc-card__spacer {
+  flex: 1 1 auto;
+}
+
+.gc-card__tag {
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-right: 6px;
+  font-size: 0.8rem;
+}
+
+.gc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .gc-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .gc-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1500px) {
+  .gc-list {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+


### PR DESCRIPTION
## Summary
- add shared SongCard component and card tokens for consistent style
- refactor Home, Setlist, and Songbook to use SongCard for song entries

## Testing
- `npm test` *(fails: sh: 1: vitest: Permission denied)*
- `npm run build` *(fails: sh: 1: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689d211a171083278b37b8511e13c727