### PR TITLE
refactor: unify song card component

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import Fuse from 'fuse.js'
 import indexData from '../data/index.json'
 import { KEYS } from '../utils/chordpro'
+import SongCard from './ui/SongCard'
 
 export default function Home(){
   const items = indexData?.items || []
@@ -280,25 +281,18 @@ export default function Home(){
         {!fuse ? <div>Loading search…</div> : (
           <div className="HomeGrid" role="listbox" aria-label="Song results">
             {results.map((s, i) => (
-              <Link
+              <SongCard
+                as={Link}
                 key={s.id}
                 to={`/song/${s.id}`}
                 role="option"
                 ref={el => (optionRefs.current[i] = el)}
                 tabIndex={i === activeIndex ? 0 : -1}
                 aria-selected={i === activeIndex}
-                className={`HomeCard ${i === activeIndex ? 'active' : ''}`}
-              >
-                <div className="row">
-                  <div>
-                    <div style={{ fontWeight: 600 }}>{s.title}</div>
-                    <div className="meta">
-                      {s.originalKey || '—'}
-                      {s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}
-                    </div>
-                  </div>
-                </div>
-              </Link>
+                className={i === activeIndex ? 'active' : ''}
+                title={s.title}
+                subtitle={`${s.originalKey || '—'}${s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}`}
+              />
             ))}
           </div>
         )}

--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -10,6 +10,7 @@ import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
 import { headOk } from '../utils/headCache'
 import Busy from './Busy'
+import SongCard from './ui/SongCard'
 
 // Lazy pdf exporter
 let pdfLibPromise
@@ -281,13 +282,12 @@ async function exportPdf() {
             <input value={q} onChange={e=> setQ(e.target.value)} placeholder="Search..." style={{display:'block', width:'100%', marginTop:6}} />
             <div style={{minHeight:0, maxHeight:300, overflow:'auto', marginTop:6}}>
               {!fuse ? <div>Loading search…</div> : results.map(s=> (
-                <div key={s.id} className="row" style={{padding:'6px 0'}}>
-                  <div style={{flex:1}}>
-                    <div style={{fontWeight:600}}>{s.title}</div>
-                    <div className="meta">{s.originalKey || ''}{s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}</div>
-                  </div>
-                  <button className="btn" onClick={()=> addSong(s)}>Add</button>
-                </div>
+                <SongCard
+                  key={s.id}
+                  title={s.title}
+                  subtitle={`${s.originalKey || ''}${s.tags?.length ? ` • ${s.tags.join(', ')}` : ''}`}
+                  rightSlot={<button className="btn" onClick={()=> addSong(s)}>Add</button>}
+                />
               ))}
             </div>
           </div>
@@ -300,18 +300,21 @@ async function exportPdf() {
               const s = items.find(it=> it.id===sel.id)
               if(!s) return null
               return (
-                <div key={sel.id} className="row" style={{padding:'6px 0'}}>
-                  <div style={{flex:1}}>
-                    <div style={{fontWeight:600}}>{s.title}</div>
-                    <div className="meta">Original: {s.originalKey || '—'}</div>
-                  </div>
-                  <select value={sel.toKey} onChange={e=> changeKey(sel.id, e.target.value)}>
-                    {KEYS.map(k=> <option key={k} value={k}>{k}</option>)}
-                  </select>
-                  <button className="btn" onClick={()=> move(sel.id,'up')} title="Move up"><ArrowUp /></button>
-                  <button className="btn" onClick={()=> move(sel.id,'down')} title="Move down"><ArrowDown /></button>
-                  <button className="btn" onClick={()=> removeSong(sel.id)} title="Remove"><RemoveIcon /></button>
-                </div>
+                <SongCard
+                  key={sel.id}
+                  title={s.title}
+                  subtitle={`Original: ${s.originalKey || '—'}`}
+                  rightSlot={
+                    <div style={{display:'flex', alignItems:'center', gap:6}}>
+                      <select value={sel.toKey} onChange={e=> changeKey(sel.id, e.target.value)}>
+                        {KEYS.map(k=> <option key={k} value={k}>{k}</option>)}
+                      </select>
+                      <button className="btn" onClick={()=> move(sel.id,'up')} title="Move up"><ArrowUp /></button>
+                      <button className="btn" onClick={()=> move(sel.id,'down')} title="Move down"><ArrowDown /></button>
+                      <button className="btn" onClick={()=> removeSong(sel.id)} title="Remove"><RemoveIcon /></button>
+                    </div>
+                  }
+                />
               )
             })}
           </div>

--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -5,6 +5,7 @@ import { parseChordPro } from '../utils/chordpro'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
 import Busy from './Busy'
+import SongCard from './ui/SongCard'
 
 // Lazy pdf exporters
 let pdfLibPromise
@@ -273,24 +274,23 @@ export default function Songbook() {
                 ? s.authors.join(', ')
                 : s.authors || ''
               const tagLine = Array.isArray(s.tags) ? s.tags.join(', ') : s.tags || ''
+              const meta = `${authorsLine || '—'}${tagLine ? ` • ${tagLine}` : ''}${s.country ? ` • ${s.country}` : ''}`
               return (
-                <li key={s.id} className="BuilderRow">
-                  <label className="RowMain">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => toggleOne(s.id, e.target.checked)}
-                      aria-label={`Select ${s.title}`}
-                    />
-                    <div className="RowText">
-                      <div className="RowTitle">{s.title}</div>
-                      <div className="RowMeta">
-                        {authorsLine || '—'}
-                        {tagLine ? ` • ${tagLine}` : ''}
-                        {s.country ? ` • ${s.country}` : ''}
-                      </div>
-                    </div>
-                  </label>
+                <li key={s.id}>
+                  <SongCard
+                    leftSlot={
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => toggleOne(s.id, e.target.checked)}
+                        onClick={(e) => e.stopPropagation()}
+                        aria-label={`Select ${s.title}`}
+                      />
+                    }
+                    title={s.title}
+                    subtitle={meta}
+                    onClick={() => toggleOne(s.id, !checked)}
+                  />
                 </li>
               )
             })}

--- a/src/components/ui/SongCard.jsx
+++ b/src/components/ui/SongCard.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import '../../styles/cards.css'
+import { Link } from 'react-router-dom'
+
+const SongCard = React.forwardRef(function SongCard({
+  title,
+  subtitle,
+  tags = [],
+  leftSlot,
+  rightSlot,
+  onClick,
+  className = '',
+  as: Component = 'div',
+  to,
+  ...rest
+}, ref) {
+  const Cmp = to ? Link : Component
+  const props = { className: `gc-card ${className}`.trim(), onClick, ref, ...rest }
+  if (to) props.to = to
+  return (
+    <Cmp {...props}>
+      {leftSlot}
+      <div className="gc-card__body">
+        <div className="gc-card__title">{title}</div>
+        {subtitle && <div className="gc-card__meta">{subtitle}</div>}
+        {tags.length > 0 && (
+          <div className="gc-card__tags">
+            {tags.map(t => (
+              <span key={t} className="gc-tag">{t}</span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="gc-card__spacer" />
+      {rightSlot}
+    </Cmp>
+  )
+})
+
+export default SongCard

--- a/src/styles.css
+++ b/src/styles.css
@@ -191,17 +191,6 @@ input,select,textarea{
   content:none !important;
 }
 
-.HomeCard{
-  border:1px solid var(--border, rgba(0,0,0,.12));
-  background: var(--surface, #f5f5f7);
-  border-radius:12px;
-  padding:.75rem 1rem;
-  display:block;
-  text-decoration:none;
-}
-@media (prefers-color-scheme: dark){
-  .HomeCard{ border-color:rgba(255,255,255,.14); background:rgba(255,255,255,.06); }
-}
 
 /* ========== Top nav ========== */
 .topnav{

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,21 @@
+.gc-card{
+  border:1px solid var(--border, rgba(0,0,0,.12));
+  background: var(--surface, #f5f5f7);
+  border-radius:12px;
+  padding:.75rem 1rem;
+  display:flex;
+  align-items:flex-start;
+  gap:0.75rem;
+  text-decoration:none;
+  color: inherit;
+}
+@media (prefers-color-scheme: dark){
+  .gc-card{ border-color:rgba(255,255,255,.14); background:rgba(255,255,255,.06); }
+}
+.gc-card__body{ flex:0 1 auto; min-width:0; }
+.gc-card__title{ font-weight:600; line-height:1.25; }
+.gc-card__meta{ color:var(--muted); font-size:.9rem; margin-top:.125rem; }
+.gc-card__spacer{ flex:1 1 auto; }
+.gc-card__tags{ margin-top:.5rem; display:flex; flex-wrap:wrap; gap:.5rem; }
+.gc-tag{ border:1px solid var(--border, rgba(0,0,0,.12)); padding:2px 8px; border-radius:999px; font-size:.8rem; }
+@media (prefers-color-scheme: dark){ .gc-tag{ border-color:rgba(255,255,255,.14); } }


### PR DESCRIPTION
## Summary
- extract Home song card into reusable `SongCard` component with dedicated styles
- render cards in Home, Setlist, and Songbook via `SongCard` for consistent look
- drop obsolete `HomeCard` styles

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d414f65b4832791195d94cbe86ee4