### PR TITLE
Add pdf2 render blob test

### DIFF
--- a/src/utils/pdf2/__tests__/render.spec.js
+++ b/src/utils/pdf2/__tests__/render.spec.js
@@ -1,0 +1,57 @@
+/** @vitest-environment happy-dom */
+
+import { describe, it, expect, vi } from 'vitest';
+import { downloadSingleSongPdf } from '../../pdf/index.js';
+
+describe('pdf2 render', () => {
+  it('produces a non-empty PDF blob', async () => {
+    const song = {
+      title: 'Test Song',
+      lyricsBlocks: [
+        {
+          section: 'Verse 1',
+          lines: [
+            {
+              plain: 'Hello world',
+              chordPositions: [
+                { index: 0, sym: 'C' },
+                { index: 6, sym: 'G' },
+              ],
+            },
+          ],
+        },
+        {
+          section: 'Chorus',
+          lines: [
+            {
+              plain: 'Sing along',
+              chordPositions: [
+                { index: 0, sym: 'F' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blobs = [];
+    const origCreate = global.URL.createObjectURL;
+    const origRevoke = global.URL.revokeObjectURL;
+    global.URL.createObjectURL = vi.fn((blob) => {
+      blobs.push(blob);
+      return 'blob:mock';
+    });
+    global.URL.revokeObjectURL = vi.fn();
+    const clickSpy = vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    await downloadSingleSongPdf(song);
+
+    expect(blobs[0]).toBeInstanceOf(Blob);
+    expect(blobs[0].size).toBeGreaterThan(0);
+
+    clickSpy.mockRestore();
+    global.URL.createObjectURL = origCreate;
+    global.URL.revokeObjectURL = origRevoke;
+  });
+});
+


### PR DESCRIPTION
## Summary
- test pdf2's downloadSingleSongPdf to ensure it creates a non-empty Blob

## Testing
- `npm test src/utils/pdf2/__tests__/render.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac803ed7908327ab53eae2d1c45bb4