### PR TITLE
Normalize song objects before export

### DIFF
--- a/src/components/Bundle.jsx
+++ b/src/components/Bundle.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import indexData from '../data/index.json'
 import { parseChordPro, stepsBetween, transposeSym, KEYS } from '../utils/chordpro'
+import { normalizeSongInput } from '../utils/pdf/pdfLayout'
 import { showToast } from '../utils/toast'
 
 export default function Bundle(){
@@ -43,7 +44,12 @@ export default function Bundle(){
               chordPositions: (ln.chords||[]).map(c => ({ sym: transposeSym(c.sym, steps), index: c.index }))
             }))
           }))
-          return { title: parsed.meta.title || it.title, key: toKey, lyricsBlocks: blocks }
+          return normalizeSongInput({
+            title: parsed.meta.title || it.title,
+            key: toKey,
+            capo: parsed.meta?.capo,
+            lyricsBlocks: blocks,
+          })
         })()
           .catch(err => {
             console.error(err)

--- a/src/components/Setlist.jsx
+++ b/src/components/Setlist.jsx
@@ -5,6 +5,7 @@ import indexData from '../data/index.json'
 import { KEYS } from '../utils/chordpro'
 import { ArrowUp, ArrowDown, RemoveIcon, DownloadIcon } from './Icons'
 import { parseChordPro, stepsBetween, transposeSym } from '../utils/chordpro'
+import { normalizeSongInput } from '../utils/pdf/pdfLayout'
 import { listSets, getSet, saveSet, deleteSet, duplicateSet } from '../utils/sets'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
@@ -177,11 +178,13 @@ async function exportPdf() {
         }));
 
         const slug = s.filename.replace(/\.chordpro$/i, "");
-        songs.push({
+        const song = normalizeSongInput({
           title: parsed.meta?.title || s.title || slug,
           key: sel.toKey || baseKey,
+          capo: parsed.meta?.capo,
           lyricsBlocks: blocks,
         });
+        songs.push(song);
       } catch (err) {
         console.error(err);
         showToast(`Failed to process ${s.filename}`);

--- a/src/components/SongView.jsx
+++ b/src/components/SongView.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { stepsBetween, transposeSym, KEYS } from '../utils/chordpro'
 import { parseChordProOrLegacy } from '../utils/chordpro/parser'
+import { normalizeSongInput } from '../utils/pdf/pdfLayout'
 import indexData from '../data/index.json'
 import { DownloadIcon, TransposeIcon, MediaIcon, EyeIcon } from './Icons'
 import { fetchTextCached } from '../utils/fetchCache'
@@ -193,7 +194,7 @@ if(!entry){
     </a>
   ) : null
 
-  const buildSong = () => ({
+  const buildSong = () => normalizeSongInput({
     title,
     key: toKey,
     capo: parsed?.meta?.capo,

--- a/src/components/Songbook.jsx
+++ b/src/components/Songbook.jsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from 'react'
 import indexData from '../data/index.json'
 import { parseChordPro } from '../utils/chordpro'
+import { normalizeSongInput } from '../utils/pdf/pdfLayout'
 import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
 import Busy from './Busy'
@@ -132,11 +133,13 @@ export default function Songbook() {
             })),
           }))
           const slug = it.filename.replace(/\.chordpro$/, '')
-          songs.push({
+          const song = normalizeSongInput({
             title: parsed.meta.title || it.title || slug,
             key: parsed.meta.key || parsed.meta.originalkey || it.originalKey || 'C',
+            capo: parsed.meta?.capo,
             lyricsBlocks: blocks,
           })
+          songs.push(song)
         } catch(err) {
           console.error(err)
           showToast(`Failed to process ${it.filename}`)

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -53,7 +53,11 @@ export function renderPlanToCanvas(plan, { pxWidth, pxHeight, dpi = 150 }) {
   return canvas
 }
 
-// High-level helper to download a song as JPEG
+/**
+ * High-level helper to download a song as JPEG.
+ * Song objects should already include `sections` or be processed via
+ * normalizeSongInput before calling this helper.
+ */
 export async function downloadSingleSongJpg(song, options = {}) {
   const dpi = options.dpi || 150
   const widthIn = options.widthInches || 8.5

--- a/src/utils/pdf/index.js
+++ b/src/utils/pdf/index.js
@@ -152,6 +152,10 @@ export async function chooseBestLayoutAuto(song, baseOpt = {}) {
 /* -----------------------------------------------------------
  * Single-song PDF
  * --------------------------------------------------------- */
+/**
+ * Download a single song as a PDF. The `song` object should already include
+ * `sections` or be processed with `normalizeSongInput`.
+ */
 export async function downloadSingleSongPdf(song, options) {
   const doc = await newPDF()
   let fams = {}
@@ -179,6 +183,10 @@ export async function downloadSingleSongPdf(song, options) {
 /* -----------------------------------------------------------
  * Multi-song PDF (setlists / songbooks)
  * --------------------------------------------------------- */
+/**
+ * Download multiple songs as a single PDF. Each song should be normalized via
+ * `normalizeSongInput` beforehand or already contain `sections`.
+ */
 export async function downloadMultiSongPdf(songs, options = {}) {
   const doc = await newPDF()
   let fams = {}
@@ -271,6 +279,10 @@ export async function downloadMultiSongPdf(songs, options = {}) {
 /* -----------------------------------------------------------
  * Songbook wrapper
  * --------------------------------------------------------- */
+/**
+ * Convenience wrapper around `downloadMultiSongPdf` for numbered songbooks.
+ * Songs should already be normalized.
+ */
 export async function downloadSongbookPdf(songs, { includeTOC, coverImageDataUrl } = {}) {
   const numbered = songs.map((s, i) => ({
     ...s,

--- a/src/utils/pdf/pdfLayout.js
+++ b/src/utils/pdf/pdfLayout.js
@@ -165,6 +165,27 @@ function scoreCandidate({ pt, cols, balance, occupancy, hasColumnsHint }) {
 const PDF_TRACE = typeof window !== 'undefined'
   && (() => { try { return localStorage.getItem('pdfPlanTrace') === '1' } catch { return false } })()
 
+/**
+ * Normalize a song representation into the shape expected by PDF/image helpers.
+ *
+ * Normalized shape:
+ * {
+ *   title?: string,
+ *   key?: string,
+ *   capo?: number,
+ *   layoutHints?: { columnBreakAfter?: number[] },
+ *   sections: Array<{
+ *     label?: string,
+ *     lines: Array<{
+ *       lyrics?: string,
+ *       chords?: Array<{ sym: string, index: number }>,
+ *       comment?: string,
+ *     }>
+ *   }>
+ * }
+ *
+ * Legacy objects with `lyricsBlocks` are supported and converted.
+ */
 export function normalizeSongInput(input) {
   if (!input) return { sections: [], meta: {} };
   if (typeof input === 'string') {


### PR DESCRIPTION
## Summary
- Normalize song data in SongView, Setlist, Bundle, and Songbook before PDF/JPG utilities
- Clarify expected normalized shape in docs and helper comments

## Testing
- `npm test` *(fails: expect(element).toHaveFocus, getLayoutMetrics is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a86bd9865c8327982ca641c9042ae9