### PR TITLE
Fix layout flexbox behavior for page headers and containers

### DIFF
--- a/src/components/ui/layout-kit/layout-kit.css
+++ b/src/components/ui/layout-kit/layout-kit.css
@@ -10,7 +10,7 @@
   gap: var(--space-4);
   flex-wrap: wrap;
 }
-.gc-page-header__text{ min-width: 0; }
+.gc-page-header__text{ min-width: 0; flex: 1 1 auto; }
 .gc-page-header__title{
   margin:0;
   font-size: var(--gc-font-title);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -83,7 +83,7 @@ input, select, textarea,
   -webkit-text-fill-color: var(--primary-text) !important;
 }
 
-.container{ padding: var(--space-4); max-width:1200px; margin:0 auto }
+.container{ padding: var(--space-4); width:100%; max-width:1200px; margin:0 auto }
 @media (max-width: 640px){ .container{ padding: var(--space-3); } }
 
 .card{


### PR DESCRIPTION
## Summary
This PR fixes flexbox layout issues in the page header and container components to ensure proper responsive behavior and content wrapping.

## Key Changes
- **Page header text**: Added `flex: 1 1 auto` to `.gc-page-header__text` to allow the text element to grow and shrink appropriately within the flex container, preventing overflow issues
- **Container width**: Added explicit `width: 100%` to `.container` to ensure it respects the max-width constraint while properly filling its parent container on all screen sizes

## Implementation Details
These changes ensure that:
- The page header text element properly participates in flex layout calculations and doesn't cause layout shifts
- The container element explicitly declares its width before applying max-width, improving cross-browser consistency and preventing potential width calculation issues

https://claude.ai/code/session_019LtV2gV1w3RGagPJfkBowq