### PR TITLE
feat(telegram-bot): load pdfium WASM from R2 to enable JPG rendering

### DIFF
--- a/workers/telegram-bot/package.json
+++ b/workers/telegram-bot/package.json
@@ -10,7 +10,7 @@
     "dry-run": "wrangler deploy --dry-run --outdir dist"
   },
   "dependencies": {
-    "@hyzyla/pdfium": "^2.1.6",
+    "@hyzyla/pdfium": "2.1.6",
     "jspdf": "^3.0.2"
   },
   "devDependencies": {

--- a/workers/telegram-bot/src/pdfRender.js
+++ b/workers/telegram-bot/src/pdfRender.js
@@ -78,16 +78,33 @@ export async function renderSetlistPdf(env, songs, keys = []) {
 
 let _pdfiumLib = null
 let _pdfiumFailed = false
+let _wasmBytesPromise = null
 
-async function getPdfium() {
+async function loadPdfiumWasm(env) {
+  if (!_wasmBytesPromise) {
+    _wasmBytesPromise = (async () => {
+      if (!env?.R2_BUCKET) throw new Error('R2_BUCKET binding missing')
+      const obj = await env.R2_BUCKET.get('pdfium/pdfium.wasm')
+      if (!obj) throw new Error("R2 object 'pdfium/pdfium.wasm' not found — upload pdfium.wasm before JPG rendering will work (see README)")
+      return await obj.arrayBuffer()
+    })().catch(err => {
+      _wasmBytesPromise = null
+      throw err
+    })
+  }
+  return _wasmBytesPromise
+}
+
+async function getPdfium(env) {
   if (_pdfiumLib) return _pdfiumLib
   if (_pdfiumFailed) return null
   try {
-    // The /browser/cdn entry fetches the pdfium WASM from jsdelivr at runtime,
-    // so we don't have to bundle it (saves ~2 MB compressed). First call per
-    // worker isolate pays a one-time fetch + instantiate cost.
-    const { PDFiumLibrary } = await import('@hyzyla/pdfium/browser/cdn')
-    _pdfiumLib = await PDFiumLibrary.init()
+    // The base @hyzyla/pdfium entry lets us bring our own WASM. We fetch it
+    // from R2 (same bucket as the Noto TTFs) to avoid the CDN entry's
+    // subresource-integrity fetch, which Cloudflare Workers don't support.
+    const wasmBinary = await loadPdfiumWasm(env)
+    const { PDFiumLibrary } = await import('@hyzyla/pdfium')
+    _pdfiumLib = await PDFiumLibrary.init({ wasmBinary })
     return _pdfiumLib
   } catch (err) {
     _pdfiumFailed = true
@@ -186,7 +203,7 @@ function crc32(bytes) {
 
 // Returns Uint8Array (PNG bytes) or null if rasterisation isn't available.
 export async function renderSongJpg(env, song, key, { scale = 2 } = {}) {
-  const lib = await getPdfium()
+  const lib = await getPdfium(env)
   if (!lib) return null
 
   const pdfBuf = await renderSongPdf(env, song, key)


### PR DESCRIPTION
The @hyzyla/pdfium/browser/cdn preset fetches pdfium.wasm from jsdelivr with subresource integrity. Cloudflare Workers fetch doesn't support the integrity option, so every pdfium init has been failing and the bot has been falling back to PDF-as-document on every render.

Switch to the base @hyzyla/pdfium entry and bring our own WASM:
- Fetch pdfium.wasm from the gracechords-bible R2 bucket (same place the Noto TTFs already live, under pdfium/ prefix).
- Cache the ArrayBuffer in module scope; a single isolate pays the R2 read once.
- Pin @hyzyla/pdfium to 2.1.6 so the bundled JS matches whichever WASM the operator uploads.

User must upload pdfium.wasm to R2 before this works; otherwise the existing PDF-only fallback path keeps the bot functional.