### PR TITLE
feat: add chordpro serializer and admin save options

### DIFF
--- a/src/utils/chordpro/__tests__/serialize.test.ts
+++ b/src/utils/chordpro/__tests__/serialize.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { parseChordProOrLegacy } from '../parser';
+import { serializeChordPro } from '../serialize';
+import type { SongDoc } from '../types';
+
+describe('ChordPro serializer', () => {
+  const sample = `
+Verse 1
+[C]Line one
+[G]Line two
+
+Chorus
+[F]Hook a
+[C]Hook b
+`;
+
+  it('serializes to directives and round-trips back identically (sections/lines/chords)', () => {
+    const doc = parseChordProOrLegacy(sample);
+    doc.meta = {
+      title: 'Sample Song',
+      key: 'C',
+      meta: { country: 'USA', tags: 'hymn, slow', youtube: 'abc123' }
+    };
+
+    const out = serializeChordPro(doc, { useDirectives: true });
+    expect(out).toMatch(/\{title: Sample Song\}/);
+    expect(out).toMatch(/\{key: C\}/);
+    expect(out).toMatch(/\{meta: country USA\}/);
+    expect(out).toMatch(/\{start_of_verse: Verse 1\}/);
+    expect(out).toMatch(/\{end_of_chorus\}/);
+
+    const doc2 = parseChordProOrLegacy(out);
+    expect(doc2.sections.length).toBe(doc.sections.length);
+    for (let i=0;i<doc.sections.length;i++){
+      const a = doc.sections[i], b = doc2.sections[i];
+      expect(b.label).toBe(a.label);
+      expect(b.lines.length).toBe(a.lines.length);
+      for (let j=0;j<a.lines.length;j++){
+        expect(b.lines[j].lyrics).toBe(a.lines[j].lyrics);
+        expect((b.lines[j].chords||[]).length).toBe((a.lines[j].chords||[]).length);
+      }
+    }
+    expect(doc2.meta.meta?.country).toBe('USA');
+    expect(doc2.meta.meta?.youtube).toBe('abc123');
+  });
+
+  it('preserves directive labels on re-parse', () => {
+    const doc: SongDoc = {
+      meta: {},
+      sections: [
+        { kind: 'verse', label: 'Verse 2', lines: [{ lyrics: 'hi', chords: [] }] }
+      ]
+    };
+    const out = serializeChordPro(doc);
+    expect(out).toMatch(/\{start_of_verse: Verse 2\}/);
+    const doc2 = parseChordProOrLegacy(out);
+    expect(doc2.sections[0].label).toBe('Verse 2');
+  });
+
+  it('handles chord collisions at same index', () => {
+    const doc: SongDoc = {
+      meta: {},
+      sections: [
+        { kind: 'verse', label: 'Verse', lines: [
+          { lyrics: '', chords: [
+            { sym: 'G', index: 0 },
+            { sym: 'C', index: 0 },
+            { sym: 'D', index: 0 }
+          ] }
+        ] }
+      ]
+    };
+    const out = serializeChordPro(doc);
+    expect(out).toMatch(/\[G\]\[C\]\[D\]/);
+    const doc2 = parseChordProOrLegacy(out);
+    const line = doc2.sections[0].lines[0];
+    expect(line.chords.map(c => c.sym)).toEqual(['G','C','D']);
+  });
+
+  it('can emit legacy header style if directives disabled', () => {
+    const doc = parseChordProOrLegacy(sample);
+    const out = serializeChordPro(doc, { useDirectives: false, includeMeta: false });
+    expect(out).toMatch(/^Verse 1/m);
+    expect(out).not.toMatch(/\{start_of_/);
+  });
+});

--- a/src/utils/chordpro/parser.ts
+++ b/src/utils/chordpro/parser.ts
@@ -100,7 +100,13 @@ export function parseChordProOrLegacy(input: string): SongDoc {
       const val = mMeta[2].trim();
       if (key === 'title') doc.meta.title = val;
       else if (key === 'key') doc.meta.key = val;
-      else {
+      else if (key === 'meta') {
+        const [mk, ...rest] = val.split(/\s+/);
+        if (mk) {
+          if (!doc.meta.meta) doc.meta.meta = {};
+          doc.meta.meta[mk.toLowerCase()] = rest.join(' ').trim();
+        }
+      } else {
         if (!doc.meta.meta) doc.meta.meta = {};
         doc.meta.meta[key] = val;
       }

--- a/src/utils/chordpro/serialize.ts
+++ b/src/utils/chordpro/serialize.ts
@@ -1,0 +1,75 @@
+import { SongDoc, SongSection, SongLine } from './types';
+
+export type SerializeOpts = {
+  useDirectives?: boolean;      // default true
+  includeMeta?: boolean;        // default true
+};
+
+export function kebab(s: string) {
+  return (s || '')
+    .toLowerCase()
+    .replace(/[^\w]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function cleanLabel(s?: string) {
+  return (s || '').replace(/[{}]/g, '').trim();
+}
+
+// Insert inline chords into a plain lyric line using chord placements.
+function lineWithChords(ln: SongLine): string {
+  if (!ln?.chords?.length) return ln.lyrics || '';
+  const chars = Array.from(ln.lyrics || '');
+  const byIndex = new Map<number, string[]>();
+  for (const c of ln.chords) {
+    const arr = byIndex.get(c.index) || [];
+    arr.push(c.sym);
+    byIndex.set(c.index, arr);
+  }
+  let out = '';
+  for (let i = 0; i <= chars.length; i++) {
+    if (byIndex.has(i)) {
+      const syms = byIndex.get(i)!;
+      out += syms.map(s => `[${s}]`).join('');
+    }
+    if (i < chars.length) out += chars[i];
+  }
+  return out.replace(/[ \t]+$/, '');
+}
+
+function emitSection(sec: SongSection): string {
+  const kind = (sec.kind || 'verse').toLowerCase();
+  const label = cleanLabel(sec.label);
+  const start = `{start_of_${kind}${label ? `: ${label}` : ''}}`;
+  const end = `{end_of_${kind}}`;
+  const body = (sec.lines || []).map(lineWithChords).join('\n');
+  return `${start}\n${body}\n${end}`;
+}
+
+export function serializeChordPro(doc: SongDoc, opts: SerializeOpts = {}): string {
+  const useDirectives = opts.useDirectives !== false;
+  const includeMeta = opts.includeMeta !== false;
+
+  const metaLines: string[] = [];
+  const title = doc?.meta?.title || '';
+  const key = doc?.meta?.key || '';
+  if (title) metaLines.push(`{title: ${cleanLabel(title)}}`);
+  if (key) metaLines.push(`{key: ${cleanLabel(key)}}`);
+
+  const extra = doc?.meta?.meta || {};
+  for (const [k, v] of Object.entries(extra)) {
+    if (!v) continue;
+    metaLines.push(`{meta: ${k} ${String(v).trim()}}`);
+  }
+  const head = includeMeta ? metaLines.join('\n') : '';
+
+  const body = (doc.sections || []).map(sec => {
+    if (useDirectives) return emitSection(sec);
+    const hdr = (sec.label || sec.kind || '').trim() || 'Verse';
+    const lines = (sec.lines || []).map(lineWithChords).join('\n');
+    return `${hdr}\n${lines}`;
+  }).join('\n\n');
+
+  return [head, body].filter(Boolean).join('\n\n').replace(/\r\n/g, '\n');
+}


### PR DESCRIPTION
## Summary
- add ChordPro serializer that writes long-form section directives and meta lines
- wire Admin staging to serialize songs and normalize filenames with toggle for directives
- extend parser to read `{meta: key value}` directives

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a357b2786483278c22b6305c2ba834