### PR TITLE
Implement stale-while-revalidate caching strategy for useSongs hook

### DIFF
--- a/src/hooks/useSongs.jsx
+++ b/src/hooks/useSongs.jsx
@@ -7,16 +7,20 @@
  *   star_count    — integer, maintained by DB trigger
  *   chordpro_content — full renderable body (metadata directives stripped)
  *
- * The result is module-level cached so subsequent hook calls in the same
- * session do not re-fetch from the network.
+ * Uses a stale-while-revalidate strategy: cached data is served immediately,
+ * but after STALE_MS a background refetch runs and all mounted hook instances
+ * are updated without requiring a hard refresh.
  */
 
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
 
-// Module-level cache so the list is only fetched once per page load.
+const STALE_MS = 5 * 60 * 1000  // revalidate after 5 minutes
+
 let _cache = null
 let _promise = null
+let _cacheTime = 0
+const _listeners = new Set()
 
 async function fetchSongs() {
   if (_promise) return _promise
@@ -33,10 +37,12 @@ async function fetchSongs() {
       if (error) {
         console.error('[useSongs] Failed to load songs from Supabase:', error)
         _promise = null // allow retry
-        return []
+        return _cache || []
       }
       const normalised = (data || []).map(normaliseSong)
       _cache = normalised
+      _cacheTime = Date.now()
+      _listeners.forEach(fn => fn(normalised))
       return normalised
     })
   return _promise
@@ -111,14 +117,24 @@ export function useSongs() {
   const [loading, setLoading] = useState(!_cache)
 
   useEffect(() => {
-    if (_cache) {
-      // Already loaded — nothing to do.
-      return
-    }
-    fetchSongs().then(data => {
-      setSongs(data)
+    _listeners.add(setSongs)
+
+    if (!_cache) {
+      // First load — fetch and clear loading when done.
+      // _listeners will push the data into this component's state.
+      fetchSongs().then(() => setLoading(false))
+    } else {
       setLoading(false)
-    })
+      // Stale-while-revalidate: if cached data is older than STALE_MS,
+      // clear the cached promise so fetchSongs issues a fresh request.
+      // _listeners will push the updated songs to all mounted hook instances.
+      if (Date.now() - _cacheTime > STALE_MS) {
+        _promise = null
+        fetchSongs()
+      }
+    }
+
+    return () => _listeners.delete(setSongs)
   }, [])
 
   return { songs, loading }


### PR DESCRIPTION
## Summary
Refactored the `useSongs` hook to implement a stale-while-revalidate (SWR) caching strategy instead of simple module-level caching. This allows cached data to be served immediately while triggering background refetches after a configurable staleness threshold, keeping all mounted hook instances in sync without hard refreshes.

## Key Changes
- **Added SWR configuration**: Introduced `STALE_MS` constant (5 minutes) to control cache staleness threshold
- **Implemented listener pattern**: Added `_listeners` Set to notify all mounted hook instances when data is updated, replacing the previous single-fetch-per-session model
- **Enhanced cache tracking**: Added `_cacheTime` to track when cache was last updated, enabling staleness checks
- **Improved error handling**: Modified `fetchSongs()` to return cached data on error instead of empty array, providing better resilience
- **Updated hook lifecycle**: 
  - Hook now registers/unregisters itself as a listener on mount/unmount
  - Performs staleness check on mount and triggers background refetch if needed
  - Properly manages loading state for both initial load and stale cache scenarios

## Implementation Details
- The listener pattern ensures all components using `useSongs()` receive updates when background refetches complete
- Cache staleness is checked only on component mount, avoiding unnecessary checks during renders
- Failed fetches gracefully fall back to existing cache rather than clearing data
- The `_promise` variable is cleared on stale cache detection to force a fresh network request

https://claude.ai/code/session_014zV5p5WoWLHQBTQc49hGbi