### PR TITLE
fix(api/bot/setlist): import _shared.js from sibling, not parent

### DIFF
--- a/functions/api/bot/setlist.js
+++ b/functions/api/bot/setlist.js
@@ -1,4 +1,4 @@
-import { json, jsonError, requireBearer, supabaseQuery } from '../_shared.js'
+import { json, jsonError, requireBearer, supabaseQuery } from './_shared.js'
 
 // Bot posts a setlist as { items: [{ song_id, key }] } and gets back the
 // full per-song payloads (in order) so it can render either per-song JPGs


### PR DESCRIPTION
setlist.js is at functions/api/bot/setlist.js — same directory as _shared.js. The previous '../_shared.js' resolved to functions/api/_shared.js, which doesn't exist, breaking Pages Functions bundling. The other two endpoints (songs/search.js, song/[id].js) live one level deeper, so their '../_shared.js' is correct.