### PR TITLE
Remove ICP-only search toggle from Songs and Setlist pages

### DIFF
--- a/public/wiki/Song-Library.md
+++ b/public/wiki/Song-Library.md
@@ -10,8 +10,7 @@ Visit the in-app [Song Library](/songs) to browse, search, and filter all availa
 
 ## Filters
 - Selecting multiple tags uses **ANY** matching—songs appear if they include **any** of the tags you pick.
-- The **ICP only** toggle sticks between visits; its state is saved in your browser's `localStorage` so it persists across reloads on the same device.
-- Song language preference is also saved in `localStorage` (`pref:songLanguage`) and reused in SongView, Setlist, Songbook, Worship Mode, and Home suggestions.
+- Song language preference is saved in `localStorage` (`pref:songLanguage`) and reused in SongView, Setlist, Songbook, Worship Mode, and Home suggestions.
 
 ## Translation behavior
 - Language chips appear only when at least one translation exists in that language.

--- a/src/pages/SetlistPage.jsx
+++ b/src/pages/SetlistPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react'
+import React, { useEffect, useMemo, useState, useRef } from 'react'
 import { Link, useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useSongs } from '../hooks/useSongs'
 import { searchSongs } from '../utils/songs/search'
@@ -140,12 +140,6 @@ export default function Setlist(){
   const [name, setName] = useState('New Setlist')
   const [q, setQ] = useState('')
   const [items, setItems] = useState([])
-  const [icpOnly, setIcpOnly] = useState(() => {
-    try { return localStorage.getItem('pref:icpOnly') === '1' } catch { return false }
-  })
-  useEffect(() => {
-    try { localStorage.setItem('pref:icpOnly', icpOnly ? '1' : '0') } catch {}
-  }, [icpOnly])
   const [list, setList] = useState([])
   const [pptxMap, setPptxMap] = useState({})
   const [pptxProgress, setPptxProgress] = useState('')
@@ -390,11 +384,6 @@ export default function Setlist(){
   }, [isStacked, mobileActionsOpen])
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search || '')
-    if (params.get('icp') === '1') setIcpOnly(true)
-  }, [location.search])
-
-  useEffect(() => {
     if (quickAppliedRef.current) return
     const quick = location.state?.quickAction
     if (!quick) return
@@ -406,18 +395,16 @@ export default function Setlist(){
   }, [location.state, items.map(s => s.id).join('|')])
 
   // search
-  const icpPass = useCallback((s) => !icpOnly || (Array.isArray(s.tags) ? s.tags.includes('ICP') : s.tags === 'ICP'), [icpOnly])
   const results = useMemo(() => {
     const base = q ? searchSongs(items, q).map((r) => r.item) : items.slice()
-    const filtered = base.filter(icpPass)
-    filtered.sort((a, b) => {
+    base.sort((a, b) => {
       if (a.hasSelectedLanguage !== b.hasSelectedLanguage) {
         return a.hasSelectedLanguage ? -1 : 1
       }
       return String(a.title || '').localeCompare(String(b.title || ''), undefined, { sensitivity: 'base' })
     })
-    return filtered
-  }, [q, items, icpPass])
+    return base
+  }, [q, items])
 
   // list mutators
   function addSong(s){
@@ -1170,12 +1157,6 @@ async function exportPdf() {
                 <div className="builder-search-row">
                   <strong style={{ whiteSpace:'nowrap' }}>Add songs</strong>
                   <Input value={q} onChange={e=> setQ(e.target.value)} placeholder="Search..." style={{flex:1, minWidth:0}} />
-                </div>
-                <div className="builder-options-row">
-                  <label className="row" style={{gap:6, alignItems:'center'}}>
-                    <input type="checkbox" checked={icpOnly} onChange={e=> setIcpOnly(e.target.checked)} />
-                    <span className="meta" title="Limit results to songs tagged ICP">ICP only</span>
-                  </label>
                 </div>
               </div>
               {languageChipCodes.length > 0 ? (

--- a/src/pages/SongsPage.jsx
+++ b/src/pages/SongsPage.jsx
@@ -8,7 +8,7 @@ import { useSongs } from '../hooks/useSongs'
 import { Chip, Input, SongCard } from '../components/ui/layout-kit'
 import { publicUrl } from '../utils/network/publicUrl'
 import { isIncompleteSong } from '../utils/songs/songStatus'
-import { buildTagMap, canonicalizeTags, normalizeTagKey, tagLabelFromKey } from '../utils/songs/tags'
+import { buildTagMap, canonicalizeTags, tagLabelFromKey } from '../utils/songs/tags'
 import {
   buildGroupSearchText,
   buildSongCatalog,
@@ -40,7 +40,6 @@ export default function Songs(){
   }, [selectedLanguage])
 
   const tagMap = useMemo(() => buildTagMap(catalog.items), [catalog.items])
-  const ICP_KEY = useMemo(() => normalizeTagKey('ICP'), [])
 
   const items = useMemo(() => {
     const out = []
@@ -100,12 +99,6 @@ export default function Songs(){
 
   const [selectedTags, setSelectedTags] = useState([])
   const [lyricsOn, setLyricsOn] = useState(false)
-  const [icpOnly, setIcpOnly] = useState(() => {
-    try { return localStorage.getItem('pref:icpOnly') === '1' } catch { return false }
-  })
-  useEffect(() => {
-    try { localStorage.setItem('pref:icpOnly', icpOnly ? '1' : '0') } catch {}
-  }, [icpOnly])
 
   const [lyricsCache, setLyricsCache] = useState({})
   const fetchingRef = useRef(new Set())
@@ -117,17 +110,11 @@ export default function Songs(){
     const tags = s.tagKeys || []
     return selectedTags.some((t) => tags.includes(t))
   }, [selectedTags])
-  const icpPass = useCallback((s) => {
-    if (!icpOnly) return true
-    const tags = s.tagKeys || []
-    return tags.includes(ICP_KEY)
-  }, [icpOnly, ICP_KEY])
 
   useEffect(() => {
     if (!lyricsOn || qLower.length === 0) return
     const shouldFetch = items
       .filter(tagPass)
-      .filter(icpPass)
       .filter((s) => !(s.id in lyricsCache) && !fetchingRef.current.has(s.id))
       .slice(0, 200)
     if (!shouldFetch.length) return
@@ -150,7 +137,7 @@ export default function Songs(){
     return () => { cancelled = true }
   // lyricsCache is intentionally omitted: this effect updates it, including it would loop.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lyricsOn, qLower, items, selectedTagsKey, icpOnly, tagPass, icpPass])
+  }, [lyricsOn, qLower, items, selectedTagsKey, tagPass])
 
   const resultParts = useMemo(() => {
     const scoreMap = new Map()
@@ -166,12 +153,11 @@ export default function Songs(){
       list = items.slice()
     }
 
-    list = list.filter(tagPass).filter(icpPass)
+    list = list.filter(tagPass)
 
     if (lyricsOn && qLower.length) {
       const extra = items
         .filter(tagPass)
-        .filter(icpPass)
         .filter((s) => {
           const txt = lyricsCache[s.id]
           return typeof txt === 'string' ? txt.includes(qLower) : false
@@ -204,7 +190,7 @@ export default function Songs(){
       else fallback.push(item)
     }
     return { translated, fallback }
-  }, [items, qLower, lyricsOn, lyricsCache, tagPass, icpPass])
+  }, [items, qLower, lyricsOn, lyricsCache, tagPass])
 
   const results = useMemo(
     () => [...resultParts.translated, ...resultParts.fallback],
@@ -392,14 +378,6 @@ export default function Songs(){
                 onChange={(e)=> setLyricsOn(e.target.checked)}
               />
               <span className="meta" title="Search within song texts (fetched on demand)">Lyrics contain</span>
-            </label>
-            <label className="row" style={{gap:8, alignItems:'center'}}>
-              <input
-                type="checkbox"
-                checked={icpOnly}
-                onChange={(e)=> setIcpOnly(e.target.checked)}
-              />
-              <span className="meta" title="Limit results to songs tagged ICP">ICP only</span>
             </label>
           </div>
 


### PR DESCRIPTION
Removes the "ICP only" filter checkbox, its localStorage persistence
(`pref:icpOnly`), and the `?icp=1` URL param wiring on the Setlist page.
The remaining ICP/InterCP International references (SongView SEO/badge,
Songbook quick-pick tag, tag acronym handling) are kept for now and will
be removed in subsequent passes.

https://claude.ai/code/session_01GX9pE8CMfkreHic8jc8oqo