### PR TITLE
Fix service worker registration

### DIFF
--- a/404.html
+++ b/404.html
@@ -26,7 +26,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.register('/sw.js', { type: 'module' });
           navigator.serviceWorker.ready.then(() => {
             document.getElementById('offline-badge').hidden = false;
           });

--- a/docs/404.html
+++ b/docs/404.html
@@ -26,7 +26,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.register('/sw.js', { type: 'module' });
           navigator.serviceWorker.ready.then(() => {
             document.getElementById('offline-badge').hidden = false;
           });

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.register('/sw.js', { type: 'module' });
           navigator.serviceWorker.ready.then(() => {
             document.getElementById('offline-badge').hidden = false;
           });

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,6 +1,8 @@
 // Include the current commit SHA in the cache name so that each deploy
 // invalidates previously cached assets and clients fetch the latest files.
-const CACHE_NAME = `gracechords-${import.meta.env.VITE_COMMIT_SHA || 'dev'}`;
+const CACHE_NAME = `gracechords-${
+  (import.meta.env && import.meta.env.VITE_COMMIT_SHA) || 'dev'
+}`;
 const STATIC_ASSETS = [
   '/',
   '/index.html',

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js');
+          navigator.serviceWorker.register('/sw.js', { type: 'module' });
           navigator.serviceWorker.ready.then(() => {
             document.getElementById('offline-badge').hidden = false;
           });

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,6 +1,8 @@
 // Include the current commit SHA in the cache name so that each deploy
 // invalidates previously cached assets and clients fetch the latest files.
-const CACHE_NAME = `gracechords-${import.meta.env.VITE_COMMIT_SHA || 'dev'}`;
+const CACHE_NAME = `gracechords-${
+  (import.meta.env && import.meta.env.VITE_COMMIT_SHA) || 'dev'
+}`;
 const STATIC_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- register service worker as ES module to support modern syntax
- guard cache name from missing VITE_COMMIT_SHA in service worker

## Testing
- `npm test` *(fails: Invalid hook call etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a86385fc4483279a8b63a5744a9ad5