### PR TITLE
Replace Fuse.js with custom word-prefix song search

### DIFF
--- a/src/pages/HomeDashboardPage.jsx
+++ b/src/pages/HomeDashboardPage.jsx
@@ -24,6 +24,7 @@ import {
   resolveGroupEntry,
   resolveInitialSongLanguage,
 } from '../utils/songs/songCatalog'
+import { searchSongs } from '../utils/songs/search'
 
 const SITE_URL = 'https://gracechords.com'
 const OG_IMAGE_URL = `${SITE_URL}/favicon.ico`
@@ -48,21 +49,9 @@ export default function HomeDashboard(){
   const trimmed = query.trim()
   const suggestions = useMemo(() => {
     if (!trimmed) return []
-    const q = trimmed.toLowerCase()
-    const scored = []
-    for (const s of items) {
-      const title = (s.title || '').toLowerCase()
-      const altTitles = (s.searchTitles || []).map((t) => String(t).toLowerCase())
-      const tags = (s.tags || []).map(t => String(t).toLowerCase())
-      const authors = (s.authors || []).map(a => String(a).toLowerCase())
-      const haystack = [title, ...altTitles, ...tags, ...authors].join(' ')
-      if (title.includes(q) || haystack.includes(q)) {
-        const starts = title.startsWith(q) ? 1 : 0
-        scored.push({ s, starts })
-      }
-    }
-    scored.sort((a, b) => b.starts - a.starts || a.s.title.localeCompare(b.s.title))
-    return scored.slice(0, MAX_SUGGESTIONS).map(x => x.s)
+    return searchSongs(items, trimmed)
+      .slice(0, MAX_SUGGESTIONS)
+      .map(r => r.item)
   }, [items, trimmed])
 
   useEffect(() => {

--- a/src/pages/SetlistPage.jsx
+++ b/src/pages/SetlistPage.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import { Link, useParams, useNavigate, useLocation } from 'react-router-dom'
-import Fuse from 'fuse.js'
 import { useSongs } from '../hooks/useSongs'
+import { searchSongs } from '../utils/songs/search'
 import { KEYS } from '../utils/chordpro'
 import { ArrowUp, ArrowDown, MinusIcon, DownloadIcon, PlusIcon, SaveIcon, TrashIcon, MediaIcon, LinkIcon, CloudDownloadIcon, SlidersIcon } from '../components/Icons'
 import { stepsBetween, transposeSymPrefer } from '../utils/chordpro'
@@ -406,13 +406,9 @@ export default function Setlist(){
   }, [location.state, items.map(s => s.id).join('|')])
 
   // search
-  const fuse = useMemo(() => new Fuse(items, {
-    keys: ['title', 'tags', 'searchTitles', 'searchTags', 'searchAuthors'],
-    threshold: 0.4
-  }), [items])
   const icpPass = useCallback((s) => !icpOnly || (Array.isArray(s.tags) ? s.tags.includes('ICP') : s.tags === 'ICP'), [icpOnly])
   const results = useMemo(() => {
-    const base = q ? fuse.search(q).map((r) => r.item) : items.slice()
+    const base = q ? searchSongs(items, q).map((r) => r.item) : items.slice()
     const filtered = base.filter(icpPass)
     filtered.sort((a, b) => {
       if (a.hasSelectedLanguage !== b.hasSelectedLanguage) {
@@ -421,7 +417,7 @@ export default function Setlist(){
       return String(a.title || '').localeCompare(String(b.title || ''), undefined, { sensitivity: 'base' })
     })
     return filtered
-  }, [q, fuse, items, icpPass])
+  }, [q, items, icpPass])
 
   // list mutators
   function addSong(s){
@@ -1201,7 +1197,7 @@ async function exportPdf() {
                 </div>
               ) : null}
               <div className={["BuilderScroll", "setlist-scroll", "setlist-list", isStacked ? 'no-pane-scroll' : 'pane-scroll', 'pane--addSongs'].join(' ')}>
-                {!fuse ? (
+                {items.length === 0 ? (
                   <div>Loading search…</div>
                 ) : (
                   <div style={{ display:'grid', gap:'.5rem', gridTemplateColumns:'repeat(auto-fill, minmax(260px, 1fr))', marginTop:6 }}>

--- a/src/pages/SongbookPage.jsx
+++ b/src/pages/SongbookPage.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import Fuse from 'fuse.js'
 import { useSongs } from '../hooks/useSongs'
+import { searchSongs } from '../utils/songs/search'
 import { parseChordProOrLegacy } from '../utils/chordpro/parser'
 import { compareSongsByTitle } from '../utils/songs/sort'
 import { showToast } from '../utils/app/toast'
@@ -74,12 +74,8 @@ export default function Songbook() {
   // Search (match Setlist semantics).
   const [q, setQ] = useState('')
 
-  const fuse = useMemo(() => new Fuse(items, {
-    keys: ['title', 'tags', 'authors', 'searchTitles', 'searchTags', 'searchAuthors'],
-    threshold: 0.4
-  }), [items])
   const results = useMemo(() => {
-    const base = q ? fuse.search(q).map((r) => r.item) : items.slice()
+    const base = q ? searchSongs(items, q).map((r) => r.item) : items.slice()
     base.sort((a, b) => {
       if (a.hasSelectedLanguage !== b.hasSelectedLanguage) {
         return a.hasSelectedLanguage ? -1 : 1
@@ -87,7 +83,7 @@ export default function Songbook() {
       return byTitle(a, b)
     })
     return base
-  }, [items, fuse, q])
+  }, [items, q])
 
   // Selection
   const [selectedIds, setSelectedIds] = useState(() => new Set())

--- a/src/pages/SongsPage.jsx
+++ b/src/pages/SongsPage.jsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigationType, useSearchParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import Fuse from 'fuse.js'
 import { compareSongsByTitle } from '../utils/songs/sort'
+import { searchSongs } from '../utils/songs/search'
 // src/data/index.json is deprecated as a songs source; data now comes from Supabase via useSongs.
 import { useSongs } from '../hooks/useSongs'
 import { Chip, Input, SongCard } from '../components/ui/layout-kit'
@@ -109,20 +109,6 @@ export default function Songs(){
   const [lyricsCache, setLyricsCache] = useState({})
   const fetchingRef = useRef(new Set())
 
-  const fuse = useMemo(() => new Fuse(items, {
-    includeScore: true,
-    threshold: 0.35,
-    ignoreLocation: true,
-    keys: [
-      { name: 'title',        weight: 0.65 },
-      { name: 'searchTitles', weight: 0.6 },
-      { name: 'tags',         weight: 0.25 },
-      { name: 'searchTags',   weight: 0.2 },
-      { name: 'authors',      weight: 0.15 },
-      { name: 'searchAuthors',weight: 0.1 },
-      { name: 'searchText',   weight: 0.05 },
-    ]
-  }), [items])
 
   const selectedTagsKey = selectedTags.join('|')
   const tagPass = useCallback((s) => {
@@ -170,9 +156,9 @@ export default function Songs(){
     let list
 
     if (qLower.length) {
-      const rs = fuse.search(qLower)
+      const rs = searchSongs(items, qLower)
       list = rs.map((r) => {
-        scoreMap.set(r.item.id, r.score ?? 0)
+        scoreMap.set(r.item.id, r.score)
         return r.item
       })
     } else {
@@ -217,7 +203,7 @@ export default function Songs(){
       else fallback.push(item)
     }
     return { translated, fallback }
-  }, [items, fuse, qLower, lyricsOn, lyricsCache, tagPass, icpPass])
+  }, [items, qLower, lyricsOn, lyricsCache, tagPass, icpPass])
 
   const results = useMemo(
     () => [...resultParts.translated, ...resultParts.fallback],

--- a/src/pages/SongsPage.jsx
+++ b/src/pages/SongsPage.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useNavigationType, useSearchParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import Fuse from 'fuse.js'
 import { compareSongsByTitle } from '../utils/songs/sort'
@@ -74,6 +74,10 @@ export default function Songs(){
     }
     return out
   }, [catalog.groups, selectedLanguage, tagMap])
+
+  const navigationType = useNavigationType()
+  const navigationTypeRef = useRef(navigationType)
+  const pendingScrollRef = useRef(null)
 
   const searchRef = useRef(null)
   const resultsRef = useRef(null)
@@ -311,6 +315,24 @@ export default function Songs(){
     } catch {}
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
+
+  useEffect(() => {
+    if (navigationTypeRef.current === 'POP') {
+      const saved = sessionStorage.getItem('songs:scrollY')
+      if (saved) pendingScrollRef.current = Number(saved)
+    }
+    return () => {
+      sessionStorage.setItem('songs:scrollY', String(window.scrollY))
+    }
+  }, [])
+
+  useEffect(() => {
+    if (pendingScrollRef.current !== null && items.length > 0) {
+      const y = pendingScrollRef.current
+      pendingScrollRef.current = null
+      requestAnimationFrame(() => window.scrollTo(0, y))
+    }
+  }, [items])
 
   function toggleTag(key){
     setSelectedTags((prev) => prev.includes(key) ? prev.filter((x) => x!==key) : [...prev, key])

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -414,6 +414,7 @@ select{
   display:grid;
   gap:0.875rem;
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
+  align-content: start;
   margin-top: var(--space-4);
   min-height: 60vh;
 }

--- a/src/utils/songs/search.js
+++ b/src/utils/songs/search.js
@@ -1,0 +1,90 @@
+/**
+ * Word-prefix song search.
+ *
+ * A result is included only when the query (or each of its space-separated
+ * tokens) matches the START of at least one word in a relevant field — never
+ * an arbitrary mid-word position.  This prevents "q" matching "Psalm" or
+ * "tr" matching "Stronger".
+ *
+ * Scoring (lower = better match):
+ *   0   – normalized title starts with the full query
+ *   0.5 – a variant title starts with the full query
+ *   1   – all query tokens are word-prefixes in the title
+ *   1.5 – all query tokens are word-prefixes in a variant title
+ *   2   – any query token is a word-prefix in the title
+ *   2.5 – any query token is a word-prefix in a variant title
+ *   3   – any query token is a prefix of any tag name
+ *   4   – any query token is a word-prefix in any author name
+ *
+ * Returns Array<{item, score}> sorted by score ascending.
+ * Returns [] when query is blank (caller should show all items).
+ */
+
+function norm(str) {
+  return (str || '')
+    .toLowerCase()
+    .replace(/['‘’ʼ]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function wordList(str) {
+  return norm(str).split(' ').filter(Boolean)
+}
+
+function anyWordStartsWith(words, token) {
+  for (let i = 0; i < words.length; i++) {
+    if (words[i].startsWith(token)) return true
+  }
+  return false
+}
+
+function scoreItem(item, q, tokens) {
+  const titleNorm = norm(item.title)
+  const titleWords = wordList(item.title)
+
+  if (titleNorm.startsWith(q)) return 0
+
+  if (tokens.every(t => anyWordStartsWith(titleWords, t))) return 1
+
+  if (tokens.some(t => anyWordStartsWith(titleWords, t))) return 2
+
+  const variantTitles = item.searchTitles || []
+  for (let i = 0; i < variantTitles.length; i++) {
+    const vt = variantTitles[i]
+    const vtNorm = norm(vt)
+    const vtWords = wordList(vt)
+    if (vtNorm.startsWith(q)) return 0.5
+    if (tokens.every(t => anyWordStartsWith(vtWords, t))) return 1.5
+    if (tokens.some(t => anyWordStartsWith(vtWords, t))) return 2.5
+  }
+
+  const allTags = (item.tags || []).concat(item.searchTags || [])
+  for (let i = 0; i < allTags.length; i++) {
+    const tagNorm = norm(allTags[i])
+    if (tokens.some(t => tagNorm.startsWith(t))) return 3
+  }
+
+  const allAuthors = (item.authors || []).concat(item.searchAuthors || [])
+  for (let i = 0; i < allAuthors.length; i++) {
+    const authorWords = wordList(allAuthors[i])
+    if (tokens.some(t => anyWordStartsWith(authorWords, t))) return 4
+  }
+
+  return Infinity
+}
+
+export function searchSongs(items, query) {
+  const q = norm(query)
+  if (!q) return []
+  const tokens = q.split(' ').filter(Boolean)
+
+  const scored = []
+  for (let i = 0; i < items.length; i++) {
+    const score = scoreItem(items[i], q, tokens)
+    if (score < Infinity) scored.push({ item: items[i], score })
+  }
+
+  scored.sort((a, b) => a.score - b.score)
+  return scored
+}


### PR DESCRIPTION
## Summary
Replaces the Fuse.js fuzzy search library with a custom word-prefix search implementation that provides more predictable and relevant results for song searches across the application.

## Key Changes
- **New search module** (`src/utils/songs/search.js`): Implements `searchSongs()` function with word-prefix matching logic
  - Matches query tokens only at word boundaries, preventing partial word matches (e.g., "q" won't match "Psalm")
  - Returns results sorted by relevance with 8-tier scoring system (0-4, with Infinity for non-matches)
  - Normalizes text by lowercasing, removing special characters, and handling apostrophes
  
- **Updated search consumers**: Replaced Fuse.js usage in three pages:
  - `SongsPage.jsx`: Removed Fuse configuration, integrated custom search with score tracking
  - `SetlistPage.jsx`: Simplified search integration, removed Fuse dependency
  - `SongbookPage.jsx`: Replaced Fuse with custom search, maintained existing filtering logic
  - `HomeDashboardPage.jsx`: Simplified suggestion logic using new search function

- **Scroll position restoration** (`SongsPage.jsx`): Added session storage-based scroll restoration on browser back navigation using `useNavigationType()` hook

- **CSS improvement** (`base.css`): Added `align-content: start` to song grid for better layout alignment

## Implementation Details
- Search scoring prioritizes exact title matches (score 0) over variant titles (0.5), then word-prefix matches in titles (1), variant titles (1.5), partial matches (2-2.5), tags (3), and authors (4)
- Maintains backward compatibility with existing song data structure (title, searchTitles, tags, searchTags, authors, searchAuthors)
- Removed Fuse.js dependency entirely from the codebase

https://claude.ai/code/session_01PZQTmD2JX2EPqDPAhkg5pn