### PR TITLE
feat: refine pdf planner with telemetry

### DIFF
--- a/src/utils/pdf/__tests__/fixtures/holy_forever.chordpro
+++ b/src/utils/pdf/__tests__/fixtures/holy_forever.chordpro
@@ -1,0 +1,47 @@
+{title: Holy Forever}
+{key: C}
+{authors: Chris Tomlin}
+{country: USA}
+{tags: Slow, Contemporary}
+{youtube: IkHgxKemCRk}
+{mp3: }
+{pptx: }
+
+Verse 1
+A [C]thousand generations
+[F]Falling down in [C]worship
+To [Am]sing the song of [G]ages to the [F]Lamb
+And [C]all who’ve gone before us and
+[F]All who will [C]believe
+Will [Am]sing the song of [G]ages to the [F]Lamb
+
+Pre-Chorus
+Your [F]name is the highest
+Your [G]name is the greatest
+Your [Am]name stands above them [F]all
+All [F]thrones and dominions
+All [G]powers and positions
+Your [Am]name stands above them [Dm]all
+
+Chorus
+And the angels [F]cry, [G]Holy
+All creation [C]cries, [Am]Holy
+You are lifted [Dm]high, [G]Holy
+Holy [C]forever
+
+Hear your people [F]sing, [G]Holy
+To the King of [C]Kings, [Am]Holy
+You will always [Dm]be, [G]Holy
+Holy [C]forever
+
+Verse 2
+[C]If you’ve been forgiven and
+[F]If you’ve been re[C]deemed
+[Am]Sing the song [C]forever to the [F]Lamb
+[C]If you walk in freedom and [F]if you bear His [C]name
+[Am]Sing the song [G]forever to the [F]Lamb
+We’ll [Am]sing the song for[G]ever and [F]amen
+
+Tag
+You will always [Dm]be, Ho[G]ly
+Holy for[C]ever

--- a/src/utils/pdf/__tests__/planner.edgeCases.test.ts
+++ b/src/utils/pdf/__tests__/planner.edgeCases.test.ts
@@ -1,0 +1,28 @@
+import { chooseBestLayout } from '../pdfLayout'
+
+describe('edge cases', () => {
+  const makeMeasureAt = (pt: number) => (text: string) => (text ? text.length * (pt * 0.6) : 0)
+
+  test('tiny tail prefers one column', () => {
+    const song = {
+      meta: { title: 'Tail' },
+      sections: [
+        { label: 'A', lines: Array.from({ length: 25 }, () => ({ lyrics: 'aaaaaaaaaa', chords: [] })) },
+        { label: 'B', lines: [{ lyrics: 'short', chords: [] }] }
+      ]
+    }
+    const { plan } = chooseBestLayout(song as any, {}, makeMeasureAt, makeMeasureAt)
+    expect(plan.columns).toBe(1)
+  })
+
+  test('very long falls back to two pages at 12pt', () => {
+    const sections = Array.from({ length: 20 }, (_, i) => ({
+      label: `S${i}`,
+      lines: Array.from({ length: 20 }, () => ({ lyrics: 'aaaaaaaaaa', chords: [] }))
+    }))
+    const song = { meta: { title: 'Long' }, sections }
+    const { plan } = chooseBestLayout(song as any, {}, makeMeasureAt, makeMeasureAt)
+    expect(plan.lyricSizePt).toBe(12)
+    expect(plan.layout.pages.length).toBe(2)
+  })
+})

--- a/src/utils/pdf/__tests__/planner.holyForever.singlePage.test.ts
+++ b/src/utils/pdf/__tests__/planner.holyForever.singlePage.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs'
+import { normalizeSongInput, chooseBestLayout } from '../pdfLayout'
+
+describe('Holy Forever layout', () => {
+  const makeMeasureAt = (pt: number) => (text: string) => (text ? text.length * (pt * 0.6) : 0)
+  const songText = readFileSync(__dirname + '/fixtures/holy_forever.chordpro', 'utf8')
+  const song = normalizeSongInput(songText)
+
+  test('fits single page two columns without splits', () => {
+    const { plan } = chooseBestLayout(song, {}, makeMeasureAt, makeMeasureAt)
+    expect(plan.layout.pages.length).toBe(1)
+    expect(plan.columns).toBe(2)
+    expect(plan.lyricSizePt).toBeGreaterThanOrEqual(14)
+    expect(plan.lyricSizePt).toBeLessThanOrEqual(15)
+    const headers: string[] = []
+    for (const col of plan.layout.pages[0].columns) {
+      for (const b of col.blocks) {
+        if (b.type === 'section') headers.push(b.header)
+      }
+    }
+    const set = new Set(headers)
+    expect(set.size).toBe(headers.length)
+  })
+})

--- a/src/utils/pdf/index.js
+++ b/src/utils/pdf/index.js
@@ -66,11 +66,7 @@ function drawPlannedSong(doc, plan, { title, key, capo, showCapo = true }) {
         doc.rect(margin + colW + plan.gutter, contentStartY, colW, pageH - margin - contentStartY)
       }
       doc.setFont(lFam, 'normal'); doc.setFontSize(9)
-      doc.text(
-        `Plan: ${plan.columns} col • size ${plan.lyricSizePt}pt • singlePage=${plan.layout.pages.length===1 ? 'yes' : 'no'} • ${plan.lyricFamily}/${plan.chordFamily}`,
-        margin,
-        pageH - (margin * 0.6)
-      )
+      doc.text(plan.debugFooter || '', margin, pageH - (margin * 0.6))
     }
 
     p.columns.forEach((col) => {


### PR DESCRIPTION
## Summary
- add pdf plan telemetry and section-based packing helper
- score layout candidates to prefer balanced single-page plans
- expose debug footer through pdf renderer

## Testing
- `npm test` *(fails: multiple test failures)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f71d736883278c37ba154de01a70