### PR TITLE
Fix pako dependency resolution and update testing library import

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
 
 // Provide a lightweight fetch mock for tests that hit /src/data/index.json or /public/songs/*.chordpro
 beforeAll(() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -49,6 +49,13 @@ export default defineConfig({
     emptyOutDir: false,
     chunkSizeWarningLimit: 1200
   },
+  optimizeDeps: {
+    // pako v2 dropped its "main" field (only "module" + "exports" remain).
+    // Explicitly including it here ensures vite's esbuild optimizer selects
+    // the CJS entry (exports.require → index.js) rather than falling back to
+    // the ESM "module" field when jszip calls require('pako').
+    include: ['pako'],
+  },
   test: {
     environment: 'happy-dom',
     setupFiles: './src/setupTests.js',


### PR DESCRIPTION
## Summary
This PR addresses two compatibility issues: ensuring proper CommonJS resolution for the pako dependency in Vite's optimization pipeline, and updating the testing library import to use the Vitest-compatible entry point.

## Key Changes
- **vite.config.js**: Added `optimizeDeps.include` configuration for `pako` to explicitly direct Vite's esbuild optimizer to use the CommonJS entry point instead of the ESM module field. This is necessary because pako v2 dropped its "main" field, which could cause issues when jszip calls `require('pako')`.
- **src/setupTests.js**: Updated the testing library import from `@testing-library/jest-dom` to `@testing-library/jest-dom/vitest` to use the correct entry point for Vitest compatibility.

## Implementation Details
The pako optimization ensures that when jszip requires pako as a CommonJS module, Vite's optimizer correctly selects the CJS entry point (via `exports.require → index.js`) rather than falling back to the ESM "module" field, preventing potential module resolution conflicts.

https://claude.ai/code/session_016frd3isE8oXMMyReAG9nbE