### PR TITLE
Add PDF content planning test with sample chordpro fixture

### DIFF
--- a/src/__tests__/fixtures/sample.chordpro
+++ b/src/__tests__/fixtures/sample.chordpro
@@ -1,0 +1,9 @@
+{title:Sample Song}
+{key:C}
+
+[Verse 1]
+This is a [C]line with [G]chords
+Another [Am]line
+
+[Chorus]
+Sing [F]loud with [G]joy

--- a/src/__tests__/pdf.content.test.js
+++ b/src/__tests__/pdf.content.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { parseChordPro } from '../utils/chordpro.js'
+import { chooseBestLayout } from '../utils/pdf/pdfLayout'
+
+// simple text width estimator
+const makeMeasure = pt => text => (text ? text.length * (pt * 0.6) : 0)
+
+describe('PDF layout content', () => {
+  it('plans line blocks with lyrics and chords', () => {
+    const songText = readFileSync(__dirname + '/fixtures/sample.chordpro', 'utf8')
+    const parsed = parseChordPro(songText)
+    const song = {
+      title: parsed.meta.title,
+      key: parsed.meta.key,
+      lyricsBlocks: parsed.blocks.map(b => ({
+        section: b.section,
+        lines: b.lines.map(ln => ({
+          plain: ln.text,
+          chordPositions: ln.chords
+        }))
+      }))
+    }
+
+    const { plan } = chooseBestLayout(song, {}, makeMeasure, makeMeasure)
+    const blocks = plan.layout.pages.flatMap(p => p.columns.flatMap(c => c.blocks))
+    const lineBlock = blocks.find(b => b.type === 'line' && b.chords?.length)
+
+    expect(lineBlock).toBeTruthy()
+    expect(lineBlock.lyrics).toContain('line with')
+    expect(lineBlock.chords[0]).toHaveProperty('sym')
+  })
+})


### PR DESCRIPTION
## Summary
- add a small sample chordpro file for tests
- test PDF planner to ensure line blocks include lyrics and chords

## Testing
- `npx vitest run src/__tests__/pdf.content.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a875fdd8b08327be9b5604e14f365d