### PR TITLE
Normalize lyricsBlocks objects

### DIFF
--- a/src/__tests__/normalizeSongInput.lyricsBlocks.test.ts
+++ b/src/__tests__/normalizeSongInput.lyricsBlocks.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeSongInput } from '../utils/pdf/pdfLayout'
+
+describe('normalizeSongInput lyricsBlocks', () => {
+  it('converts lyricsBlocks into sections with lines', () => {
+    const song = {
+      title: 'Test',
+      key: 'C',
+      capo: 2,
+      layoutHints: { requestedColumns: 2 },
+      meta: { tempo: '120bpm' },
+      lyricsBlocks: [
+        {
+          section: 'Verse',
+          lines: [
+            { plain: 'Line 1', chordPositions: [{ index: 0, sym: 'C' }] },
+            { plain: 'Line 2', chordPositions: [], comment: 'Note' },
+          ],
+        },
+      ],
+    }
+
+    const out = normalizeSongInput(song)
+
+    expect(out.title).toBe('Test')
+    expect(out.key).toBe('C')
+    expect(out.capo).toBe(2)
+    expect(out.layoutHints?.requestedColumns).toBe(2)
+    expect(out.tempo).toBe('120bpm')
+    expect(out.sections).toHaveLength(1)
+
+    const sec = out.sections[0]
+    expect(sec.label).toBe('Verse')
+    expect(sec.lines).toHaveLength(2)
+    expect(sec.lines[0]).toEqual({
+      lyrics: 'Line 1',
+      chords: [{ index: 0, sym: 'C' }],
+      comment: undefined,
+    })
+    expect(sec.lines[1]).toEqual({
+      lyrics: 'Line 2',
+      chords: [],
+      comment: 'Note',
+    })
+  })
+})
+

--- a/src/utils/pdf/pdfLayout.js
+++ b/src/utils/pdf/pdfLayout.js
@@ -182,7 +182,21 @@ export function normalizeSongInput(input) {
       return { sections: [], meta: {} };
     }
   }
-  if (typeof input === 'object') return input;
+  if (typeof input === 'object') {
+    if (Array.isArray(input?.lyricsBlocks)) {
+      const { title, key, capo, layoutHints, meta, lyricsBlocks } = input;
+      const sections = lyricsBlocks.map(b => ({
+        label: b.section,
+        lines: (b.lines || []).map(ln => ({
+          lyrics: ln.plain,
+          chords: ln.chordPositions,
+          comment: ln.comment,
+        })),
+      }));
+      return { title, key, capo, layoutHints, ...(meta || {}), sections };
+    }
+    return input;
+  }
   return { sections: [], meta: {} };
 }
 


### PR DESCRIPTION
## Summary
- Normalize songs that include `lyricsBlocks` into section-based structure
- Add unit test verifying `lyricsBlocks` normalization

## Testing
- `node ./node_modules/vitest/vitest.mjs run src/__tests__/normalizeSongInput.lyricsBlocks.test.ts`
- `node ./node_modules/vitest/vitest.mjs run` *(fails: Invalid hook call errors, jsPDF font errors, missing functions)*

------
https://chatgpt.com/codex/tasks/task_e_68a867c0fc788327944bec401239128c