### PR TITLE
docs: add bundle page and links

### DIFF
--- a/public/wiki/Bundle.md
+++ b/public/wiki/Bundle.md
@@ -1,0 +1,14 @@
+Build a quick PDF bundle from selected songs.
+
+## At a glance
+- Pick songs from the catalog and adjust each key
+- Selections persist in the browser using `localStorage`
+- Export merges songs into a single PDF
+- Use **Clear** to remove stored selections
+
+1. Search or browse for songs and mark them for the bundle.
+2. Open `/bundle` to review your list and choose target keys.
+3. Click **Download PDF** to create a combined chart.
+4. Press **Clear** to delete the bundle selection (clears `localStorage`).
+
+[[Home-Search-and-Filters]] [[PDF-and-Printing]]

--- a/public/wiki/Home.md
+++ b/public/wiki/Home.md
@@ -14,6 +14,7 @@ GraceChords keeps a ChordPro song catalog with fast search, transposable views, 
 - [[Slides-(PPTX)]]
 - [[Setlists]]
 - [[Songbook-Builder]]
+- [[Bundle]]
 - [[ChordPro-Guide]]
 - [[PDF-and-Printing]]
 - [[Index-Building]]

--- a/public/wiki/_Sidebar.md
+++ b/public/wiki/_Sidebar.md
@@ -6,6 +6,7 @@
   - [[Slides-(PPTX)]]
   - [[Setlists]]
   - [[Songbook-Builder]]
+  - [[Bundle]]
   - [[ChordPro-Guide]]
   - [[PDF-and-Printing]]
   - [[Admin-Tool]]


### PR DESCRIPTION
## Summary
- document how to bundle selected songs into a PDF
- link new Bundle page from Home and sidebar

## Testing
- `node node_modules/vitest/vitest.mjs` *(fails: 24 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a86d2ff8808327b90b67af7712afda