### PR TITLE
feat: integrate pdf2 songbook features

### DIFF
--- a/src/utils/pdf2/__tests__/render.spec.js
+++ b/src/utils/pdf2/__tests__/render.spec.js
@@ -53,5 +53,40 @@ describe('pdf2 render', () => {
     global.URL.createObjectURL = origCreate;
     global.URL.revokeObjectURL = origRevoke;
   });
+
+  it('handles songs normalized with `sections`', async () => {
+    const song = {
+      title: 'Normalized',
+      sections: [
+        {
+          label: 'Verse',
+          lines: [
+            { lyrics: 'Hello world', chords: [{ index: 0, sym: 'C' }] },
+          ],
+        },
+      ],
+    };
+
+    const blobs = [];
+    const origCreate = global.URL.createObjectURL;
+    const origRevoke = global.URL.revokeObjectURL;
+    global.URL.createObjectURL = vi.fn((blob) => {
+      blobs.push(blob);
+      return 'blob:mock';
+    });
+    global.URL.revokeObjectURL = vi.fn();
+    const clickSpy = vi
+      .spyOn(window.HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    await downloadSingleSongPdf(song);
+
+    expect(blobs[0]).toBeInstanceOf(Blob);
+    expect(blobs[0].size).toBeGreaterThan(0);
+
+    clickSpy.mockRestore();
+    global.URL.createObjectURL = origCreate;
+    global.URL.revokeObjectURL = origRevoke;
+  });
 });
 


### PR DESCRIPTION
## Summary
- delegate PDF facade to pdf2 with lazy legacy fallback
- add multi-song and songbook exports via planSong/renderSongIntoDoc
- support cover images, TOC, and single-title headers in songbooks
- fix blank single-song exports by handling normalized `sections`

## Testing
- `npm test` *(fails: vitest: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3590f65c83278c8c0d4d24912ba7