### PR TITLE
Fix PDF font registration and resilient rendering

### DIFF
--- a/src/utils/pdf2/fonts.js
+++ b/src/utils/pdf2/fonts.js
@@ -26,7 +26,7 @@ async function fetchUrlAsBase64(url) {
   return base64;
 }
 
-function fontFamilyExists(doc, family) {
+export function fontFamilyExists(doc, family) {
   try {
     const list = typeof doc.getFontList === "function" ? doc.getFontList() : null;
     return !!(list && list[family]);
@@ -57,4 +57,11 @@ export async function registerPdfFonts(doc) {
   }
 
   registeredOnce = true;
+
+  try {
+    if (localStorage.getItem("pdfFontTrace") === "1") {
+      const list = doc.getFontList?.() || {};
+      console.log("jsPDF font list:", Object.keys(list));
+    }
+  } catch {}
 }


### PR DESCRIPTION
## Summary
- ensure jsPDF font registration fetches Noto assets once and logs available fonts when `localStorage.pdfFontTrace` is set
- initialize document fonts and text color before rendering songs
- harden renderer: probe metrics, wrap font switches and drawing in fallbacks

## Testing
- `npm test` *(fails: Unable to look up font label for font 'NotoSans', missing planner helpers, and multiple assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f93c14483278817173c634ccf94