### PR TITLE
fix: remove duplicate keys in normalizeSong object literal

### DIFF
--- a/src/hooks/useSongs.jsx
+++ b/src/hooks/useSongs.jsx
@@ -92,11 +92,6 @@ function normaliseSong(song) {
     // Translation grouping (not yet wired)
     song_group_id: song.song_group_id || null,
 
-    // GraceTracks integration
-    gracetracks_url: song.gracetracks_url || null,
-    has_stems: song.has_stems || false,
-    stem_slug: song.stem_slug || null,
-
     incomplete: false,
 
     // GraceTracks stem fields


### PR DESCRIPTION
has_stems, stem_slug, and gracetracks_url were defined twice in the
normalizeSong function — the first set used || (which coerces false/0)
and the second used ?? (correct). Removed the first set to silence
the Vite build warnings.

https://claude.ai/code/session_01P9gdAXTEsrN2X3kLaqGgeQ