### PR TITLE
Ensure explicit .js imports and jsPDF runtime guard

### DIFF
--- a/src/utils/pdf/index.js
+++ b/src/utils/pdf/index.js
@@ -73,6 +73,22 @@ function sectionsFromSong(song) {
 
 export { sectionsFromSong };
 
+function createJsPdfDoc(opts) {
+  const JsPDFCtor = (typeof window !== "undefined" && window.jsPDF) || jsPDF;
+  if (typeof JsPDFCtor !== "function") {
+    throw new Error(
+      'jsPDF is not available (window.jsPDF is undefined). Include it via <script src="https://cdn.jsdelivr.net/npm/jspdf"></script>.'
+    );
+  }
+  try {
+    return new JsPDFCtor(opts);
+  } catch {
+    throw new Error(
+      'Failed to initialize jsPDF. Ensure the jsPDF script is correctly included.'
+    );
+  }
+}
+
 // Registers fonts if available; safe to no-op if your build already embeds Noto.
 function tryRegisterFonts(doc) {
   try {
@@ -99,7 +115,7 @@ export async function downloadSingleSongPdf(song, { lyricSizePt = 16 } = {}) {
   const { plan, fontPt } = await planSong(sections, opts);
   debugWarnFirstPage(plan);
 
-  const doc = new jsPDF({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
+  const doc = createJsPdfDoc({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
   tryRegisterFonts(doc);
   renderSongIntoDoc(doc, song?.title || "Untitled", sections, plan, { ...opts, fontPt });
 
@@ -113,7 +129,7 @@ export async function downloadMultiSongPdf(songs = []) {
   if (!Array.isArray(songs) || songs.length === 0) return;
   const opts = { ...defaultOpts };
 
-  const doc = new jsPDF({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
+  const doc = createJsPdfDoc({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
   tryRegisterFonts(doc);
 
   let firstPage = true;
@@ -139,7 +155,7 @@ export async function downloadSongbookPdf(
   if (!Array.isArray(songs) || songs.length === 0) return;
   const opts = { ...defaultOpts };
 
-  const doc = new jsPDF({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
+  const doc = createJsPdfDoc({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
   tryRegisterFonts(doc);
 
   // Cover page

--- a/src/utils/pdf2/__tests__/holyForever.spec.ts
+++ b/src/utils/pdf2/__tests__/holyForever.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { planLayout } from "../planner";
-import type { Section, PlanOptions } from "../index";
+import { planLayout } from "../planner.js";
+import type { Section, PlanOptions } from "../index.js";
 
 const opts: PlanOptions = {
   ptWindow: [16, 15, 14, 13, 12],

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
+  // Set base to "./" if assets fail on GH Pages
   base: '',
   plugins: [
     react({


### PR DESCRIPTION
## Summary
- enforce `.js` extensions in pdf2 tests
- document Vite base configuration for GH Pages
- add jsPDF availability checks when creating PDF docs

## Testing
- `npm test` *(fails: Invalid hook call errors and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ac93081a6083278cea7aaefc9b9ea1