### PR TITLE
docs: add offline support wiki page

### DIFF
--- a/public/wiki/Home.md
+++ b/public/wiki/Home.md
@@ -19,5 +19,6 @@ GraceChords keeps a ChordPro song catalog with fast search, transposable views, 
 - [[PDF-and-Printing]]
 - [[Index-Building]]
 - [[Admin-Tool]]
+- [[Offline-Support]]
 - [[Troubleshooting]]
 - [[Contributing]]

--- a/public/wiki/Offline-Support.md
+++ b/public/wiki/Offline-Support.md
@@ -1,0 +1,13 @@
+GraceChords caches key assets for offline use.
+
+## At a glance
+- JS, CSS, fonts, and previously opened songs are stored by a service worker
+- Cached files update when you revisit the site and a new version is available
+- Offline mode excludes features that require network requests
+
+## Troubleshooting
+- Stale assets: hard refresh (Ctrl+Shift+R) to fetch the latest bundle
+- Clear site data via browser settings or DevTools > Application > Clear storage
+- Unregister the service worker if caching problems persist
+
+[[Troubleshooting]]


### PR DESCRIPTION
## Summary
- add Offline-Support wiki page detailing cached assets and update behavior
- link Offline-Support page from wiki home quick links

## Testing
- `npm test` *(fails: 24 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a875f51d3083278e794f418c8c14ba