### PR TITLE
fix(songview): import panel component

### DIFF
--- a/src/components/SongView.jsx
+++ b/src/components/SongView.jsx
@@ -10,6 +10,7 @@ import { fetchTextCached } from '../utils/fetchCache'
 import { showToast } from '../utils/toast'
 import { headOk, clearHeadCache } from '../utils/headCache'
 import Busy from './Busy'
+import Panel from './ui/Panel'
 
 // Lazy-loaded heavy modules
 let pdfLibPromise


### PR DESCRIPTION
## Summary
- import the Panel component in SongView so the media accordion renders without a runtime reference error

## Testing
- npm test -- --run *(fails: Admin login test expects "Add to drafts" button; Songbook filter test cannot find author label)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9b97c9434832796d6a50c207fa4a3