### PR TITLE
Refactor PDF planner for section-based layout and hints

### DIFF
--- a/src/utils/pdf/__tests__/planner.hints.test.ts
+++ b/src/utils/pdf/__tests__/planner.hints.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { chooseBestLayoutAuto } from '../../pdf'
+
+const case3 = `
+{start_of_verse: Verse 1}
+[C]a
+[C]b
+{end_of_verse}
+{start_of_verse: Verse 2}
+[C]c
+[C]d
+{end_of_verse}
+{start_of_chorus}
+[C]e
+[C]f
+{end_of_chorus}
+{start_of_verse: Verse 3}
+[C]g
+[C]h
+{end_of_verse}
+`
+
+describe('Planner single-page priorities & hints', () => {
+  it('prefers 2-col single page over spilling to page 2 (Case 3)', async () => {
+    const { plan } = await chooseBestLayoutAuto(case3)
+    expect(plan.layout.pages.length).toBe(1)
+    expect(plan.columns).toBe(2)
+    expect(plan.lyricSizePt).toBeGreaterThanOrEqual(12)
+  })
+
+  it('2-col tiny second column guard prefers 1-col at same size', async () => {
+    const tinyTail = `
+{start_of_verse} [C]aaa {end_of_verse}
+{start_of_verse} [C]bbb {end_of_verse}
+{start_of_verse} [C]ccc {end_of_verse}
+`
+    const { plan } = await chooseBestLayoutAuto(tinyTail)
+    expect(plan.layout.pages.length).toBe(1)
+    expect(plan.columns).toBe(1)
+  })
+})
+

--- a/src/utils/pdf/index.js
+++ b/src/utils/pdf/index.js
@@ -105,7 +105,29 @@ export async function chooseBestLayoutAuto(song, baseOpt = {}) {
     chordFamily: fams.chordFamily || baseOpt.chordFamily || 'Courier',
     ...baseOpt,
   }
-  return planWithDoc(doc, normalizeSongInput(song), o)
+  const pageW = doc.internal.pageSize.getWidth()
+  const pageH = doc.internal.pageSize.getHeight()
+  const fallbackMeasure = (pt) => (text) => (text ? text.length * (pt * 0.6) : 0)
+  const makeLyric = (pt) => (text) => {
+    try {
+      doc.setFont(o.lyricFamily, 'normal')
+      doc.setFontSize(pt)
+      return doc.getTextWidth(text || '')
+    } catch {
+      return fallbackMeasure(pt)(text)
+    }
+  }
+  const makeChord = (pt) => (text) => {
+    try {
+      doc.setFont(o.chordFamily, 'bold')
+      doc.setFontSize(pt)
+      return doc.getTextWidth(text || '')
+    } catch {
+      return fallbackMeasure(pt)(text)
+    }
+  }
+  const norm = normalizeSongInput(song)
+  return chooseBestLayout(norm, { ...o, pageWidth: pageW, pageHeight: pageH }, makeLyric, makeChord)
 }
 
 /* -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize song input into explicit sections
- refactor layout planner to work on whole sections with column guard
- add PDF planner hints tests and jsPDF measurement fallback

## Testing
- `npx vitest run src/utils/pdf/__tests__/planner.hints.test.ts` *(fails: expected 2 columns but got 1)*
- `npm test` *(fails: various module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a339b90bd08327b5dddcf154f14f09