### PR TITLE
fix: more React audit follow-ups (#4, #5, #6, #9)

### DIFF
--- a/src/components/song/StarButton.jsx
+++ b/src/components/song/StarButton.jsx
@@ -20,6 +20,11 @@ export default function StarButton({ songId }) {
       setChecking(false)
       return
     }
+    // Rapid navigation between songs can stack in-flight queries; ignore any
+    // response whose deps have already changed to avoid setState-after-unmount
+    // and stale starred-flag flicker.
+    let cancelled = false
+    setChecking(true)
     supabase
       .from('user_starred_songs')
       .select('song_id')
@@ -27,9 +32,11 @@ export default function StarButton({ songId }) {
       .eq('song_id', songId)
       .maybeSingle()
       .then(({ data }) => {
+        if (cancelled) return
         setStarred(!!data)
         setChecking(false)
       })
+    return () => { cancelled = true }
   }, [loading, isLoggedIn, userId, songId])
 
   async function handleClick() {

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -50,6 +50,7 @@ export default function ProfilePage() {
   // Fetch stars + contributor request status
   useEffect(() => {
     if (!session) return
+    let cancelled = false
 
     // Join with songs to get slug, title, key, artist in one query.
     supabase
@@ -58,6 +59,7 @@ export default function ProfilePage() {
       .eq('user_id', session.user.id)
       .order('songs(title)')
       .then(({ data, error }) => {
+        if (cancelled) return
         if (error) console.error('[ProfilePage] Failed to load starred songs:', error)
         setStarredItems(data || [])
         setStarsLoading(false)
@@ -71,10 +73,18 @@ export default function ProfilePage() {
         .eq('user_id', session.user.id)
         .eq('status', 'pending')
         .maybeSingle(),
-    ]).then(([settingsRes, requestRes]) => {
-      setContributorRequestsEnabled(settingsRes.data?.contributor_requests_enabled ?? false)
-      setPendingRequest(!!requestRes.data)
-    })
+    ])
+      .then(([settingsRes, requestRes]) => {
+        if (cancelled) return
+        setContributorRequestsEnabled(settingsRes.data?.contributor_requests_enabled ?? false)
+        setPendingRequest(!!requestRes.data)
+      })
+      .catch(err => {
+        if (cancelled) return
+        console.error('[ProfilePage] Failed to load contributor request status:', err)
+      })
+
+    return () => { cancelled = true }
   }, [session])
 
   async function saveProfile() {

--- a/src/pages/SetlistPage.jsx
+++ b/src/pages/SetlistPage.jsx
@@ -235,7 +235,7 @@ export default function Setlist(){
       })
     }
     setItems(out)
-  }, [catalog.groups, selectedLanguage])
+  }, [catalog, selectedLanguage])
 
   function getSongById(songId){
     if (!songId) return null

--- a/src/pages/WorshipModePage.jsx
+++ b/src/pages/WorshipModePage.jsx
@@ -42,7 +42,7 @@ export default function WorshipMode(){
   const allSongsById = catalog.byId
   const selectedLanguage = useMemo(
     () => resolveInitialSongLanguage(catalog.translationLanguages?.length ? catalog.translationLanguages : catalog.allLanguages),
-    [catalog]
+    [catalog.translationLanguages, catalog.allLanguages]
   )
 
   const [songs, setSongs] = useState([]) // [{ id, title, baseKey, sections, type }]


### PR DESCRIPTION
Four small audit-driven fixes; each touches one effect/memo and is independent.

- StarButton (audit #4): Rapid navigation between songs could stack in-flight Supabase reads, with each .then() racing to set state on a remounted/unmounted component. Add a `cancelled` flag in the cleanup return so a stale response is ignored, and reset `checking` when deps change so the disabled state matches the in-progress query.

- ProfilePage (audit #9): The `Promise.all` for system_settings + contributor_requests was fired without await or `.catch`; a network failure would surface as an unhandled rejection and leave UI flags stale. Add a cancelled flag to both .then() chains and a .catch on Promise.all so failures log instead of escaping.

- WorshipModePage (audit #6): `selectedLanguage` memo depended on the whole `catalog` object, so it recomputed when any unrelated property (e.g. byId) changed. Narrow to the two arrays it actually reads.

- SetlistPage (audit #5): The catalog→items effect depended on `catalog.groups`, which is a derived field. Depend on `catalog` (the source memoized value) so the dependency surface is consistent with the rest of the page and ESLint exhaustive-deps.

https://claude.ai/code/session_01WGuUPgsQi8CaVw256H6eN1