### PR TITLE
Configure KV namespace ID for Telegram bot worker

### DIFF
--- a/workers/telegram-bot/wrangler.toml
+++ b/workers/telegram-bot/wrangler.toml
@@ -24,7 +24,7 @@ crons = ["0 22 * * 1,5"]
 # Paste the returned id below before first deploy.
 [[kv_namespaces]]
 binding = "BOT_KV"
-id = "REPLACE_WITH_NAMESPACE_ID"
+id = "7c716aa9f03e4cf7bc89a3ed477270a7"
 
 # R2 holds the Noto TTFs the PDF renderer uses (under fonts/ prefix). The
 # bucket already exists for pptx-upload; we just bind it here. Upload the


### PR DESCRIPTION
## Summary
Configure the KV namespace binding for the Telegram bot worker by replacing the placeholder with the actual namespace ID.

## Changes
- Updated `workers/telegram-bot/wrangler.toml` to set the `BOT_KV` namespace binding ID to the production KV namespace (`7c716aa9f03e4cf7bc89a3ed477270a7`)

## Details
This change replaces the `REPLACE_WITH_NAMESPACE_ID` placeholder with the actual Cloudflare KV namespace ID, enabling the Telegram bot worker to access its configured key-value storage on first deployment.

https://claude.ai/code/session_01TJNmeGMdsbdQjRjAEkw9Fe