### PR TITLE
feat(pdf): add chord/lyric line rendering

### DIFF
--- a/src/utils/pdf/index.js
+++ b/src/utils/pdf/index.js
@@ -117,7 +117,7 @@ export async function downloadSingleSongPdf(song, { lyricSizePt = 16 } = {}) {
 
   const doc = createJsPdfDoc({ unit: "pt", format: [opts.pageSizePt.w, opts.pageSizePt.h] });
   tryRegisterFonts(doc);
-  renderSongIntoDoc(doc, song?.title || "Untitled", sections, plan, { ...opts, fontPt });
+  renderSongIntoDoc(doc, song?.title || "Untitled", sections, plan, { ...opts, fontPt, songKey: song?.key || song?.originalKey });
 
   const blob = doc.output("blob");
   triggerDownload(blob, `${(song?.title || "song").replace(/[\\/:*?"<>|]+/g, "_")}.pdf`);
@@ -140,7 +140,7 @@ export async function downloadMultiSongPdf(songs = []) {
     debugWarnFirstPage(plan);
     if (!firstPage) doc.addPage([opts.pageSizePt.w, opts.pageSizePt.h]);
     firstPage = false;
-    renderSongIntoDoc(doc, song?.title || "Untitled", sections, plan, { ...opts, fontPt });
+    renderSongIntoDoc(doc, song?.title || "Untitled", sections, plan, { ...opts, fontPt, songKey: song?.key || song?.originalKey });
   }
 
   const blob = doc.output("blob");
@@ -241,7 +241,8 @@ export async function downloadSongbookPdf(
     doc.addPage([opts.pageSizePt.w, opts.pageSizePt.h]);
     // decorate header with song number
     const numberedTitle = `${songNo}. ${title}`;
-    renderSongIntoDoc(doc, numberedTitle, sections, plan, { ...opts, fontPt });
+      const song = songs[i];
+      renderSongIntoDoc(doc, numberedTitle, sections, plan, { ...opts, fontPt, songKey: song?.key || song?.originalKey });
   }
 
   // Remove the initial implicit blank first page if jsPDF started with one and we added cover after.

--- a/src/utils/pdf2/renderer.js
+++ b/src/utils/pdf2/renderer.js
@@ -3,9 +3,31 @@
 // the migration period.
 
 const DEBUG = (() => {
-  try { return typeof window !== "undefined" && window.localStorage?.getItem("pdfPlanTrace") === "1"; }
-  catch { return false; }
+  try {
+    return typeof window !== "undefined" && window.localStorage?.getItem("pdfPlanTrace") === "1";
+  } catch {
+    return false;
+  }
 })();
+
+// Convert inline chord tokens like "[C]Hello" into separate chord and lyric lines.
+function parseChordLine(line = "") {
+  const chordRegex = /\[([^\]]+)\]/g;
+  let lyric = "";
+  let chords = "";
+  let idx = 0;
+  let match;
+  while ((match = chordRegex.exec(line)) !== null) {
+    const seg = line.slice(idx, match.index);
+    lyric += seg;
+    chords += " ".repeat(seg.length) + match[1];
+    idx = match.index + match[0].length;
+  }
+  const tail = line.slice(idx);
+  lyric += tail;
+  chords += " ".repeat(tail.length);
+  return { chord: chords.trimEnd(), lyric };
+}
 
 /**
  * Draw a layout plan into a jsPDF document.
@@ -26,22 +48,53 @@ export function renderSongInto(doc, songTitle, sections, plan, opts) {
   const usableW = opts.pageSizePt.w - opts.marginsPt.left - opts.marginsPt.right;
   const twoCols = plan.pages[0]?.columns?.length === 2;
   const colW = twoCols ? (usableW - opts.gutterPt) / 2 : usableW;
-  const firstPageSections = plan.pages?.[0]?.columns?.reduce((n, c) => n + (c.sectionIds?.length || 0), 0) || 0;
+  const firstPageSections =
+    plan.pages?.[0]?.columns?.reduce((n, c) => n + (c.sectionIds?.length || 0), 0) || 0;
 
   // Fonts (assumes you registered Noto; otherwise falls back to default)
-  try { doc.setFont("NotoSans", "normal"); } catch {}
+  try {
+    doc.setFont("NotoSans", "normal");
+  } catch {}
   doc.setFontSize(plan.fontPt || opts.fontPt || 12);
 
   plan.pages.forEach((page, pIdx) => {
-    if (!(doc.getNumberOfPages?.() > 0) || (doc.getCurrentPageInfo?.().pageNumber || 1) === 0) {
+    if (
+      !(doc.getNumberOfPages?.() > 0) ||
+      (doc.getCurrentPageInfo?.().pageNumber || 1) === 0
+    ) {
       // first page already present
     } else {
       doc.addPage([opts.pageSizePt.w, opts.pageSizePt.h]);
     }
 
-    // Header
-    doc.setFontSize(Math.max((plan.fontPt || opts.fontPt || 12) + 2, 12));
-    doc.text(String(songTitle || ""), opts.marginsPt.left, opts.marginsPt.top - 8, { baseline: "bottom" });
+    // Header with title and optional key subtitle
+    const titleAvailW = usableW;
+    let titlePt = 20;
+    doc.setFontSize(titlePt);
+    try {
+      doc.setFont("NotoSans", "bold");
+    } catch {}
+    if (doc.getTextWidth(String(songTitle || "")) > titleAvailW) {
+      titlePt = 18;
+      doc.setFontSize(18);
+    }
+    const titleLines = doc.splitTextToSize(String(songTitle || ""), titleAvailW);
+    const titleY = opts.marginsPt.top - 24;
+    doc.text(titleLines, opts.marginsPt.left, titleY);
+
+    if (opts.songKey) {
+      try {
+        doc.setFont("NotoSans", "italic");
+      } catch {}
+      doc.setFontSize(15);
+      const subY = titleY + titlePt * 1.2;
+      doc.text(`Key of ${opts.songKey}`, opts.marginsPt.left, subY);
+    }
+
+    // Reset font to body
+    try {
+      doc.setFont("NotoSans", "normal");
+    } catch {}
     doc.setFontSize(plan.fontPt || opts.fontPt || 12);
 
     const colX0 = opts.marginsPt.left;
@@ -51,9 +104,12 @@ export function renderSongInto(doc, songTitle, sections, plan, opts) {
       doc.setDrawColor(200);
       doc.setLineWidth(0.5);
       doc.line(colX0, opts.marginsPt.top, colX0, opts.pageSizePt.h - opts.marginsPt.bottom);
-      if (twoCols) doc.line(colX1, opts.marginsPt.top, colX1, opts.pageSizePt.h - opts.marginsPt.bottom);
+      if (twoCols)
+        doc.line(colX1, opts.marginsPt.top, colX1, opts.pageSizePt.h - opts.marginsPt.bottom);
       doc.setDrawColor(0);
     }
+
+    const lineH = (plan.fontPt || opts.fontPt || 12) * 1.25;
 
     const drawCol = (x, col) => {
       let y = opts.marginsPt.top;
@@ -62,13 +118,40 @@ export function renderSongInto(doc, songTitle, sections, plan, opts) {
         doc.text("— empty —", x, y);
         doc.setTextColor(0);
       }
-      for (const id of col.sectionIds) {
+      for (const id of col.sectionIds || []) {
         const s = map.get(id);
         if (!s) continue;
-        const lines = doc.splitTextToSize(s.text || "", colW);
-        doc.text(lines, x, y);
-        const lineH = (plan.fontPt || opts.fontPt || 12) * 1.25;
-        y += lines.length * lineH + (s.postSpacing ?? 0);
+        const rawLines = String(s.text || "").split(/\n/);
+        for (const ln of rawLines) {
+          const m = /^\[([^\]]+)\]$/.exec(ln.trim());
+          if (m) {
+            // Section header
+            try {
+              doc.setFont("NotoSansMono", "normal");
+            } catch {}
+            doc.text(m[1].toUpperCase(), x, y);
+            y += lineH * 1.5; // header line + half-line gap
+            try {
+              doc.setFont("NotoSans", "normal");
+            } catch {}
+            continue;
+          }
+
+          const { chord, lyric } = parseChordLine(ln);
+          if (chord) {
+            try {
+              doc.setFont("NotoSansMono", "bold");
+            } catch {}
+            doc.text(doc.splitTextToSize(chord, colW), x, y);
+            y += lineH;
+          }
+          try {
+            doc.setFont("NotoSans", "normal");
+          } catch {}
+          doc.text(doc.splitTextToSize(lyric, colW), x, y);
+          y += lineH;
+        }
+        y += s.postSpacing ?? 0;
       }
     };
 
@@ -78,9 +161,15 @@ export function renderSongInto(doc, songTitle, sections, plan, opts) {
     if (DEBUG && pIdx === 0) {
       doc.setFontSize(8);
       doc.setTextColor(150);
-      doc.text(`debug: sections on first page = ${firstPageSections}`, opts.marginsPt.left, opts.pageSizePt.h - 4, { baseline: "bottom" });
+      doc.text(
+        `debug: sections on first page = ${firstPageSections}`,
+        opts.marginsPt.left,
+        opts.pageSizePt.h - 4,
+        { baseline: "bottom" }
+      );
       doc.setTextColor(0);
       doc.setFontSize(plan.fontPt || opts.fontPt || 12);
     }
   });
 }
+


### PR DESCRIPTION
## Summary
- render chords above lyrics using monospace bold font
- support section headers and song key subtitle
- allow PDF title shrink and wrap when needed

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68ad30bb65c4832782c8c1b68ac50d33