### PR TITLE
feat: support ChordPro section directives

### DIFF
--- a/src/utils/chordpro/__tests__/sections.test.ts
+++ b/src/utils/chordpro/__tests__/sections.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { parseChordProOrLegacy } from '../parser';
+
+describe('ChordPro sections — long form + shorthands + legacy', () => {
+  it('parses long-form start/end with labels', () => {
+    const s = `
+{start_of_verse: Verse 1}
+[A]Line 1
+{end_of_verse}
+{start_of_chorus}
+[B]Hook
+{end_of_chorus}
+`;
+    const doc = parseChordProOrLegacy(s);
+    expect(doc.sections.length).toBe(2);
+    expect(doc.sections[0].kind).toBe('verse');
+    expect(doc.sections[0].label).toMatch(/Verse 1/i);
+    expect(doc.sections[1].kind).toBe('chorus');
+    expect(doc.sections[1].label).toMatch(/Chorus/i);
+  });
+
+  it('parses shorthand {soc}/{eoc}, {sov}/{eov}, {sob}/{eob}', () => {
+    const s = `
+{soc}
+[C]Chorus line
+{eoc}
+{sov}
+[D]Verse line
+{eov}
+{sob}
+[E]Bridge line
+{eob}
+`;
+    const doc = parseChordProOrLegacy(s);
+    expect(doc.sections.map(s => s.kind)).toEqual(['chorus','verse','bridge']);
+  });
+
+  it('falls back to legacy plain headers when no directives exist', () => {
+    const s = `
+Verse 2
+[A]one
+Chorus
+[B]two
+`;
+    const doc = parseChordProOrLegacy(s);
+    expect(doc.sections.length).toBe(2);
+    expect(doc.sections[0].label).toMatch(/Verse 2/i);
+    expect(doc.sections[1].label).toMatch(/Chorus/i);
+  });
+
+  it('ignores stray end tags safely and auto-closes last section', () => {
+    const s = `
+{eoc}
+{sov}
+[A]text
+`;
+    const doc = parseChordProOrLegacy(s);
+    expect(doc.sections.length).toBe(1);
+    expect(doc.sections[0].kind).toBe('verse');
+    expect(doc.sections[0].lines.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/chordpro/lexer.ts
+++ b/src/utils/chordpro/lexer.ts
@@ -1,0 +1,14 @@
+export type LexToken =
+  | { type: 'directive'; raw: string }
+  | { type: 'lyrics'; raw: string }
+  | { type: 'blank' };
+
+export function lexChordPro(input: string): LexToken[] {
+  const lines = input.split(/\r?\n/);
+  return lines.map((raw) => {
+    const t = raw.trim();
+    if (t.startsWith('{') && t.endsWith('}')) return { type: 'directive', raw };
+    if (t.length === 0) return { type: 'blank' };
+    return { type: 'lyrics', raw };
+  });
+}

--- a/src/utils/chordpro/parser.ts
+++ b/src/utils/chordpro/parser.ts
@@ -1,0 +1,136 @@
+import { SongDoc, SongSection, SongLine, ChordPlacement } from './types';
+
+const RX_LONG_DIR = /^\{(start_of|end_of)_(verse|chorus|bridge|intro|tag|outro)(?::\s*([^}]+))?\}$/i;
+const RX_SHORT_DIR = /^\{(sov|eov|soc|eoc|sob|eob)\}$/i;
+const SHORT_MAP: Record<string, { start: boolean; kind: string }> = {
+  sov: { start: true,  kind: 'verse' },
+  eov: { start: false, kind: 'verse' },
+  soc: { start: true,  kind: 'chorus' },
+  eoc: { start: false, kind: 'chorus' },
+  sob: { start: true,  kind: 'bridge' },
+  eob: { start: false, kind: 'bridge' },
+};
+
+const RX_PLAIN_HEADER = /^(verse|chorus|bridge|intro|tag|outro)(?:\s+(\d+))?$/i;
+const RX_META = /^\{\s*([^:}]+)\s*:\s*([^}]*)\s*\}$/;
+
+// Inline chord parser
+const RX_CHORD = /\[([^\]]+)\]/g;
+function parseInline(line: string): SongLine {
+  const chords: ChordPlacement[] = [];
+  let plain = '';
+  let last = 0;
+  line.replace(RX_CHORD, (match, sym: string, offset: number) => {
+    plain += line.slice(last, offset);
+    chords.push({ sym, index: plain.length });
+    last = offset + match.length;
+    return match;
+  });
+  plain += line.slice(last);
+  return { lyrics: plain, chords };
+}
+
+function isPlainHeader(line: string) {
+  return RX_PLAIN_HEADER.test(line.trim());
+}
+function normalizePlainHeader(line: string) {
+  const m = RX_PLAIN_HEADER.exec(line.trim());
+  if (!m) return { kind: 'verse', label: '' };
+  const kind = m[1].toLowerCase();
+  const label = m[2] ? `${capitalize(kind)} ${m[2]}` : capitalize(kind);
+  return { kind, label };
+}
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+type Dir = { start: boolean; kind: string; label?: string };
+function parseDirective(raw: string): Dir | null {
+  const t = raw.trim();
+  let m = RX_LONG_DIR.exec(t);
+  if (m) {
+    return {
+      start: m[1].toLowerCase() === 'start_of',
+      kind: m[2].toLowerCase(),
+      label: (m[3] || '').trim() || undefined,
+    };
+  }
+  m = RX_SHORT_DIR.exec(t);
+  if (m) {
+    const map = SHORT_MAP[m[1].toLowerCase()];
+    if (map) return { start: map.start, kind: map.kind };
+  }
+  return null;
+}
+
+export function parseChordProOrLegacy(input: string): SongDoc {
+  const lines = input.split(/\r?\n/);
+
+  // detect start/end directives
+  let hasEnv = false;
+  for (const L of lines) {
+    const t = L.trim();
+    if (RX_LONG_DIR.test(t) || RX_SHORT_DIR.test(t)) { hasEnv = true; break; }
+  }
+
+  const doc: SongDoc = { meta: {}, sections: [] };
+  let cur: SongSection | null = null;
+
+  const openSection = (kind: string, label?: string) => {
+    if (cur) doc.sections.push(cur);
+    const lbl = label || capitalize(kind);
+    cur = { kind, label: lbl, lines: [] };
+  };
+  const closeSection = () => {
+    if (cur) { doc.sections.push(cur); cur = null; }
+  };
+
+  for (const raw of lines) {
+    const t = raw.trim();
+
+    if (t === '') {
+      if (cur) cur.lines.push({ lyrics: '', chords: [] })
+      continue
+    }
+
+    // metadata lines
+    const mMeta = RX_META.exec(t);
+    if (mMeta && !RX_LONG_DIR.test(t) && !RX_SHORT_DIR.test(t)) {
+      const key = mMeta[1].trim().toLowerCase();
+      const val = mMeta[2].trim();
+      if (key === 'title') doc.meta.title = val;
+      else if (key === 'key') doc.meta.key = val;
+      else {
+        if (!doc.meta.meta) doc.meta.meta = {};
+        doc.meta.meta[key] = val;
+      }
+      continue;
+    }
+
+    if (hasEnv) {
+      const dir = parseDirective(t);
+      if (dir) { dir.start ? openSection(dir.kind, dir.label) : closeSection(); continue; }
+      if (t.startsWith('{') && t.endsWith('}')) continue; // unknown directive
+      if (!cur) openSection('verse', 'Verse');
+      cur.lines.push(parseInline(raw));
+      continue;
+    }
+
+    if (isPlainHeader(raw)) {
+      const { kind, label } = normalizePlainHeader(raw);
+      openSection(kind, label);
+      continue;
+    }
+
+    if (t.startsWith('{') && t.endsWith('}')) {
+      // ignore other directives/comments
+      continue;
+    }
+
+    if (!cur) openSection('verse', 'Verse');
+    cur.lines.push(parseInline(raw));
+  }
+
+  if (cur) closeSection();
+  return doc;
+}

--- a/src/utils/chordpro/types.ts
+++ b/src/utils/chordpro/types.ts
@@ -1,0 +1,19 @@
+export type ChordPlacement = { sym: string; index: number };
+export type SongLine = { lyrics: string; chords: ChordPlacement[] };
+
+export type SongSection = {
+  kind: string; // e.g., 'verse', 'chorus'
+  label?: string;
+  lines: SongLine[];
+};
+
+export type SongMeta = {
+  title?: string;
+  key?: string;
+  meta?: Record<string, string>;
+};
+
+export type SongDoc = {
+  meta: SongMeta;
+  sections: SongSection[];
+};

--- a/src/utils/pdf/index.js
+++ b/src/utils/pdf/index.js
@@ -94,7 +94,7 @@ function drawPlannedSong(doc, plan, { title, key }) {
 /* -----------------------------------------------------------
  * Exposed helpers
  * --------------------------------------------------------- */
-export { planSongLayout, chooseBestLayout } from './pdfLayout'
+export { planSongLayout, chooseBestLayout, normalizeSongInput } from './pdfLayout'
 
 export async function chooseBestLayoutAuto(song, baseOpt = {}) {
   const doc = await newPDF()


### PR DESCRIPTION
## Summary
- add SongDoc types, lexer, and parser for ChordPro with section directives and shorthand
- normalize song input via new parser while keeping legacy support
- expose normalizeSongInput from PDF utilities

## Testing
- `npx vitest run src/utils/chordpro/__tests__/sections.test.ts`
- `npx vitest run src/__tests__/pdf.planner.test.js` *(fails: expected 2 columns but got 1)*


------
https://chatgpt.com/codex/tasks/task_e_68a331b4f57883278953cb116b2c2424