### PR TITLE
Fix Daily Word bible default to follow UI locale instead of song lang…

### DIFF
--- a/src/utils/bible/__tests__/translations.test.ts
+++ b/src/utils/bible/__tests__/translations.test.ts
@@ -29,7 +29,7 @@ describe('bible translations defaults', () => {
   })
 
   it('defaults to ESV when UI language resolves to english', async () => {
-    localStorage.setItem('pref:songLanguage', 'en')
+    localStorage.setItem('gracechords.uiLanguage', 'en')
     mockManifest([
       { id: 'nvi', label: 'NVI', name: 'Nueva Versión Internacional', language: 'es', dataRoot: 'bible/es/nvi' },
       { id: 'esv', label: 'ESV', name: 'English Standard Version', language: 'en', dataRoot: 'bible/en/esv' },
@@ -41,7 +41,7 @@ describe('bible translations defaults', () => {
   })
 
   it('defaults to first translation in UI language when UI is not english', async () => {
-    localStorage.setItem('pref:songLanguage', 'tr')
+    localStorage.setItem('gracechords.uiLanguage', 'tr')
     mockManifest([
       { id: 'esv', label: 'ESV', name: 'English Standard Version', language: 'en', dataRoot: 'bible/en/esv' },
       { id: 'yyc', label: 'YYÇ', name: 'Yeni Yaşam Ceviri', language: 'tr', dataRoot: 'bible/tr/yyc' },

--- a/src/utils/bible/translations.ts
+++ b/src/utils/bible/translations.ts
@@ -1,5 +1,6 @@
 import { publicUrl } from '../network/publicUrl'
-import { normalizeLanguageCode as normalizeSongLanguageCode, resolveInitialSongLanguage } from '../songs/songCatalog'
+import { normalizeLanguageCode as normalizeSongLanguageCode, detectUiLanguage } from '../songs/songCatalog'
+import { LOCALE_STORAGE_KEY } from '../../i18n/config'
 
 export type BibleTranslation = {
   id: string
@@ -123,11 +124,17 @@ async function fetchTranslations(){
   }
 }
 
+function readUiLocale(): string {
+  try {
+    if (typeof window === 'undefined') return ''
+    return window.localStorage.getItem(LOCALE_STORAGE_KEY) || ''
+  } catch {
+    return ''
+  }
+}
+
 function normalizeDefaultTranslationId(raw: unknown, translations: BibleTranslation[]){
-  const uiLanguage = resolveInitialSongLanguage(
-    translations.map((item) => normalizeSongLanguageCode(item.language, 'en')),
-    'en'
-  )
+  const uiLanguage = normalizeSongLanguageCode(readUiLocale() || detectUiLanguage(), 'en')
 
   if (uiLanguage === 'en' && translations.some((item) => item.id === DEFAULT_BIBLE_TRANSLATION_ID)) {
     return DEFAULT_BIBLE_TRANSLATION_ID


### PR DESCRIPTION
…uage

`normalizeDefaultTranslationId` was reading `pref:songLanguage` (the song-filter preference) to pick the default bible translation, which could produce a mismatch when song language and UI locale differ.

Now reads `gracechords.uiLanguage` first (the i18n locale key written by the LanguageDetector on every visit), falling back to `detectUiLanguage()` which checks `document.documentElement.lang` and then navigator.language.  Result: Turkish UI → Turkish bible by default, Korean UI → Korean bible, any unsupported locale → ESV.  Stored `pref:bibleTranslation` preference still takes priority over the locale-derived default.

Update translations.test.ts to seed `gracechords.uiLanguage` instead of `pref:songLanguage` to match the new signal.

https://claude.ai/code/session_01Y8GEuMvJ2z6n8CB13PVmoB