### PR TITLE
fix(hooks): memoize useRole.isAtLeast/can to stop dep churn

### DIFF
--- a/src/components/editor/SuggestionReviewPanel.jsx
+++ b/src/components/editor/SuggestionReviewPanel.jsx
@@ -315,7 +315,7 @@ export default function SuggestionReviewPanel({ songId, currentSong, onApproved,
       setSuggestions(data || [])
     }
     setLoading(false)
-  }, [songId])
+  }, [songId, isAtLeast])
 
   useEffect(() => {
     fetchSuggestions()

--- a/src/hooks/useRole.js
+++ b/src/hooks/useRole.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useAuth } from './useAuth'
 
 // Role hierarchy: user < collaborator < editor < admin < owner
@@ -18,19 +19,26 @@ const ACTIONS = {
  * isAtLeast(minRole) — true if current role >= minRole in the hierarchy
  * can(action) — where action is one of:
  *   'suggest' | 'directSave' | 'suggestDeletion' | 'directDelete' | 'review' | 'viewAuditLog' | 'deletePptx'
+ *
+ * Both functions are memoized on `hasMinRole` so consumers can safely list
+ * them in useEffect/useCallback dep arrays without re-running on every render.
  */
 export function useRole() {
   const { role, hasMinRole } = useAuth()
 
-  function isAtLeast(minRole) {
-    return hasMinRole(minRole)
-  }
+  const isAtLeast = useCallback(
+    (minRole) => hasMinRole(minRole),
+    [hasMinRole]
+  )
 
-  function can(action) {
-    const required = ACTIONS[action]
-    if (!required) return false
-    return hasMinRole(required)
-  }
+  const can = useCallback(
+    (action) => {
+      const required = ACTIONS[action]
+      if (!required) return false
+      return hasMinRole(required)
+    },
+    [hasMinRole]
+  )
 
   return { role, isAtLeast, can }
 }


### PR DESCRIPTION
Previously, useRole() returned fresh function instances on every render, which made every consumer that listed isAtLeast/can in a useCallback or useEffect dep array re-run on every parent render. SuggestionReviewPanel and AuditLogPanel each issue Supabase reads from those callbacks, so the churn meant duplicate queries on every keystroke or filter change.

- Wrap isAtLeast and can in useCallback bound to hasMinRole (already stable from useAuth).
- Add isAtLeast to fetchSuggestions's dep array in SuggestionReviewPanel; it was being read inside the callback but omitted from deps, so the closure could capture a stale role check.

AuditLogPanel already lists isAtLeast in its deps; the memoization fix makes that listing stable, so no change is needed there.

Addresses REACT_AUDIT_REPORT.md items #1 and #2 (and unblocks #3).

https://claude.ai/code/session_01WGuUPgsQi8CaVw256H6eN1