### PR TITLE
Refactor songbook builder layout

### DIFF
--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -192,10 +192,62 @@ export default function Songbook() {
   return (
     <div className="BuilderPage">
       <Busy busy={busy} />
-      {/* LEFT: Picker */}
+
+      {/* Top row: back/blank + title + blank (mirrors Setlist visual rhythm) */}
+      <div className="TopRow">
+        <div className="TopLeft"></div>
+        <h1 className="TopTitle">Songbook Builder</h1>
+        <div className="TopRight"></div>
+      </div>
+
+      {/* Toolbar spanning both columns */}
+      <div className="card SongbookToolbar">
+        <div className="Row" style={{ gap: '1rem', flexWrap: 'wrap', alignItems: 'center' }}>
+          <div className="Field">
+            <input
+              id="sb-toc"
+              type="checkbox"
+              checked={includeTOC}
+              onChange={(e) => setIncludeTOC(e.target.checked)}
+            />
+            <label htmlFor="sb-toc">Include table of contents</label>
+          </div>
+
+          <div className="Field">
+            <label htmlFor="sb-cover">Cover page (image):</label>
+            <input
+              id="sb-cover"
+              className="CoverInput"
+              type="file"
+              accept="image/*"
+              onChange={onCoverFile}
+            />
+          </div>
+
+          <div className="Field" style={{ marginLeft: 'auto', gap: '.5rem' }}>
+            <button className="btn" onClick={selectAllFiltered} disabled={!filteredCount}>
+              Select all ({filteredCount} filtered)
+            </button>
+            <button className="btn" onClick={clearAll} disabled={!selectedCount}>
+              Clear
+            </button>
+            <button
+              className="btn primary"
+              onClick={handleExport}
+              onMouseEnter={prefetchPdf}
+              onFocus={prefetchPdf}
+              disabled={!selectedEntries.length || busy}
+              title={!selectedEntries.length ? 'Select some songs first' : 'Export PDF'}
+            >
+              {busy ? 'Exporting…' : `Export PDF (${selectedEntries.length})`}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Two-pane region (left: search & list; right: live selection) */}
       <section className="BuilderLeft">
         <header className="BuilderHeader">
-          <h1 style={{ margin: 0 }}>Songbook Builder</h1>
           <div className="Row" style={{ gap: '1rem', alignItems: 'flex-end', flexWrap: 'wrap' }}>
             <div className="Field" style={{ minWidth: 220 }}>
               <label htmlFor="sb-search">Search:</label>
@@ -252,15 +304,6 @@ export default function Songbook() {
                 ))}
               </select>
             </div>
-
-            <div className="Field" style={{ marginLeft: 'auto', gap: '.5rem' }}>
-              <button className="btn" onClick={selectAllFiltered} disabled={!filteredCount}>
-                Select all ({filteredCount} filtered)
-              </button>
-              <button className="btn" onClick={clearAll} disabled={!selectedCount}>
-                Clear
-              </button>
-            </div>
           </div>
 
           <div className="Row Small" style={{ marginTop: '.5rem' }}>
@@ -308,46 +351,8 @@ export default function Songbook() {
         </div>
       </section>
 
-      {/* RIGHT: Preview / Export */}
+      {/* RIGHT: Preview only (toolbar moved above both panes) */}
       <aside className="BuilderRight">
-        <div className="RightSection">
-          <div className="Row" style={{ justifyContent: 'space-between', flexWrap: 'wrap' }}>
-            <div className="Field">
-              <input
-                id="sb-toc"
-                type="checkbox"
-                checked={includeTOC}
-                onChange={(e) => setIncludeTOC(e.target.checked)}
-              />
-              <label htmlFor="sb-toc">Include table of contents</label>
-            </div>
-
-            <div className="Field">
-              <label htmlFor="sb-cover">Cover page (image):</label>
-              <input
-                id="sb-cover"
-                className="CoverInput"
-                type="file"
-                accept="image/*"
-                onChange={onCoverFile}
-              />
-            </div>
-
-            <div className="Field" style={{ marginLeft: 'auto' }}>
-              <button
-                className="btn"
-                onClick={handleExport}
-                onMouseEnter={prefetchPdf}
-                onFocus={prefetchPdf}
-                disabled={!selectedEntries.length || busy}
-                title={!selectedEntries.length ? 'Select some songs first' : 'Export PDF'}
-              >
-                {busy ? 'Exporting…' : `Export PDF (${selectedEntries.length})`}
-              </button>
-            </div>
-          </div>
-        </div>
-
         <div className="RightSection RightScroll" role="region" aria-label="Selected songs">
           <ol className="List" style={{ listStyle: 'decimal inside' }}>
             {selectedEntries.map((s) => (

--- a/src/styles/songbook.css
+++ b/src/styles/songbook.css
@@ -1,14 +1,58 @@
-.gc-scroll {
+/* Page grid matches Setlist feel */
+.BuilderPage {
+  display: grid;
+  grid-template-rows: auto auto 1fr; /* TopRow, Toolbar, Two-panels */
+  gap: 12px;
+}
+
+/* Top title row (mirrors Setlist's centered H1 line) */
+.TopRow {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+}
+.TopTitle {
+  margin: 0;
+}
+
+/* Toolbar spanning both columns */
+.SongbookToolbar {
+  grid-column: 1 / -1;
+}
+
+/* Two-pane region */
+.BuilderLeft,
+.BuilderRight {
+  min-height: 0;
+}
+
+/* Left list scroll area */
+.BuilderScroll.gc-scroll {
   min-height: 0;
   overflow: auto;
 }
 
+/* Right pane scroll area */
+.RightSection.RightScroll {
+  min-height: 0;
+  max-height: 100%;
+  overflow: auto;
+}
+
+/* Two-column card list on wider screens */
 .gc-list {
   display: grid;
   gap: 0.875rem;
   margin: 0;
   padding: 0;
   list-style: none;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 960px) {
+  .gc-list {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 /* Neutralize legacy Builder row styles */
@@ -16,8 +60,18 @@
 .RowMain,
 .RowText,
 .RowTitle,
-.RowMeta {
+.RowMeta,
+.songbook-item,
+.song-row {
   background: transparent !important;
   border: 0 !important;
   padding: 0 !important;
+}
+
+/* Optional: give the right pane a subtle "contracting" background */
+.BuilderRight .RightSection {
+  background: var(--panel-muted, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--gc-card-border, #2a2f3a);
+  border-radius: 10px;
+  padding: 12px;
 }


### PR DESCRIPTION
## Summary
- Rebuild Songbook builder layout to mirror Setlist
- Move export/selection controls into shared toolbar
- Support two-column SongCard list with independent scroll panes

## Testing
- `npm test` *(fails: SongView tests report invalid hook call and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dfa9659b4832792799b29974e2728