### PR TITLE
fix(styles): restore navbar dropdown + profile section CSS globally

### DIFF
--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -9,6 +9,7 @@ import { supabase } from '../../lib/supabase'
 import SpriteAvatar from './SpriteAvatar'
 import SettingsCluster from './SettingsCluster'
 import { useSettings } from '../../hooks/useSettings'
+import '../../styles/auth.css'
 
 export default function Navbar(){
   const { t } = useTranslation(['nav', 'common'])


### PR DESCRIPTION
The route-CSS split (ca92f666) left .gc-user-dropdown* and .gc-profile-section in auth.css, which only loads on /login, /signup, /forgot, /reset. The user-menu dropdown and profile page sections silently lost their styling on every other route. Surfaced when the bot refactor added more dropdown items and a Telegram profile section.

Quick fix: import auth.css from Navbar (rendered on every page). Bundle cost is small; a longer-term cleanup would split auth.css into login-form / navbar / profile chunks.