### PR TITLE
fix(telegram-bot): pin @hyzyla/pdfium to 2.1.13 to match lockfile

### DIFF
--- a/workers/telegram-bot/package-lock.json
+++ b/workers/telegram-bot/package-lock.json
@@ -8,7 +8,7 @@
       "name": "gracechords-telegram-bot",
       "version": "0.1.0",
       "dependencies": {
-        "@hyzyla/pdfium": "^2.1.6",
+        "@hyzyla/pdfium": "2.1.13",
         "jspdf": "^3.0.2"
       },
       "devDependencies": {

--- a/workers/telegram-bot/package.json
+++ b/workers/telegram-bot/package.json
@@ -10,7 +10,7 @@
     "dry-run": "wrangler deploy --dry-run --outdir dist"
   },
   "dependencies": {
-    "@hyzyla/pdfium": "2.1.6",
+    "@hyzyla/pdfium": "2.1.13",
     "jspdf": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The earlier pin to 2.1.6 disagreed with the lockfile's already-resolved 2.1.13 and broke npm ci in Workers Builds. Use 2.1.13 — the version Cloudflare has actually been installing — so operator can match the uploaded WASM against the bundled JS.