### PR TITLE
Remove TypeScript type annotations from PDF footer utilities

### DIFF
--- a/src/utils/pdf/footer.js
+++ b/src/utils/pdf/footer.js
@@ -1,6 +1,6 @@
 import { getPdfFooterDisclaimer, isDisclaimerEnabled } from '../../config/disclaimer'
 
-export function drawPdfFooter(doc: any, layout: { left: number; bottom: number; pageWidth: number; pageHeight: number }){
+export function drawPdfFooter(doc, layout){
   if (!isDisclaimerEnabled()) return
   const text = getPdfFooterDisclaimer()
   const fontSize = 8
@@ -13,10 +13,10 @@ export function drawPdfFooter(doc: any, layout: { left: number; bottom: number; 
 }
 
 export function applyFooterToAllPages(
-  doc: any,
-  margins: { left: number; bottom: number },
-  page: { w: number; h: number },
-  opts: { startPage?: number } = {}
+  doc,
+  margins,
+  page,
+  opts = {}
 ){
   if (!isDisclaimerEnabled()) return
   const n = (typeof doc.getNumberOfPages === 'function') ? doc.getNumberOfPages() : 1


### PR DESCRIPTION
## Summary
Removed TypeScript type annotations from the PDF footer utility functions in `src/utils/pdf/footer.js`, simplifying the function signatures while maintaining the same functionality.

## Key Changes
- Removed type annotations from `drawPdfFooter()` function parameters (`doc: any` → `doc`, and removed the `layout` object type definition)
- Removed type annotations from `applyFooterToAllPages()` function parameters:
  - `doc: any` → `doc`
  - `margins: { left: number; bottom: number }` → `margins`
  - `page: { w: number; h: number }` → `page`
  - `opts: { startPage?: number } = {}` → `opts = {}`

## Implementation Details
The changes simplify the function signatures by removing explicit TypeScript type definitions. The default parameter value for `opts` is preserved (`= {}`), ensuring backward compatibility. The core logic and behavior of both functions remain unchanged.

https://claude.ai/code/session_01Q2QJdDrETGtNH84VnvAC7p