### PR TITLE
feat: add chord parsing helper with collision handling

### DIFF
--- a/src/__tests__/chords.helper.test.js
+++ b/src/__tests__/chords.helper.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { parseChordLine, resolveChordCollisions } from '../utils/chords.js'
+
+const m = (s = '') => s.length
+
+describe('parseChordLine', () => {
+  it('extracts chords with measured positions', () => {
+    const res = parseChordLine('[G]Hello [D]world', m, m)
+    expect(res.lyrics).toBe('Hello world')
+    expect(res.chords).toEqual([
+      { sym: 'G', x: 0, w: 1 },
+      { sym: 'D', x: 6, w: 1 }
+    ])
+  })
+})
+
+describe('resolveChordCollisions', () => {
+  it('nudges overlapping chords to keep a space gap', () => {
+    const res = parseChordLine('a[G]b[C]c', m, m)
+    const [c1, c2] = res.chords
+    expect(c2.x - (c1.x + c1.w)).toBeGreaterThanOrEqual(1)
+    expect(c1.x).toBe(0)
+    expect(c2.x).toBe(3)
+  })
+
+  it('spreads three stacked chords symmetrically', () => {
+    const chords = [
+      { sym: 'G', x: 0, w: 1 },
+      { sym: 'C', x: 0, w: 1 },
+      { sym: 'D', x: 0, w: 1 }
+    ]
+    resolveChordCollisions(chords, 1)
+    const xs = chords.map(c => c.x)
+    expect(xs).toEqual([-2, 0, 2])
+    expect(chords[1].x - (chords[0].x + chords[0].w)).toBeGreaterThanOrEqual(1)
+    expect(chords[2].x - (chords[1].x + chords[1].w)).toBeGreaterThanOrEqual(1)
+  })
+})
+

--- a/src/utils/chords.js
+++ b/src/utils/chords.js
@@ -1,0 +1,64 @@
+// src/utils/chords.js
+// Helper to parse chord tokens and compute x positions with collision resolution
+
+/**
+ * Parse a lyric line containing [CHORD] tokens.
+ * @param {string} line
+ * @param {(text: string) => number} measureLyric  function returning width of lyric text
+ * @param {(text: string) => number} measureChord  function returning width of chord text
+ * @returns {{ lyrics: string, chords: Array<{ sym: string, x: number, w: number }> }}
+ */
+export function parseChordLine(line = '', measureLyric = s => s.length, measureChord = s => s.length) {
+  const chords = []
+  let lyrics = ''
+  let x = 0
+  const re = /\[([^\]]+)\]/g
+  let last = 0
+  let m
+  while ((m = re.exec(line))) {
+    const before = line.slice(last, m.index)
+    lyrics += before
+    x += measureLyric(before)
+    const sym = m[1]
+    const w = measureChord(sym)
+    chords.push({ sym, x, w })
+    last = m.index + m[0].length
+  }
+  lyrics += line.slice(last)
+  const spaceW = measureLyric(' ')
+  resolveChordCollisions(chords, spaceW)
+  return { lyrics, chords }
+}
+
+/**
+ * Resolve chord collisions by nudging left/right so neighbors stay at least
+ * `spaceWidth` apart.
+ * @param {Array<{x:number,w:number}>} chords
+ * @param {number} spaceWidth  minimum desired gap between chords
+ * @param {number} maxIter
+ * @returns {Array}
+ */
+export function resolveChordCollisions(chords, spaceWidth = 0, maxIter = 10) {
+  if (!Array.isArray(chords) || chords.length < 2) return chords
+  chords.sort((a, b) => a.x - b.x)
+  let changed = true
+  let iter = 0
+  while (changed && iter < maxIter) {
+    changed = false
+    iter++
+    for (let i = 1; i < chords.length; i++) {
+      const prev = chords[i - 1]
+      const cur = chords[i]
+      const gap = cur.x - (prev.x + prev.w)
+      if (gap < spaceWidth) {
+        const shift = Math.ceil((spaceWidth - gap) / 2)
+        prev.x -= shift
+        cur.x += shift
+        changed = true
+      }
+    }
+  }
+  chords.sort((a, b) => a.x - b.x)
+  return chords
+}
+

--- a/src/utils/pdf/measure.js
+++ b/src/utils/pdf/measure.js
@@ -1,4 +1,5 @@
 // src/utils/pdf/measure.js
+import { resolveChordCollisions } from '../chords.js'
 
 // Create a jsPDF text measurer bound to a font family/style
 export function makeMeasure(doc, family, style = 'normal') {
@@ -9,28 +10,5 @@ export function makeMeasure(doc, family, style = 'normal') {
   }
 }
 
-// Resolve chord collisions by nudging left/right up to maxNudge pt
-export function resolveChordCollisions(chords, maxNudge = 3) {
-  if (!Array.isArray(chords) || chords.length < 2) return chords
-  chords.sort((a, b) => a.x - b.x)
-  let changed = true
-  let iter = 0
-  while (changed && iter < 10) {
-    changed = false
-    iter++
-    for (let i = 1; i < chords.length; i++) {
-      const prev = chords[i - 1]
-      const cur = chords[i]
-      if (prev.x + prev.w > cur.x) {
-        const overlap = prev.x + prev.w - cur.x
-        const shift = Math.min(maxNudge, Math.ceil(overlap / 2))
-        prev.x -= shift
-        cur.x += shift
-        changed = true
-      }
-    }
-  }
-  chords.sort((a, b) => a.x - b.x)
-  return chords
-}
+export { resolveChordCollisions }
 

--- a/src/utils/pdf/pdfLayout.js
+++ b/src/utils/pdf/pdfLayout.js
@@ -3,7 +3,7 @@
 // NOTE: Removed import of measureSectionHeight to avoid circular import with ./index.js
 
 import { parseChordPro } from '../chordpro.js';
-import { resolveChordCollisions } from './measure.js';
+import { resolveChordCollisions } from '../chords.js';
 
 const PT_WINDOW = [16, 15, 14, 13, 12];
 


### PR DESCRIPTION
## Summary
- add `chords.js` helper to parse [CHORD] tokens and compute x positions
- ensure adjacent chords maintain at least one-space gap
- add unit tests for chord collision scenarios

## Testing
- `npm test` *(fails: invalid hook call; multiple failing tests)*
- `npx vitest run src/__tests__/chords.helper.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ad2c4e3af08327b99ccd16f56cef4f