### PR TITLE
Ensure normalized sections include blocks for PDF planner

### DIFF
--- a/src/__tests__/normalizeSongInput.lyricsBlocks.test.ts
+++ b/src/__tests__/normalizeSongInput.lyricsBlocks.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { normalizeSongInput } from '../utils/pdf/pdfLayout'
 
 describe('normalizeSongInput lyricsBlocks', () => {
-  it('converts lyricsBlocks into sections with lines', () => {
+  it('converts lyricsBlocks into sections with lines and blocks', () => {
     const song = {
       title: 'Test',
       key: 'C',
@@ -32,6 +32,7 @@ describe('normalizeSongInput lyricsBlocks', () => {
     const sec = out.sections[0]
     expect(sec.label).toBe('Verse')
     expect(sec.lines).toHaveLength(2)
+    expect(sec.blocks).toHaveLength(3)
     expect(sec.lines[0]).toEqual({
       lyrics: 'Line 1',
       chords: [{ index: 0, sym: 'C' }],
@@ -42,6 +43,9 @@ describe('normalizeSongInput lyricsBlocks', () => {
       chords: [],
       comment: 'Note',
     })
+    expect(sec.blocks[0]).toEqual({ type: 'section', header: 'Verse' })
+    expect(sec.blocks[1]).toMatchObject({ type: 'line', lyrics: 'Line 1' })
+    expect(sec.blocks[2]).toMatchObject({ type: 'line', comment: 'Note' })
   })
 })
 


### PR DESCRIPTION
## Summary
- Populate both `lines` and `blocks` when normalizing songs so PDF planner receives iterable sections
- Support existing `sections` objects missing block data
- Extend lyricsBlocks test to assert block output

## Testing
- `npm test` *(fails: Cannot read properties of null (reading 'useRef')...)*

------
https://chatgpt.com/codex/tasks/task_e_68a87d3840448327bb7fdfa28ee84a4f