### PR TITLE
Optimize LCP and code-split vendor dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <meta name="robots" content="index,follow" />
     <meta name="description" content="GraceChords provides free worship chord sheets and lyrics for churches, worship teams, and believers." />
     <title>GraceChords</title>
+    <!-- Preconnect to Supabase so DNS + TLS happen in parallel with HTML parsing -->
+    <link rel="preconnect" href="https://tndnjetevtgohunqpzbi.supabase.co" crossorigin />
+    <link rel="dns-prefetch" href="https://tndnjetevtgohunqpzbi.supabase.co" />
     <!-- Preload variable font to cut requests and improve LCP -->
     <link
       rel="preload"

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -6,6 +6,7 @@ import { useAuth } from '../hooks/useAuth'
 import { showToast } from '../utils/app/toast'
 import Button from '../components/ui/layout-kit/Button'
 import { ROLES_BY_RANK_DESC } from '../lib/roles'
+import '../styles/admin-portal.css'
 
 function formatTime(date) {
   if (!date) return ''

--- a/src/pages/EditorPage.jsx
+++ b/src/pages/EditorPage.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import '../styles/admin-portal.css'
+import '../styles/editor.css'
 
 export default function EditorPage() {
   const { profile, role } = useAuth()

--- a/src/pages/ForgotPasswordPage.jsx
+++ b/src/pages/ForgotPasswordPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
+import '../styles/auth.css'
 
 export default function ForgotPasswordPage() {
   const [isDark, setIsDark] = useState(

--- a/src/pages/HomeDashboardPage.jsx
+++ b/src/pages/HomeDashboardPage.jsx
@@ -224,6 +224,17 @@ export default function HomeDashboard(){
     blurTimer.current = setTimeout(() => setShowSuggestions(false), 120)
   }
 
+  // Fetch published posts in parallel with the songs query so the network
+  // requests don't serialize into the LCP critical chain.
+  useEffect(() => {
+    let cancelled = false
+    fetchPosts({ status: 'published' }).then(({ data }) => {
+      if (cancelled) return
+      setLatestPosts((data || []).slice(0, 3))
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
   // Defer heavier work (sorting, observer) until idle to keep LCP quick
   // Defer heavy data prep and observers so first paint/LCP can happen quickly
   useEffect(() => {
@@ -231,7 +242,7 @@ export default function HomeDashboard(){
     const idle = window.requestIdleCallback || ((cb) => setTimeout(() => cb(), 1))
     const cancel = window.cancelIdleCallback || clearTimeout
     let observer = null
-    const idleId = idle(async () => {
+    const idleId = idle(() => {
       try {
         const catalog = buildSongCatalog(catalogSongs)
         const prefLang = resolveInitialSongLanguage(
@@ -274,8 +285,6 @@ export default function HomeDashboard(){
           .sort((a, b) => (b.addedMs || 0) - (a.addedMs || 0))
           .slice(0, 6)
         setLatestSongs(songsSorted)
-        const { data: postsData } = await fetchPosts({ status: 'published' })
-        setLatestPosts((postsData || []).slice(0, 3))
         setListsReady(true)
       } catch {
         setListsReady(true)

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../hooks/useAuth'
+import '../styles/auth.css'
 
 export default function LoginPage() {
   const { t } = useTranslation(['auth', 'common'])

--- a/src/pages/PostDetailPage.jsx
+++ b/src/pages/PostDetailPage.jsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import DOMPurify from 'dompurify'
 import { fetchPostBySlug } from '../hooks/usePosts'
+import '../styles/posts.css'
 
 // TipTap-authored posts may include YouTube/Vimeo embeds. Strip any iframe whose
 // src is not from a known-safe host so a compromised editor can't inject scripts

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
 import { fetchPublishedPostsWithAuthors } from '../hooks/usePosts'
 import Button from '../components/ui/layout-kit/Button'
+import '../styles/posts.css'
 
 function formatDate(iso) {
   if (!iso) return ''

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -9,6 +9,7 @@ import SpriteAvatar from '../components/ui/SpriteAvatar'
 import LanguageSelector from '../components/ui/LanguageSelector'
 import CollaboratorRequest from '../components/CollaboratorRequest'
 import { showToast } from '../utils/app/toast'
+import '../styles/settings.css'
 // src/data/index.json is deprecated as a songs source; starred songs are now joined from Supabase.
 
 export default function ProfilePage() {

--- a/src/pages/ResetPasswordPage.jsx
+++ b/src/pages/ResetPasswordPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import PasswordStrengthPopover from '../components/auth/PasswordStrengthPopover'
+import '../styles/auth.css'
 
 export default function ResetPasswordPage() {
   const navigate = useNavigate()

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -6,6 +6,7 @@ import { useAuth } from '../hooks/useAuth'
 import SpritePicker from '../components/ui/SpritePicker'
 import { showToast } from '../utils/app/toast'
 import PasswordStrengthPopover from '../components/auth/PasswordStrengthPopover'
+import '../styles/auth.css'
 
 function GoogleIcon() {
   return (

--- a/src/pages/portal/EditPostPage.jsx
+++ b/src/pages/portal/EditPostPage.jsx
@@ -5,6 +5,8 @@ import { createPost, fetchPostById, updatePost } from '../../hooks/usePosts'
 import { useAuth } from '../../hooks/useAuth'
 import { showToast } from '../../utils/app/toast'
 import PostEditor from '../../components/editor/PostEditor'
+import '../../styles/admin-portal.css'
+import '../../styles/posts.css'
 
 /* -----------------------------------------------------------------------
  * Derive a slug from a title:

--- a/src/pages/portal/EditorPage.jsx
+++ b/src/pages/portal/EditorPage.jsx
@@ -13,6 +13,8 @@ import ChordProEditor from '../../components/editor/ChordProEditor'
 import LivePreviewModal from '../../components/editor/LivePreviewModal'
 import ChordProGuideDrawer from '../../components/editor/ChordProGuideDrawer'
 import SuggestionReviewPanel from '../../components/editor/SuggestionReviewPanel'
+import '../../styles/admin-portal.css'
+import '../../styles/editor.css'
 
 const BLANK_FORM = {
   title: '',

--- a/src/pages/portal/ManagePostsPage.jsx
+++ b/src/pages/portal/ManagePostsPage.jsx
@@ -4,6 +4,8 @@ import { Helmet } from 'react-helmet-async'
 import { fetchPosts, deletePost } from '../../hooks/usePosts'
 import { useAuth } from '../../hooks/useAuth'
 import { showToast } from '../../utils/app/toast'
+import '../../styles/admin-portal.css'
+import '../../styles/posts.css'
 
 function StatusBadge({ status }) {
   return (

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,8 +4,3 @@
 @import './base.css';
 @import '../components/ui/ui.css';
 @import '../components/ui/layout-kit/layout-kit.css';
-@import './auth.css';
-@import './settings.css';
-@import './admin-portal.css';
-@import './editor.css';
-@import './posts.css';

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,41 @@ import { visualizer } from 'rollup-plugin-visualizer'
 
 const SW_VERSION = process.env.VITE_COMMIT_SHA || new Date().toISOString()
 
+// Inject a <link rel="preload"> for the hashed home-hero WebP variants so the
+// browser can fetch the LCP image before parsing the JS bundle. The hero file
+// names are content-hashed at build time, so the tag must be generated from the
+// emitted bundle rather than written by hand in index.html.
+const injectLcpPreload = {
+  name: 'inject-lcp-preload',
+  apply: 'build',
+  enforce: 'post',
+  transformIndexHtml(html, ctx) {
+    const wanted = ['768', '960', '1200']
+    const map = {}
+    for (const fileName of Object.keys(ctx.bundle || {})) {
+      const m = fileName.match(/assets\/dashboard-hero-worship-angled-(\d+)-[A-Za-z0-9_-]+\.webp$/)
+      if (m && wanted.includes(m[1])) map[m[1]] = '/' + fileName
+    }
+    const parts = wanted.filter(w => map[w]).map(w => `${map[w]} ${w}w`)
+    if (parts.length === 0) return html
+    return {
+      html,
+      tags: [{
+        tag: 'link',
+        attrs: {
+          rel: 'preload',
+          as: 'image',
+          type: 'image/webp',
+          imagesrcset: parts.join(', '),
+          imagesizes: '100vw',
+          fetchpriority: 'high',
+        },
+        injectTo: 'head-prepend',
+      }],
+    }
+  },
+}
+
 export default defineConfig({
   // Keep assets rooted at the site origin for absolute public paths.
   base: '/',
@@ -23,6 +58,7 @@ export default defineConfig({
         { src: '404.html', dest: '' }
       ]
     }),
+    injectLcpPreload,
     // Enable bundle analysis with ANALYZE=1 to find unused JS and split chunks safely
     process.env.ANALYZE ? visualizer({ filename: 'dist/stats.html', template: 'treemap' }) : null
   ],
@@ -47,7 +83,17 @@ export default defineConfig({
     // Keep previous hashed assets so stale cached HTML can still load CSS/JS.
     // This is important when a CDN caches HTML longer than expected.
     emptyOutDir: false,
-    chunkSizeWarningLimit: 1200
+    chunkSizeWarningLimit: 1200,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'supabase':     ['@supabase/supabase-js'],
+          'i18n':         ['i18next', 'react-i18next'],
+          'helmet':       ['react-helmet-async'],
+        },
+      },
+    },
   },
   optimizeDeps: {
     // pako v2 dropped its "main" field (only "module" + "exports" remain).


### PR DESCRIPTION
## Summary
This PR improves Core Web Vitals performance by optimizing Largest Contentful Paint (LCP) and implementing strategic code splitting for vendor dependencies.

## Key Changes

**Performance Optimizations:**
- Added Vite plugin to inject `<link rel="preload">` for hashed home-hero WebP image variants, enabling the browser to fetch the LCP image before parsing the JS bundle
- Added preconnect and dns-prefetch links to Supabase in `index.html` to parallelize DNS resolution and TLS handshake with HTML parsing
- Moved `fetchPosts()` call into a separate `useEffect` hook to parallelize the network request with the songs query, preventing serialization into the LCP critical chain
- Removed `async` keyword from idle callback in `HomeDashboardPage` since the posts fetch is now independent

**Code Splitting:**
- Configured Rollup `manualChunks` to split vendor dependencies into separate bundles:
  - `react-vendor`: React, React DOM, and React Router
  - `supabase`: Supabase client library
  - `i18n`: i18next and react-i18next
  - `helmet`: React Helmet Async

**CSS Loading Strategy:**
- Removed global CSS imports from `src/styles/index.css` for route-specific stylesheets (`auth.css`, `settings.css`, `admin-portal.css`, `editor.css`, `posts.css`)
- Added local CSS imports to each page component that uses them, enabling code splitting and lazy loading of styles only when needed

## Implementation Details
- The LCP preload plugin scans the build bundle for hashed WebP variants matching the pattern `dashboard-hero-worship-angled-{width}-*.webp` and generates responsive image srcset attributes
- Posts are now fetched in parallel with the songs query via a separate effect, reducing the critical path length for initial page render
- CSS files are now loaded on-demand per route rather than bundled globally, reducing initial CSS payload for pages that don't need them

https://claude.ai/code/session_01TGTTZSfLw6D2qSJk7RHMhu