### PR TITLE
Handle SW cache errors individually

### DIFF
--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,6 @@ const CACHE_NAME = `gracechords-${
 const STATIC_ASSETS = [
   '/',
   '/index.html',
-  '/src/data/index.json',
   '/fonts/NotoSans-Regular.ttf',
   '/fonts/NotoSans-Bold.ttf',
   '/fonts/NotoSans-Italic.ttf',
@@ -17,7 +16,17 @@ const STATIC_ASSETS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.allSettled(STATIC_ASSETS.map((asset) => cache.add(asset))).then(
+        (results) => {
+          results.forEach((result, i) => {
+            if (result.status === 'rejected') {
+              console.error(`Failed to cache ${STATIC_ASSETS[i]}`, result.reason);
+            }
+          });
+        }
+      )
+    )
   );
   self.skipWaiting();
 });

--- a/src/sw.js
+++ b/src/sw.js
@@ -6,7 +6,6 @@ const CACHE_NAME = `gracechords-${
 const STATIC_ASSETS = [
   '/',
   '/index.html',
-  '/src/data/index.json',
   '/fonts/NotoSans-Regular.ttf',
   '/fonts/NotoSans-Bold.ttf',
   '/fonts/NotoSans-Italic.ttf',
@@ -17,7 +16,17 @@ const STATIC_ASSETS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.allSettled(STATIC_ASSETS.map((asset) => cache.add(asset))).then(
+        (results) => {
+          results.forEach((result, i) => {
+            if (result.status === 'rejected') {
+              console.error(`Failed to cache ${STATIC_ASSETS[i]}`, result.reason);
+            }
+          });
+        }
+      )
+    )
   );
   self.skipWaiting();
 });


### PR DESCRIPTION
## Summary
- cache static assets one-by-one with Promise.allSettled so install survives failures
- remove obsolete /src/data/index.json from pre-cache list

## Testing
- `npx vitest run` *(fails: expect(element).toHaveFocus, getLayoutMetrics is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8773fb6ec832796dd722c3b013e37