### PR TITLE
Redesign setlist & teams schema with RLS and limit enforcement

### DIFF
--- a/supabase/migrations/20240001_create_user_starred_songs.sql
+++ b/supabase/migrations/20240001_create_user_starred_songs.sql
@@ -1,0 +1,55 @@
+-- Creates the user_starred_songs table with song_id as plain TEXT (no FK to a songs table).
+-- Songs are served from static files in this app; there is no songs DB table.
+-- Using TEXT for song_id stores the slug (e.g. "10-000-reasons") directly.
+
+create table if not exists public.user_starred_songs (
+  user_id    uuid        not null references auth.users(id) on delete cascade,
+  song_id    text        not null,
+  created_at timestamptz not null default now(),
+  primary key (user_id, song_id)
+);
+
+-- Enable row-level security so users can only access their own stars.
+alter table public.user_starred_songs enable row level security;
+
+-- Users can read their own stars.
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename  = 'user_starred_songs'
+      and policyname = 'users can view own stars'
+  ) then
+    create policy "users can view own stars"
+      on public.user_starred_songs for select
+      using (auth.uid() = user_id);
+  end if;
+end $$;
+
+-- Users can insert their own stars.
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename  = 'user_starred_songs'
+      and policyname = 'users can insert own stars'
+  ) then
+    create policy "users can insert own stars"
+      on public.user_starred_songs for insert
+      with check (auth.uid() = user_id);
+  end if;
+end $$;
+
+-- Users can delete their own stars.
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename  = 'user_starred_songs'
+      and policyname = 'users can delete own stars'
+  ) then
+    create policy "users can delete own stars"
+      on public.user_starred_songs for delete
+      using (auth.uid() = user_id);
+  end if;
+end $$;

--- a/supabase/migrations/20240002_fix_starred_songs_fk.sql
+++ b/supabase/migrations/20240002_fix_starred_songs_fk.sql
@@ -1,0 +1,27 @@
+-- Drops any foreign-key constraint from user_starred_songs.song_id to a songs table.
+-- The app serves songs from static files; song_id is a plain text slug, not a DB foreign key.
+-- This migration is idempotent: it does nothing if no such constraint exists.
+
+do $$
+declare
+  _constraint text;
+begin
+  select conname into _constraint
+  from pg_constraint
+  where conrelid = 'public.user_starred_songs'::regclass
+    and contype  = 'f'
+    and conkey   = array[
+      (select attnum
+       from   pg_attribute
+       where  attrelid = 'public.user_starred_songs'::regclass
+         and  attname  = 'song_id')
+    ];
+
+  if _constraint is not null then
+    execute format('alter table public.user_starred_songs drop constraint %I', _constraint);
+    raise notice 'Dropped FK constraint % from user_starred_songs.song_id', _constraint;
+  else
+    raise notice 'No FK constraint found on user_starred_songs.song_id — nothing to drop';
+  end if;
+end;
+$$;

--- a/supabase/migrations/20240003_add_delete_user_function.sql
+++ b/supabase/migrations/20240003_add_delete_user_function.sql
@@ -1,0 +1,23 @@
+-- Function to delete the currently authenticated user and all their data.
+-- Uses SECURITY DEFINER so it can delete from auth.users.
+-- Cascades handle public.users and user_starred_songs automatically.
+create or replace function public.delete_user()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Explicit delete for tables without CASCADE from auth.users
+  delete from public.contributor_requests where user_id = auth.uid();
+
+  -- Deleting from auth.users cascades to:
+  --   public.users (via FK references auth.users(id) on delete cascade)
+  --   public.user_starred_songs (via FK references auth.users(id) on delete cascade)
+  delete from auth.users where id = auth.uid();
+end;
+$$;
+
+-- Restrict execution to authenticated users only
+revoke all on function public.delete_user() from public;
+grant execute on function public.delete_user() to authenticated;

--- a/supabase/migrations/20260305_songs_migration.sql
+++ b/supabase/migrations/20260305_songs_migration.sql
@@ -1,0 +1,174 @@
+-- =============================================================================
+-- GraceChords: Songs DB migration (2026-03-05)
+-- Creates the songs table, wires up user_starred_songs as a UUID FK,
+-- adds RLS policies, and installs a star_count maintenance trigger.
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. SONGS TABLE
+-- ---------------------------------------------------------------------------
+-- Uses CREATE TABLE IF NOT EXISTS so it is safe to run even if the table was
+-- created manually in the Supabase dashboard.
+
+create table if not exists public.songs (
+  id               uuid        primary key default gen_random_uuid(),
+  slug             text        unique not null,   -- URL-safe id, e.g. "10-000-reasons"
+  title            text        not null,
+  artist           text,                          -- comma-separated string
+  default_key      text,
+  tags             text[]      not null default '{}',
+  country          text,
+  youtube_id       text,                          -- bare video ID, not a full URL
+  source_filename  text,                          -- original .chordpro filename stem (e.g. "all_thats_within_me")
+  chordpro_content text,
+  star_count       integer     not null default 0,
+  song_group_id    uuid,                          -- set manually when translation pairs are linked
+  pptx_url         text,
+  mp3_url          text,
+  tempo            integer,
+  time_signature   text,
+  is_deleted       boolean     not null default false,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+-- 1a. Columns that may already exist if the table was created earlier
+--     (also covers the case where songs was created manually without some columns)
+alter table public.songs add column if not exists slug             text;
+alter table public.songs add column if not exists artist           text;
+alter table public.songs add column if not exists default_key      text;
+alter table public.songs add column if not exists tags             text[] not null default '{}';
+alter table public.songs add column if not exists country          text;
+alter table public.songs add column if not exists youtube_id       text;
+alter table public.songs add column if not exists source_filename  text;
+alter table public.songs add column if not exists chordpro_content text;
+alter table public.songs add column if not exists star_count       integer not null default 0;
+alter table public.songs add column if not exists song_group_id    uuid;
+alter table public.songs add column if not exists pptx_url         text;
+alter table public.songs add column if not exists mp3_url          text;
+alter table public.songs add column if not exists tempo            integer;
+alter table public.songs add column if not exists time_signature   text;
+alter table public.songs add column if not exists is_deleted       boolean not null default false;
+alter table public.songs add column if not exists created_at       timestamptz not null default now();
+alter table public.songs add column if not exists updated_at       timestamptz not null default now();
+
+-- 1b. Indexes
+-- Ensure slug has a unique index (required for upsert onConflict: 'slug').
+-- Drop a pre-existing non-unique index first so we can recreate it as unique.
+drop index if exists public.songs_slug_idx;
+create unique index if not exists songs_slug_idx   on public.songs (slug);
+create index if not exists songs_song_group_id_idx on public.songs (song_group_id);
+create index if not exists songs_title_idx         on public.songs (title);
+
+-- 1c. RLS
+alter table public.songs enable row level security;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'songs'
+      and policyname = 'Songs are publicly readable'
+  ) then
+    create policy "Songs are publicly readable"
+      on public.songs for select
+      using (is_deleted = false);
+  end if;
+end $$;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. FIX user_starred_songs — change song_id from TEXT → UUID FK
+-- ---------------------------------------------------------------------------
+-- The current schema stores a plain text slug in song_id.  We now need a UUID
+-- FK pointing at songs.id.  Since the starring feature has been broken (no
+-- songs table), we truncate the stale rows, change the column type, recreate
+-- the primary key, and add the FK.
+
+-- 2a. Drop old primary key (it depends on the song_id column type)
+alter table public.user_starred_songs
+  drop constraint if exists user_starred_songs_pkey;
+
+-- 2b. Remove any leftover FK on song_id (idempotent)
+do $$
+declare _constraint text;
+begin
+  select conname into _constraint
+  from   pg_constraint
+  where  conrelid = 'public.user_starred_songs'::regclass
+    and  contype  = 'f'
+    and  conkey   = array[
+           (select attnum from pg_attribute
+            where  attrelid = 'public.user_starred_songs'::regclass
+              and  attname  = 'song_id')
+         ];
+  if _constraint is not null then
+    execute format('alter table public.user_starred_songs drop constraint %I', _constraint);
+  end if;
+end;
+$$;
+
+-- 2c. Remove any existing rows (they reference slug strings, not UUIDs —
+--     the starring feature was broken, so this data is not valid).
+truncate public.user_starred_songs;
+
+-- 2d. Change column type
+alter table public.user_starred_songs
+  alter column song_id type uuid using song_id::uuid;
+
+-- 2e. Restore primary key
+alter table public.user_starred_songs
+  add primary key (user_id, song_id);
+
+-- 2f. Add FK to songs
+alter table public.user_starred_songs
+  add constraint user_starred_songs_song_id_fkey
+  foreign key (song_id) references public.songs(id) on delete cascade;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS POLICIES for user_starred_songs
+-- ---------------------------------------------------------------------------
+-- Drop old policies by their original names, then recreate with canonical names.
+
+drop policy if exists "users can view own stars"   on public.user_starred_songs;
+drop policy if exists "users can insert own stars" on public.user_starred_songs;
+drop policy if exists "users can delete own stars" on public.user_starred_songs;
+drop policy if exists "Users can view own starred songs" on public.user_starred_songs;
+drop policy if exists "Users can star songs"           on public.user_starred_songs;
+drop policy if exists "Users can unstar songs"         on public.user_starred_songs;
+
+create policy "Users can view own starred songs"
+  on public.user_starred_songs for select
+  using (user_id = auth.uid());
+
+create policy "Users can star songs"
+  on public.user_starred_songs for insert
+  with check (user_id = auth.uid());
+
+create policy "Users can unstar songs"
+  on public.user_starred_songs for delete
+  using (user_id = auth.uid());
+
+
+-- ---------------------------------------------------------------------------
+-- 4. STAR COUNT TRIGGER
+-- ---------------------------------------------------------------------------
+
+create or replace function public.update_song_star_count()
+returns trigger language plpgsql security definer as $$
+begin
+  if (TG_OP = 'INSERT') then
+    update public.songs set star_count = star_count + 1 where id = NEW.song_id;
+  elsif (TG_OP = 'DELETE') then
+    update public.songs set star_count = greatest(star_count - 1, 0) where id = OLD.song_id;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists on_starred_song_change on public.user_starred_songs;
+
+create trigger on_starred_song_change
+  after insert or delete on public.user_starred_songs
+  for each row execute function public.update_song_star_count();

--- a/supabase/migrations/20260307_collaborator_requests.sql
+++ b/supabase/migrations/20260307_collaborator_requests.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- GraceChords: collaborator_requests table (2026-03-07)
+-- Stores requests from users wanting collaborator access.
+-- Admins/owners can approve or deny via the Admin Portal.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.collaborator_requests (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      uuid        REFERENCES public.users(id) ON DELETE CASCADE,
+  status       text        NOT NULL DEFAULT 'pending'
+                           CHECK (status IN ('pending', 'approved', 'denied')),
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id)
+);
+
+ALTER TABLE public.collaborator_requests ENABLE ROW LEVEL SECURITY;
+
+-- Users can read/write their own request; admins can read/write all
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'collaborator_requests'
+      AND policyname = 'own_or_admin_request'
+  ) THEN
+    CREATE POLICY "own_or_admin_request"
+      ON public.collaborator_requests
+      FOR ALL
+      USING (user_id = auth.uid() OR has_min_role('admin'));
+  END IF;
+END $$;
+
+-- Index for fast lookup by status
+CREATE INDEX IF NOT EXISTS collaborator_requests_status_idx
+  ON public.collaborator_requests (status);
+
+CREATE INDEX IF NOT EXISTS collaborator_requests_user_id_idx
+  ON public.collaborator_requests (user_id);

--- a/supabase/migrations/20260312_posts.sql
+++ b/supabase/migrations/20260312_posts.sql
@@ -1,0 +1,88 @@
+-- Posts table (already applied manually; kept here for reference/reproducibility)
+create table if not exists public.posts (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique not null,
+  title text not null,
+  excerpt text,
+  content text not null default '',
+  featured_image_url text,
+  author_id uuid references public.users(id) on delete set null,
+  status text not null default 'draft',
+  published_at timestamptz,
+  tags text[] default '{}',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Indexes
+create index if not exists posts_slug_idx on public.posts(slug);
+create index if not exists posts_status_idx on public.posts(status);
+create index if not exists posts_author_idx on public.posts(author_id);
+create index if not exists posts_published_at_idx on public.posts(published_at desc);
+
+-- RLS
+alter table public.posts enable row level security;
+
+-- Anyone can read published posts
+create policy "Public can read published posts"
+  on posts for select
+  using (status = 'published');
+
+-- Editors and above can read all posts (including drafts)
+-- NOTE: uses `role` column on public.users (NOT global_role)
+create policy "Editors can read all posts"
+  on posts for select
+  using (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+        and role in ('editor', 'admin', 'owner')
+    )
+  );
+
+-- Editors and above can insert
+create policy "Editors can insert posts"
+  on posts for insert
+  with check (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+        and role in ('editor', 'admin', 'owner')
+    )
+  );
+
+-- Editors and above can update
+create policy "Editors can update posts"
+  on posts for update
+  using (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+        and role in ('editor', 'admin', 'owner')
+    )
+  );
+
+-- Only admins/owners can delete
+create policy "Admins can delete posts"
+  on posts for delete
+  using (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+        and role in ('admin', 'owner')
+    )
+  );
+
+-- updated_at trigger
+create or replace function public.update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists posts_updated_at on public.posts;
+create trigger posts_updated_at
+  before update on public.posts
+  for each row execute function public.update_updated_at();

--- a/supabase/migrations/20260312_song_editor.sql
+++ b/supabase/migrations/20260312_song_editor.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- GraceChords: Song Editor migration (2026-03-12)
+-- Rebuilds song_suggestions, drops song_proposals, creates editor_audit_log
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1a. Rebuild song_suggestions
+-- ---------------------------------------------------------------------------
+drop table if exists song_suggestions cascade;
+
+create table song_suggestions (
+  id               uuid        primary key default gen_random_uuid(),
+  song_id          uuid        references songs(id) on delete cascade,
+  suggested_by     uuid        references public.users(id),
+  change_type      text        not null check (change_type in ('addition', 'edit', 'deletion')),
+  payload          jsonb       not null,
+  status           text        not null default 'pending' check (status in ('pending', 'approved', 'rejected')),
+  proposer_note    text,
+  reviewed_by      uuid        references public.users(id),
+  reviewed_at      timestamptz,
+  rejection_reason text,
+  created_at       timestamptz default now()
+);
+
+alter table song_suggestions enable row level security;
+
+-- Collaborator+ can insert
+create policy "collab_insert" on song_suggestions
+  for insert with check (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+      and global_role in ('collaborator','editor','admin','owner')
+    )
+  );
+
+-- Suggester can read their own; Editor+ can read all
+create policy "read_suggestions" on song_suggestions
+  for select using (
+    suggested_by = auth.uid()
+    or exists (
+      select 1 from public.users
+      where id = auth.uid()
+      and global_role in ('editor','admin','owner')
+    )
+  );
+
+-- Editor+ can update status (approve/reject)
+create policy "editor_update" on song_suggestions
+  for update using (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+      and global_role in ('editor','admin','owner')
+    )
+  );
+
+
+-- ---------------------------------------------------------------------------
+-- 1b. Drop song_proposals
+-- ---------------------------------------------------------------------------
+drop table if exists song_proposals cascade;
+
+
+-- ---------------------------------------------------------------------------
+-- 1c. Create editor_audit_log
+-- ---------------------------------------------------------------------------
+create table editor_audit_log (
+  id               uuid        primary key default gen_random_uuid(),
+  actor_id         uuid        references public.users(id) on delete set null,
+  action           text        not null check (action in ('direct_save','suggestion_submitted','approved','rejected','deleted','touched_up')),
+  song_id          uuid        references songs(id) on delete set null,
+  song_slug        text,
+  song_title       text,
+  payload_snapshot jsonb,
+  note             text,
+  created_at       timestamptz default now()
+);
+
+alter table editor_audit_log enable row level security;
+
+-- Admin+ can read
+create policy "admin_read_audit" on editor_audit_log
+  for select using (
+    exists (
+      select 1 from public.users
+      where id = auth.uid()
+      and global_role in ('admin','owner')
+    )
+  );
+
+-- Any authenticated user can insert (controlled in app logic)
+create policy "auth_insert_audit" on editor_audit_log
+  for insert with check (auth.uid() is not null);

--- a/supabase/migrations/20260312_song_language.sql
+++ b/supabase/migrations/20260312_song_language.sql
@@ -1,0 +1,2 @@
+-- Add language column to songs table (idempotent)
+alter table songs add column if not exists language text;

--- a/supabase/migrations/20260313_fix_function_search_paths.sql
+++ b/supabase/migrations/20260313_fix_function_search_paths.sql
@@ -1,0 +1,429 @@
+-- =============================================================================
+-- GraceChords: Security hardening — add SET search_path = '' to all public
+-- schema functions flagged by Supabase Advisor lint 0011.
+--
+-- All bodies are verified against the live Supabase Dashboard definitions.
+--
+-- Corrections applied on top of the verified definitions:
+--   • current_user_global_role — DROPPED (no callers in src/; global_role
+--     enum may no longer exist after profiles/enum cleanup).
+--   • claim_contributor_invite — `current_role global_role` → `current_role
+--     text`; `set global_role = 'contributor'` → `set role = 'collaborator'`.
+--   • review_contributor_request — same global_role → role fix.
+--   • is_global_admin / is_global_editor — rewritten to call get_user_role()
+--     instead of the dropped current_user_global_role().
+--
+-- WARNING: claim_contributor_invite and review_contributor_request reference
+-- the `contributor_invites`, `contributor_requests`, and `song_proposals`
+-- tables plus the `request_status` / `proposal_status` custom types.
+-- Confirm these objects still exist in the DB before pushing.
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. update_updated_at
+--    Source: supabase/migrations/20260312_posts.sql (verified)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.update_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. update_song_star_count
+--    Source: supabase/migrations/20260305_songs_migration.sql (verified)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.update_song_star_count()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF (TG_OP = 'INSERT') THEN
+    UPDATE public.songs SET star_count = star_count + 1 WHERE id = NEW.song_id;
+  ELSIF (TG_OP = 'DELETE') THEN
+    UPDATE public.songs SET star_count = greatest(star_count - 1, 0) WHERE id = OLD.song_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. set_updated_at (verified — no SECURITY DEFINER)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 4. get_user_role (verified — LANGUAGE sql STABLE)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_user_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT role FROM public.users WHERE id = auth.uid();
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 5. has_min_role (verified — LANGUAGE sql STABLE)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.has_min_role(min_role text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT CASE public.get_user_role()
+    WHEN 'owner'        THEN true
+    WHEN 'admin'        THEN min_role IN ('admin','editor','collaborator','user')
+    WHEN 'editor'       THEN min_role IN ('editor','collaborator','user')
+    WHEN 'collaborator' THEN min_role IN ('collaborator','user')
+    WHEN 'user'         THEN min_role = 'user'
+    ELSE false
+  END;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 6. current_user_global_role — DROPPED
+--    No callers exist in src/; the global_role enum may have been removed
+--    during the profiles/enum cleanup.  Drop it to clear the Advisor flag.
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.current_user_global_role();
+
+
+-- ---------------------------------------------------------------------------
+-- 7. is_global_editor
+--    Verified body rewritten: calls get_user_role() instead of the dropped
+--    current_user_global_role().
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_global_editor()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT public.get_user_role() IN ('admin', 'editor');
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 8. is_global_admin
+--    Verified body rewritten: calls get_user_role() instead of the dropped
+--    current_user_global_role().
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_global_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT public.get_user_role() = 'admin';
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 9. is_collaborator_eligible (verified — LANGUAGE sql STABLE)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_collaborator_eligible()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT (now() - account_created_at) >= interval '7 days'
+  FROM public.users
+  WHERE id = auth.uid();
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 10. get_set_limit (verified — LANGUAGE sql IMMUTABLE, takes p_role text)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_set_limit(p_role text)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $function$
+  SELECT CASE p_role
+    WHEN 'owner'        THEN NULL
+    WHEN 'admin'        THEN 30
+    WHEN 'editor'       THEN 30
+    WHEN 'collaborator' THEN 25
+    WHEN 'user'         THEN 10
+    ELSE 10
+  END;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 11. enforce_set_limit (verified — calls get_set_limit(user_role_val))
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enforce_set_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  user_role_val text;
+  set_limit     int;
+  current_count int;
+BEGIN
+  SELECT role INTO user_role_val FROM public.users WHERE id = NEW.user_id;
+  set_limit := get_set_limit(user_role_val);
+  IF set_limit IS NULL THEN RETURN NEW; END IF;
+  SELECT COUNT(*) INTO current_count FROM public.saved_sets WHERE user_id = NEW.user_id;
+  IF current_count >= set_limit THEN
+    RAISE EXCEPTION 'SET_LIMIT_REACHED: % sets allowed for role %', set_limit, user_role_val;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 12. update_user_role (verified)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.update_user_role(target_user_id uuid, new_role text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  caller_role         text := public.get_user_role();
+  target_current_role text;
+BEGIN
+  IF new_role NOT IN ('owner','admin','editor','collaborator','user') THEN
+    RAISE EXCEPTION 'Invalid role: %', new_role;
+  END IF;
+
+  SELECT role INTO target_current_role
+  FROM public.users WHERE id = target_user_id;
+
+  IF new_role IN ('owner','admin') AND caller_role != 'owner' THEN
+    RAISE EXCEPTION 'Insufficient privileges to assign role: %', new_role;
+  END IF;
+
+  IF caller_role = 'admin' AND new_role NOT IN ('editor','collaborator','user') THEN
+    RAISE EXCEPTION 'Admins can only assign editor, collaborator, or user roles';
+  END IF;
+
+  IF target_current_role = 'owner' AND caller_role != 'owner' THEN
+    RAISE EXCEPTION 'Cannot modify an owner account';
+  END IF;
+
+  UPDATE public.users SET role = new_role WHERE id = target_user_id;
+END;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 13. claim_contributor_invite (verified, with corrections)
+--    • `current_role global_role` → `current_role text`
+--    • `set global_role = 'contributor'` → `set role = 'collaborator'`
+--    WARNING: references contributor_invites table — confirm it exists.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.claim_contributor_invite(invite_token text)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+declare
+  invite contributor_invites%rowtype;
+  current_role text;
+begin
+  select * into invite
+  from contributor_invites
+  where token = invite_token;
+
+  if not found then
+    return 'invalid_token';
+  end if;
+
+  if invite.claimed_by is not null then
+    return 'already_claimed';
+  end if;
+
+  if invite.expires_at is not null and invite.expires_at < now() then
+    return 'expired';
+  end if;
+
+  select role into current_role
+  from public.users
+  where id = auth.uid();
+
+  if current_role is not null then
+    return 'already_contributor';
+  end if;
+
+  update contributor_invites
+  set claimed_by = auth.uid(),
+      claimed_at = now()
+  where id = invite.id;
+
+  update public.users
+  set role = 'collaborator'
+  where id = auth.uid();
+
+  return 'claimed';
+end;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 14. review_contributor_request (verified, with corrections)
+--    • `set global_role = 'contributor'` → `set role = 'collaborator'`
+--    WARNING: references contributor_requests table and request_status type.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.review_contributor_request(request_id uuid, decision request_status, reason text DEFAULT NULL::text)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+declare
+  req contributor_requests%rowtype;
+begin
+  if not public.is_global_admin() then
+    return 'unauthorized';
+  end if;
+
+  select * into req
+  from contributor_requests
+  where id = request_id;
+
+  if not found then
+    return 'not_found';
+  end if;
+
+  if req.status <> 'pending' then
+    return 'already_reviewed';
+  end if;
+
+  update contributor_requests
+  set status           = decision,
+      reviewed_by      = auth.uid(),
+      reviewed_at      = now(),
+      rejection_reason = reason
+  where id = request_id;
+
+  if decision = 'approved' then
+    update public.users
+    set role = 'collaborator'
+    where id = req.user_id;
+  end if;
+
+  return 'done';
+end;
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 15. review_song_proposal (verified)
+--    WARNING: references song_proposals table and proposal_status type.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.review_song_proposal(proposal_id uuid, decision proposal_status, reason text DEFAULT NULL::text)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+declare
+  prop song_proposals%rowtype;
+begin
+  if not public.is_global_editor() then
+    return 'unauthorized';
+  end if;
+
+  select * into prop
+  from song_proposals
+  where id = proposal_id;
+
+  if not found then
+    return 'not_found';
+  end if;
+
+  if prop.status <> 'pending' then
+    return 'already_reviewed';
+  end if;
+
+  update song_proposals
+  set status           = decision,
+      reviewed_by      = auth.uid(),
+      reviewed_at      = now(),
+      rejection_reason = reason
+  where id = proposal_id;
+
+  if decision = 'approved' then
+    case prop.type
+
+      when 'add' then
+        insert into songs (
+          title, artist, default_key, tempo, time_signature,
+          chordpro_content, created_by, updated_by
+        ) values (
+          prop.proposed_title,
+          prop.proposed_artist,
+          prop.proposed_default_key,
+          prop.proposed_tempo,
+          prop.proposed_time_signature,
+          prop.proposed_chordpro_content,
+          prop.proposed_by,
+          auth.uid()
+        );
+
+      when 'update' then
+        update songs set
+          title            = coalesce(prop.proposed_title,            title),
+          artist           = coalesce(prop.proposed_artist,           artist),
+          default_key      = coalesce(prop.proposed_default_key,      default_key),
+          tempo            = coalesce(prop.proposed_tempo,            tempo),
+          time_signature   = coalesce(prop.proposed_time_signature,   time_signature),
+          chordpro_content = coalesce(prop.proposed_chordpro_content, chordpro_content),
+          updated_by       = auth.uid(),
+          updated_at       = now()
+        where id = prop.song_id;
+
+      when 'delete' then
+        update songs
+        set is_deleted = true,
+            updated_by = auth.uid(),
+            updated_at = now()
+        where id = prop.song_id;
+
+    end case;
+  end if;
+
+  return 'done';
+end;
+$function$;

--- a/supabase/migrations/20260316000000_setlist_teams_redesign.sql
+++ b/supabase/migrations/20260316000000_setlist_teams_redesign.sql
@@ -1,0 +1,543 @@
+-- =============================================================================
+-- GraceChords: Setlist & Teams schema redesign (2026-03-16)
+--
+-- Drops: saved_sets, team_role enum
+-- Creates: teams, team_members, setlists (fresh), setlist_songs (fresh),
+--          setlist_comments
+-- Includes: limit-enforcement triggers, updated_at triggers, RLS policies
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 0. DROP OLD OBJECTS
+-- ---------------------------------------------------------------------------
+
+-- Drop functions that reference saved_sets so the table can be dropped cleanly
+DROP FUNCTION IF EXISTS public.enforce_set_limit();
+DROP FUNCTION IF EXISTS public.get_set_limit(text);
+
+-- Drop old table
+DROP TABLE IF EXISTS public.saved_sets CASCADE;
+
+-- Drop enum type (only existed in some environments)
+DROP TYPE IF EXISTS public.team_role;
+
+-- Drop tables we are recreating (in reverse-dependency order)
+DROP TABLE IF EXISTS public.setlist_comments  CASCADE;
+DROP TABLE IF EXISTS public.setlist_songs     CASCADE;
+DROP TABLE IF EXISTS public.setlists          CASCADE;
+DROP TABLE IF EXISTS public.team_members      CASCADE;
+DROP TABLE IF EXISTS public.teams             CASCADE;
+
+
+-- ---------------------------------------------------------------------------
+-- 1. TEAMS
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.teams (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        text        NOT NULL,
+  color       text        NOT NULL
+                          CHECK (color IN (
+                            '#E07B54','#E8C547','#4CAF82',
+                            '#4A90D9','#9B6DD6','#E05C7A','#7B8FA1'
+                          )),
+  created_by  uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at  timestamptz DEFAULT now(),
+  updated_at  timestamptz DEFAULT now()
+);
+
+
+-- ---------------------------------------------------------------------------
+-- 2. TEAM_MEMBERS
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.team_members (
+  team_id    uuid        NOT NULL REFERENCES public.teams(id)   ON DELETE CASCADE,
+  user_id    uuid        NOT NULL REFERENCES auth.users(id)     ON DELETE CASCADE,
+  role       text        NOT NULL CHECK (role IN ('leader', 'member')),
+  joined_at  timestamptz DEFAULT now(),
+  PRIMARY KEY (team_id, user_id)
+);
+
+CREATE INDEX team_members_user_id_idx ON public.team_members (user_id);
+
+
+-- ---------------------------------------------------------------------------
+-- 3. SETLISTS
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.setlists (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id     uuid        NOT NULL REFERENCES auth.users(id)  ON DELETE CASCADE,
+  team_id      uuid        REFERENCES public.teams(id)         ON DELETE CASCADE,
+  name         text        NOT NULL,
+  service_date date,
+  notes        text,
+  edit_mode    text        NOT NULL DEFAULT 'suggest'
+                           CHECK (edit_mode IN ('edit', 'suggest')),
+  created_at   timestamptz DEFAULT now(),
+  updated_at   timestamptz DEFAULT now()
+);
+
+CREATE INDEX setlists_owner_id_idx ON public.setlists (owner_id);
+CREATE INDEX setlists_team_id_idx  ON public.setlists (team_id);
+
+
+-- ---------------------------------------------------------------------------
+-- 4. SETLIST_SONGS
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.setlist_songs (
+  id           uuid  PRIMARY KEY DEFAULT gen_random_uuid(),
+  setlist_id   uuid  NOT NULL REFERENCES public.setlists(id) ON DELETE CASCADE,
+  song_id      uuid  NOT NULL REFERENCES public.songs(id)    ON DELETE CASCADE,
+  position     int4  NOT NULL,
+  key_override text,
+  notes        text
+);
+
+CREATE INDEX setlist_songs_setlist_id_idx ON public.setlist_songs (setlist_id);
+
+
+-- ---------------------------------------------------------------------------
+-- 5. SETLIST_COMMENTS
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.setlist_comments (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  setlist_id  uuid        NOT NULL REFERENCES public.setlists(id) ON DELETE CASCADE,
+  user_id     uuid        NOT NULL REFERENCES auth.users(id)      ON DELETE CASCADE,
+  body        text        NOT NULL,
+  created_at  timestamptz DEFAULT now()
+);
+
+CREATE INDEX setlist_comments_setlist_id_idx ON public.setlist_comments (setlist_id);
+
+
+-- ---------------------------------------------------------------------------
+-- 6. TRIGGER FUNCTIONS
+-- ---------------------------------------------------------------------------
+
+-- 6a. Personal setlist limit
+--     When team_id IS NULL, enforce per-role cap on personal setlists.
+CREATE OR REPLACE FUNCTION public.check_personal_setlist_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_role  text;
+  v_limit int;
+  v_count int;
+BEGIN
+  IF NEW.team_id IS NOT NULL THEN
+    RETURN NEW;  -- handled by team limit trigger
+  END IF;
+
+  SELECT role INTO v_role FROM public.users WHERE id = NEW.owner_id;
+
+  v_limit := CASE v_role
+    WHEN 'user'         THEN 3
+    WHEN 'collaborator' THEN 5
+    WHEN 'editor'       THEN 10
+    WHEN 'admin'        THEN 20
+    WHEN 'owner'        THEN 30
+    ELSE 3
+  END;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.setlists
+  WHERE owner_id = NEW.owner_id AND team_id IS NULL;
+
+  IF v_count >= v_limit THEN
+    RAISE EXCEPTION 'PERSONAL_SETLIST_LIMIT_REACHED: limit % for role %', v_limit, v_role;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+
+-- 6b. Team setlist limit
+--     When team_id IS NOT NULL, cap total setlists per team at 5.
+CREATE OR REPLACE FUNCTION public.check_team_setlist_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  IF NEW.team_id IS NULL THEN
+    RETURN NEW;  -- handled by personal limit trigger
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.setlists
+  WHERE team_id = NEW.team_id;
+
+  IF v_count >= 5 THEN
+    RAISE EXCEPTION 'TEAM_SETLIST_LIMIT_REACHED: teams are limited to 5 setlists';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+
+-- 6c. Team membership limit
+--     A user may belong to at most 3 teams total.
+CREATE OR REPLACE FUNCTION public.check_team_membership_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM public.team_members
+  WHERE user_id = NEW.user_id;
+
+  IF v_count >= 3 THEN
+    RAISE EXCEPTION 'TEAM_MEMBERSHIP_LIMIT_REACHED: users may belong to at most 3 teams';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+
+-- 6d. Team leader limit
+--     A user may be leader of at most 1 team.
+CREATE OR REPLACE FUNCTION public.check_team_leader_limit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  IF NEW.role <> 'leader' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.team_members
+  WHERE user_id = NEW.user_id AND role = 'leader';
+
+  IF v_count >= 1 THEN
+    RAISE EXCEPTION 'TEAM_LEADER_LIMIT_REACHED: users may lead at most 1 team';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- 7. TRIGGERS
+-- ---------------------------------------------------------------------------
+
+-- updated_at — teams
+--   Reuses the existing public.update_updated_at() function.
+CREATE TRIGGER teams_updated_at
+  BEFORE UPDATE ON public.teams
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+-- updated_at — setlists
+CREATE TRIGGER setlists_updated_at
+  BEFORE UPDATE ON public.setlists
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at();
+
+-- Personal setlist limit (BEFORE INSERT on setlists)
+CREATE TRIGGER trg_personal_setlist_limit
+  BEFORE INSERT ON public.setlists
+  FOR EACH ROW EXECUTE FUNCTION public.check_personal_setlist_limit();
+
+-- Team setlist limit (BEFORE INSERT on setlists)
+CREATE TRIGGER trg_team_setlist_limit
+  BEFORE INSERT ON public.setlists
+  FOR EACH ROW EXECUTE FUNCTION public.check_team_setlist_limit();
+
+-- Team membership limit (BEFORE INSERT on team_members)
+CREATE TRIGGER trg_team_membership_limit
+  BEFORE INSERT ON public.team_members
+  FOR EACH ROW EXECUTE FUNCTION public.check_team_membership_limit();
+
+-- Team leader limit (BEFORE INSERT on team_members)
+CREATE TRIGGER trg_team_leader_limit
+  BEFORE INSERT ON public.team_members
+  FOR EACH ROW EXECUTE FUNCTION public.check_team_leader_limit();
+
+
+-- ---------------------------------------------------------------------------
+-- 8. ROW LEVEL SECURITY
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.teams            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.team_members     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.setlists         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.setlist_songs    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.setlist_comments ENABLE ROW LEVEL SECURITY;
+
+
+-- ── teams ──────────────────────────────────────────────────────────────────
+
+-- SELECT: user is a member or leader of the team
+CREATE POLICY "teams_select"
+  ON public.teams FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.team_id = teams.id
+        AND tm.user_id = auth.uid()
+    )
+  );
+
+-- INSERT: any authenticated user (they become leader via separate team_members insert)
+CREATE POLICY "teams_insert"
+  ON public.teams FOR INSERT
+  WITH CHECK (auth.uid() IS NOT NULL);
+
+-- UPDATE: team leader only
+CREATE POLICY "teams_update"
+  ON public.teams FOR UPDATE
+  USING (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.team_id = teams.id
+        AND tm.user_id = auth.uid()
+        AND tm.role = 'leader'
+    )
+  );
+
+-- DELETE: team leader only
+CREATE POLICY "teams_delete"
+  ON public.teams FOR DELETE
+  USING (
+    created_by = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.team_id = teams.id
+        AND tm.user_id = auth.uid()
+        AND tm.role = 'leader'
+    )
+  );
+
+
+-- ── team_members ────────────────────────────────────────────────────────────
+
+-- SELECT: members can see other members of their own teams
+CREATE POLICY "team_members_select"
+  ON public.team_members FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.team_members self
+      WHERE self.team_id = team_members.team_id
+        AND self.user_id = auth.uid()
+    )
+  );
+
+-- INSERT: any authenticated user (trigger enforces limits)
+CREATE POLICY "team_members_insert"
+  ON public.team_members FOR INSERT
+  WITH CHECK (auth.uid() IS NOT NULL);
+
+-- DELETE: user removes themselves, OR leader removes any member of their team
+CREATE POLICY "team_members_delete"
+  ON public.team_members FOR DELETE
+  USING (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.team_members leader
+      WHERE leader.team_id = team_members.team_id
+        AND leader.user_id = auth.uid()
+        AND leader.role = 'leader'
+    )
+  );
+
+
+-- ── setlists ────────────────────────────────────────────────────────────────
+
+-- SELECT: owner, or team member
+CREATE POLICY "setlists_select"
+  ON public.setlists FOR SELECT
+  USING (
+    owner_id = auth.uid()
+    OR (
+      team_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.team_members tm
+        WHERE tm.team_id = setlists.team_id
+          AND tm.user_id = auth.uid()
+      )
+    )
+  );
+
+-- INSERT: any authenticated user (triggers enforce limits)
+CREATE POLICY "setlists_insert"
+  ON public.setlists FOR INSERT
+  WITH CHECK (auth.uid() IS NOT NULL);
+
+-- UPDATE: owner, or team member when edit_mode = 'edit'
+CREATE POLICY "setlists_update"
+  ON public.setlists FOR UPDATE
+  USING (
+    owner_id = auth.uid()
+    OR (
+      team_id IS NOT NULL
+      AND edit_mode = 'edit'
+      AND EXISTS (
+        SELECT 1 FROM public.team_members tm
+        WHERE tm.team_id = setlists.team_id
+          AND tm.user_id = auth.uid()
+      )
+    )
+  );
+
+-- DELETE: owner only
+CREATE POLICY "setlists_delete"
+  ON public.setlists FOR DELETE
+  USING (owner_id = auth.uid());
+
+
+-- ── setlist_songs ────────────────────────────────────────────────────────────
+-- Helper: returns true when caller can VIEW the parent setlist
+
+-- SELECT: same access as parent setlist
+CREATE POLICY "setlist_songs_select"
+  ON public.setlist_songs FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.setlists sl
+      WHERE sl.id = setlist_songs.setlist_id
+        AND (
+          sl.owner_id = auth.uid()
+          OR (
+            sl.team_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1 FROM public.team_members tm
+              WHERE tm.team_id = sl.team_id
+                AND tm.user_id = auth.uid()
+            )
+          )
+        )
+    )
+  );
+
+-- INSERT / UPDATE / DELETE: same as setlist UPDATE rules
+CREATE POLICY "setlist_songs_insert"
+  ON public.setlist_songs FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.setlists sl
+      WHERE sl.id = setlist_songs.setlist_id
+        AND (
+          sl.owner_id = auth.uid()
+          OR (
+            sl.team_id IS NOT NULL
+            AND sl.edit_mode = 'edit'
+            AND EXISTS (
+              SELECT 1 FROM public.team_members tm
+              WHERE tm.team_id = sl.team_id
+                AND tm.user_id = auth.uid()
+            )
+          )
+        )
+    )
+  );
+
+CREATE POLICY "setlist_songs_update"
+  ON public.setlist_songs FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.setlists sl
+      WHERE sl.id = setlist_songs.setlist_id
+        AND (
+          sl.owner_id = auth.uid()
+          OR (
+            sl.team_id IS NOT NULL
+            AND sl.edit_mode = 'edit'
+            AND EXISTS (
+              SELECT 1 FROM public.team_members tm
+              WHERE tm.team_id = sl.team_id
+                AND tm.user_id = auth.uid()
+            )
+          )
+        )
+    )
+  );
+
+CREATE POLICY "setlist_songs_delete"
+  ON public.setlist_songs FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.setlists sl
+      WHERE sl.id = setlist_songs.setlist_id
+        AND (
+          sl.owner_id = auth.uid()
+          OR (
+            sl.team_id IS NOT NULL
+            AND sl.edit_mode = 'edit'
+            AND EXISTS (
+              SELECT 1 FROM public.team_members tm
+              WHERE tm.team_id = sl.team_id
+                AND tm.user_id = auth.uid()
+            )
+          )
+        )
+    )
+  );
+
+
+-- ── setlist_comments ─────────────────────────────────────────────────────────
+
+-- SELECT: same access as parent setlist
+CREATE POLICY "setlist_comments_select"
+  ON public.setlist_comments FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.setlists sl
+      WHERE sl.id = setlist_comments.setlist_id
+        AND (
+          sl.owner_id = auth.uid()
+          OR (
+            sl.team_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1 FROM public.team_members tm
+              WHERE tm.team_id = sl.team_id
+                AND tm.user_id = auth.uid()
+            )
+          )
+        )
+    )
+  );
+
+-- INSERT: authenticated and has access to setlist
+CREATE POLICY "setlist_comments_insert"
+  ON public.setlist_comments FOR INSERT
+  WITH CHECK (
+    auth.uid() IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM public.setlists sl
+      WHERE sl.id = setlist_comments.setlist_id
+        AND (
+          sl.owner_id = auth.uid()
+          OR (
+            sl.team_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1 FROM public.team_members tm
+              WHERE tm.team_id = sl.team_id
+                AND tm.user_id = auth.uid()
+            )
+          )
+        )
+    )
+  );
+
+-- DELETE: comment owner only
+CREATE POLICY "setlist_comments_delete"
+  ON public.setlist_comments FOR DELETE
+  USING (user_id = auth.uid());


### PR DESCRIPTION
## Summary
This PR implements a comprehensive redesign of the setlist and teams infrastructure, replacing the legacy `saved_sets` table with a modern schema that supports team collaboration, granular access control, and per-role/per-team limits. It also hardens all public schema functions with explicit `SET search_path = ''` for security.

## Key Changes

### Schema Redesign (20260316_setlist_teams_redesign.sql)
- **Dropped**: `saved_sets` table, `team_role` enum, and legacy limit-enforcement functions
- **Created new tables**:
  - `teams` — team metadata with color coding and creator tracking
  - `team_members` — membership with leader/member roles
  - `setlists` — setlists with owner, optional team association, and edit mode (edit/suggest)
  - `setlist_songs` — songs within a setlist with position, key override, and notes
  - `setlist_comments` — collaborative comments on setlists
- **Limit enforcement triggers**:
  - Personal setlist limit: 3–30 per user depending on role (when `team_id IS NULL`)
  - Team setlist limit: 5 per team (when `team_id IS NOT NULL`)
  - Team membership limit: 3 teams per user
  - Team leader limit: 1 team per user
- **Row-level security policies**:
  - Teams: members can view; leaders can edit/delete
  - Setlists: owner or team members can view; edit depends on `edit_mode`
  - Setlist songs & comments: inherit parent setlist access rules
  - Team members: users can remove themselves; leaders can manage members

### Security Hardening (20260313_fix_function_search_paths.sql)
- Added `SET search_path = ''` to all public schema functions for defense against search-path injection attacks
- Dropped `current_user_global_role()` (no callers; enum may have been removed)
- Rewrote `is_global_editor()` and `is_global_admin()` to call `get_user_role()` instead
- Fixed `claim_contributor_invite()` and `review_contributor_request()` to use `role` column instead of dropped `global_role` enum

### Songs & Editor Infrastructure
- **20260305_songs_migration.sql**: Created `songs` table with slug-based indexing, fixed `user_starred_songs` to use UUID FK, added RLS policies
- **20260312_song_editor.sql**: Rebuilt `song_suggestions` table, dropped `song_proposals`, created `editor_audit_log` for tracking edits
- **20260312_posts.sql**: Created `posts` table with draft/published status and editor-only access
- **20260312_song_language.sql**: Added `language` column to songs table

### Supporting Migrations
- **20240001_create_user_starred_songs.sql**: Initial starred songs table (text-based song IDs)
- **20240002_fix_starred_songs_fk.sql**: Removed FK constraints on song_id (idempotent)
- **20240003_add_delete_user_function.sql**: User self-deletion function with cascading cleanup
- **20260307_collaborator_requests.sql**: Collaborator request workflow table

## Notable Implementation Details
- All limit-enforcement triggers use `SECURITY DEFINER` to safely query the `users` table
- Setlist edit permissions respect the `edit_mode` flag: 'edit' allows team members to modify; 'suggest' restricts to owner only
- Team membership and leadership limits are enforced at insert time via triggers
- RLS policies use nested EXISTS subqueries to check team membership transitively
- The `updated_at` trigger is reused across multiple tables for consistency

https://claude.ai/code/session_01FiTwUFhkwKiKDQvAe7Kkkt