### PR TITLE
fix: avoid caching index html

### DIFF
--- a/docs/sw.js
+++ b/docs/sw.js
@@ -4,8 +4,6 @@ const CACHE_NAME = `gracechords-${
   (import.meta.env && import.meta.env.VITE_COMMIT_SHA) || 'dev'
 }`;
 const STATIC_ASSETS = [
-  '/',
-  '/index.html',
   '/fonts/NotoSans-Regular.ttf',
   '/fonts/NotoSans-Bold.ttf',
   '/fonts/NotoSans-Italic.ttf',

--- a/src/sw.js
+++ b/src/sw.js
@@ -4,8 +4,6 @@ const CACHE_NAME = `gracechords-${
   (import.meta.env && import.meta.env.VITE_COMMIT_SHA) || 'dev'
 }`;
 const STATIC_ASSETS = [
-  '/',
-  '/index.html',
   '/fonts/NotoSans-Regular.ttf',
   '/fonts/NotoSans-Bold.ttf',
   '/fonts/NotoSans-Italic.ttf',


### PR DESCRIPTION
## Summary
- prevent service worker from caching stale index.html that referenced removed bundles
- rebuild service worker output

## Testing
- `node node_modules/vite/bin/vite.js build`
- `npx vitest run` *(fails: expect(element).toHaveFocus(), TypeError: getLayoutMetrics is not a function, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aa8c664798832781a152b23fe998ba