### PR TITLE
docs(i18n): add maintenance rules for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,65 @@
 
 ---
 
+## Internationalization (i18n)
+
+UI translations live as JSON files under `src/i18n/locales/{lang}/` across ten
+namespaces: `admin`, `auth`, `common`, `editor`, `errors`, `home`, `nav`,
+`profile`, `setlist`, `song`. The English files at `src/i18n/locales/en/`
+are the **source of truth**; every other locale must mirror their key shape.
+Runtime wiring lives in `src/i18n/index.js` and `src/hooks/useLocale.jsx`;
+the supported list is in `src/i18n/config.js`.
+
+Translation tooling lives at `gracechords-i18n/`:
+- `SKILL.md` — translation and revision skill used to author/refresh copy.
+- `scripts/validate.py` — key parity, placeholder, and HTML tag validator.
+- `glossaries/{lang}.md` — per-locale terminology, register, and convention
+  decisions. Reference these for any word-choice question; do **not**
+  duplicate their contents here.
+
+### Workflow when English UI strings change
+
+When you add, modify, or remove a key under `src/i18n/locales/en/`:
+
+1. Apply the same key change to every other locale folder under
+   `src/i18n/locales/`.
+2. For each non-English file modified, set `_meta.needsReview` to `true` and
+   clear `_meta.reviewer` and `_meta.reviewedAt` to empty strings.
+3. For translation guidance, follow `gracechords-i18n/SKILL.md`.
+4. For terminology and word-choice decisions, consult
+   `gracechords-i18n/glossaries/{lang}.md` for the target locale. If the
+   change introduces new terminology not already in the glossary, append it
+   to the appropriate section there so future updates stay consistent.
+5. Run the validator before committing — once per non-English locale:
+   ```bash
+   python gracechords-i18n/scripts/validate.py \
+     src/i18n/locales/en src/i18n/locales/{lang}
+   ```
+   Exit code `0` is clean. The in-repo parity smoke check
+   (`npm run i18n:check`) is a faster sanity pass and should also be green.
+
+### Hard rules
+
+- **Never modify a file where `_meta.needsReview` is `false`** without
+  explicit user instruction. That value is a human reviewer's signoff;
+  touching it invalidates trust.
+- **Never change JSON keys, HTML tags, or `{{variables}}`** — these must be
+  byte-identical across all locales.
+- **Never translate the brand name "GraceChords."**
+- **Never populate `_meta.reviewer` or `_meta.reviewedAt`.** Those fields are
+  filled by human reviewers after QA, not by agents.
+- **Always run the validator** before committing locale changes.
+
+### Schema notes
+
+- Each file begins with an inline `_meta` block:
+  `{ "reviewer": string, "reviewedAt": string, "needsReview": boolean }`. The
+  inline single-line format is deliberate; preserve it when editing.
+- Files use 2-space indentation with a trailing newline. Match the source
+  key order to keep diffs reviewable.
+
+---
+
 ## Claude Code — Agent Instructions
 
 These are the conventions and patterns used by Claude Code (AI-assisted development) in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Code Guidance
+
+This repository's agent guidance is consolidated in [AGENTS.md](./AGENTS.md).
+Read it in full before making changes — it is the single source of truth for
+project conventions, build and test commands, design tokens, file-scope rules,
+and the i18n maintenance workflow.
+
+Maintainer note: keep this file as a pointer only. Add new agent rules to
+`AGENTS.md` so the two files cannot drift.


### PR DESCRIPTION
Adds an Internationalization section to AGENTS.md covering the workflow for keeping locales in sync when English strings change, hard rules (never touch needsReview=false files, never alter keys/HTML/variables, never populate reviewer/reviewedAt), and schema notes. Points at the gracechords-i18n/ skill, validator, and glossaries for translation guidance and word-choice decisions rather than duplicating their contents.

Adds a minimal CLAUDE.md that points to AGENTS.md so the two files cannot drift.