### PR TITLE
Improve PDF planner telemetry and single-page layout scoring

### DIFF
--- a/src/utils/pdf/__tests__/planner.fallback.multpage.test.ts
+++ b/src/utils/pdf/__tests__/planner.fallback.multpage.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { chooseBestPlan } from '../pdfLayout';
+
+describe('Planner fallback', () => {
+  it('falls back to multipage at 12pt when nothing fits', () => {
+    const measured = [
+      { id: 1, height: 500 },
+      { id: 2, height: 500 },
+      { id: 3, height: 500 },
+    ];
+    const res = chooseBestPlan({ measuredSections: measured, pageContentHeight: 400 });
+    expect(res.multipage).toBe(true);
+    expect(res.pt).toBe(12);
+  });
+});

--- a/src/utils/pdf/__tests__/planner.holyForever.singlePage.test.ts
+++ b/src/utils/pdf/__tests__/planner.holyForever.singlePage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { chooseBestPlan } from '../../pdfLayout';
+import { chooseBestPlan } from '../pdfLayout';
 
 // Tiny helper: parse fixture into sections separated by ChordPro section blocks.
 function parseSections(chordpro: string) {

--- a/src/utils/pdf/__tests__/planner.tinyTail.guard.test.ts
+++ b/src/utils/pdf/__tests__/planner.tinyTail.guard.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { chooseBestPlan } from '../pdfLayout';
+
+describe('Planner tiny tail guard', () => {
+  it('prefers 1 column when second column would be tiny', () => {
+    const measured = [
+      { id: 1, height: 150 },
+      { id: 2, height: 150 },
+      { id: 3, height: 50 },
+    ];
+    const res = chooseBestPlan({ measuredSections: measured, pageContentHeight: 400 });
+    expect(res.multipage).toBeFalsy();
+    expect(res.cols).toBe(1);
+    expect(res.pt).toBeGreaterThanOrEqual(12);
+  });
+});


### PR DESCRIPTION
## Summary
- instrument PDF planner with optional console traces and debug footer
- refactor column packing and layout scoring to evaluate 1/2‑col candidates across font sizes
- add regression tests for tiny-tail guard and multipage fallback

## Testing
- `npm test` *(fails: Invalid hook call, jsPDF font cmap errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5db53b05083278e8218ff24fee7e1