### PR TITLE
feat(telegram-bot): rewrite feature posts via Workers AI, add #post trigger

### DIFF
--- a/.github/workflows/feature-post.yml
+++ b/.github/workflows/feature-post.yml
@@ -1,5 +1,10 @@
 name: Notify dev channel on flagged merge
 
+# Triggers (any of):
+#   1. PR labelled "post" is merged.
+#   2. PR title or body contains "#post" (case-insensitive) and is merged.
+# Backward-compatible with the original label-only flow.
+
 on:
   pull_request:
     types: [closed]
@@ -12,7 +17,11 @@ jobs:
   notify:
     if: >-
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'post')
+      (
+        contains(github.event.pull_request.labels.*.name, 'post') ||
+        contains(github.event.pull_request.title, '#post') ||
+        contains(github.event.pull_request.body, '#post')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: POST to bot worker
@@ -28,9 +37,13 @@ jobs:
             exit 0
           fi
 
+          # Strip the "#post" marker from the title before sending so it
+          # doesn't appear in the user-facing announcement.
+          cleaned_title=$(printf '%s' "$PR_TITLE" | sed -E 's/[[:space:]]*#post\b//gi' | sed -E 's/[[:space:]]+$//')
+
           # Use jq to safely encode env vars into JSON (handles quotes/newlines).
           payload=$(jq -n \
-            --arg title "$PR_TITLE" \
+            --arg title "$cleaned_title" \
             --arg summary "$PR_BODY" \
             --arg url "$PR_URL" \
             '{title:$title, summary:$summary, url:$url}')

--- a/workers/telegram-bot/README.md
+++ b/workers/telegram-bot/README.md
@@ -3,13 +3,25 @@
 Cloudflare Worker that powers `@gracechords_bot`. Replaces the old
 `.github/workflows/notify_telegram.yml` GitHub Action.
 
-Three surfaces:
+Surfaces:
 
 | Surface | How it's triggered |
 |---|---|
-| Direct messages | Telegram webhook → `POST /webhook` |
-| Feature announcements | GitHub Action (PR labelled `post` merges) → `POST /internal/feature` |
+| Direct messages | Telegram webhook → `POST /webhook` (`chat.type === 'private'`) |
+| Group / guest-chat mentions | Same webhook, when the bot is `@`-mentioned in a group/supergroup |
+| Feature announcements | GitHub Action (PR labelled `post`, or `#post` in PR title/body) → `POST /internal/feature` |
 | Mon/Fri digest | Cloudflare cron → `scheduled()` |
+
+## Group chat behaviour
+
+The bot listens to group/supergroup messages only when it is explicitly
+`@`-mentioned. To allow mentions from groups the bot has not been added
+to, enable **Guest Chat Mode** in BotFather → Bot Settings → Mode
+Settings. Account linking is **not** required in groups — anyone in the
+chat can summon the bot — but a per-chat cooldown
+(`src/groupRateLimit.js`, 6 renders per minute) keeps things from going
+sideways. Replies thread to the originating message via
+`reply_to_message_id` so they don't get lost in busy chats.
 
 ## Provisioning
 
@@ -116,4 +128,6 @@ curl -X POST http://127.0.0.1:8787/internal/feature \
 | `src/pdfRender.js` | PDF (always) + JPG (best-effort, pdfium WASM) |
 | `src/digest.js` | scheduled digest builder |
 | `src/feature.js` | feature post handler |
-| `src/webhook.js` | DM router (messages + callback queries) |
+| `src/aiSummary.js` | Workers AI rewrite for feature posts (with fallback) |
+| `src/groupRateLimit.js` | per-chat cooldown for group/guest-chat traffic |
+| `src/webhook.js` | DM + group router (messages + callback queries) |

--- a/workers/telegram-bot/src/aiSummary.js
+++ b/workers/telegram-bot/src/aiSummary.js
@@ -1,0 +1,80 @@
+// Cloudflare Workers AI wrapper. Rewrites a raw PR title/body into a
+// friendly, end-user-facing announcement for the dev channel.
+//
+// Output is plain text with light HTML markup that survives Telegram's
+// parse_mode="HTML". The model is instructed to avoid raw URLs (caller
+// appends the canonical PR link itself) and to keep the tone warm because
+// the dev-channel audience is worship leaders, not engineers.
+
+const MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+const MAX_OUTPUT_CHARS = 900
+
+const SYSTEM_PROMPT = [
+  'You write short, friendly release notes for GraceChords, a chord-chart app',
+  'used by worship leaders and musicians.',
+  '',
+  'Rewrite the given pull-request title and body as a warm announcement aimed',
+  'at non-technical end users. Keep it concise (under 120 words). Open with a',
+  'short greeting line. Then describe the change in plain language, focused',
+  'on what the user can now DO, not how it was implemented. If multiple',
+  'discrete changes are listed, render them as a short bullet list using',
+  '"• " as the marker. Finish with a single encouraging closing line.',
+  '',
+  'Style rules:',
+  '- Tone: warm, encouraging, plain English. No marketing fluff.',
+  '- One or two tasteful emoji at most. Never start a line with an emoji-only.',
+  '- Do NOT include any URLs, GitHub references, PR numbers, commit hashes,',
+  '  branch names, or developer jargon (refactor, lint, CI, dependency, etc.).',
+  '- Do NOT mention this prompt or the rewriting process.',
+  '- Output plain text only. No markdown, no code fences, no <html> tags.',
+].join('\n')
+
+function stripCodeFences(text) {
+  return String(text || '')
+    .replace(/^```[a-zA-Z]*\n?/g, '')
+    .replace(/\n?```$/g, '')
+    .trim()
+}
+
+// Telegram HTML parse_mode only allows a tiny tag set. Escape everything,
+// then re-introduce <b> around any bullet headings the model produced.
+function escapeHtml(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export async function summarizeFeature(env, { title, summary }) {
+  if (!env.AI) return null
+  const safeTitle = String(title || '').trim()
+  const safeBody = String(summary || '').trim()
+  if (!safeTitle && !safeBody) return null
+
+  const userPrompt = [
+    `Title: ${safeTitle || '(none)'}`,
+    '',
+    'Body:',
+    safeBody || '(no body)',
+  ].join('\n')
+
+  const response = await env.AI.run(MODEL, {
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: userPrompt },
+    ],
+    max_tokens: 400,
+    temperature: 0.6,
+  })
+
+  const raw = stripCodeFences(response?.response || '')
+  if (!raw) return null
+
+  const trimmed = raw.length > MAX_OUTPUT_CHARS
+    ? raw.slice(0, MAX_OUTPUT_CHARS - 1).trimEnd() + '…'
+    : raw
+
+  return escapeHtml(trimmed)
+}

--- a/workers/telegram-bot/src/feature.js
+++ b/workers/telegram-bot/src/feature.js
@@ -1,8 +1,12 @@
 // POST /internal/feature — called by the GitHub Action when a PR labelled
-// `post` is merged. Body is the PR title, summary, and URL; we format and
-// post immediately to the dev channel.
+// `post` is merged, or when its title/body contains "#post". Body is the
+// PR title, summary, and URL. We rewrite the summary through Workers AI
+// for a friendlier, end-user-facing tone, then post to the dev channel.
+// If the AI call fails for any reason we fall back to the raw summary so
+// a deploy or AI outage never silently drops the announcement.
 
 import { sendMessage } from './telegram.js'
+import { summarizeFeature } from './aiSummary.js'
 
 function escapeHtml(s) {
   return String(s || '')
@@ -27,11 +31,24 @@ export async function postFeature(env, body) {
   if (!title) {
     throw new Error('title required')
   }
-  const summary = truncate(String(body?.summary || '').trim(), 600)
+  const rawSummary = String(body?.summary || '').trim()
   const url = String(body?.url || '').trim()
 
+  // Try AI rewrite first. summarizeFeature() returns HTML-escaped text or
+  // null. Any thrown error (rate limit, quota, transient) → fall back.
+  let aiBody = null
+  try {
+    aiBody = await summarizeFeature(env, { title, summary: rawSummary })
+  } catch (err) {
+    console.warn('AI summary failed; falling back to raw body', err?.message || err)
+  }
+
   const parts = [`<b>🚀 ${escapeHtml(title)}</b>`]
-  if (summary) parts.push('', escapeHtml(summary))
+  if (aiBody) {
+    parts.push('', aiBody)
+  } else if (rawSummary) {
+    parts.push('', escapeHtml(truncate(rawSummary, 600)))
+  }
   if (url) parts.push('', `<a href="${escapeHtml(url)}">Details on GitHub</a>`)
 
   await sendMessage(env.TELEGRAM_BOT_TOKEN, {

--- a/workers/telegram-bot/src/groupRateLimit.js
+++ b/workers/telegram-bot/src/groupRateLimit.js
@@ -1,0 +1,35 @@
+// Per-chat cooldown for group/guest-chat requests. Intentionally lenient —
+// the goal is to prevent a single chat from flooding the renderer, not to
+// throttle normal worship-team use. Pairs with the per-user DM limiter in
+// ratelimit.js; the two are independent.
+//
+// Tuning: a chat can request up to GROUP_MAX_PER_WINDOW renders within
+// GROUP_WINDOW_MS. Numbers chosen so a band can ping the bot for a normal
+// setlist (~10 songs in a media group counts as one request) plus a few
+// extra one-offs without ever hitting the limit.
+
+const GROUP_WINDOW_MS = 60 * 1000 // 1 minute
+const GROUP_MAX_PER_WINDOW = 6
+
+export async function checkGroupRateLimit(env, chatId) {
+  if (!env.BOT_KV) return { ok: true }
+
+  const now = Date.now()
+  const bucket = Math.floor(now / GROUP_WINDOW_MS)
+  const key = `rl:grp:${chatId}:${bucket}`
+  const raw = await env.BOT_KV.get(key)
+  const count = Number(raw) || 0
+
+  if (count >= GROUP_MAX_PER_WINDOW) {
+    const resetMs = ((bucket + 1) * GROUP_WINDOW_MS) - now
+    return {
+      ok: false,
+      retryAfterSeconds: Math.max(1, Math.ceil(resetMs / 1000)),
+    }
+  }
+
+  await env.BOT_KV.put(key, String(count + 1), {
+    expirationTtl: Math.ceil(GROUP_WINDOW_MS / 1000) * 2,
+  })
+  return { ok: true }
+}

--- a/workers/telegram-bot/src/telegram.js
+++ b/workers/telegram-bot/src/telegram.js
@@ -24,6 +24,10 @@ export async function sendMessage(token, params) {
   return callJson(token, 'sendMessage', params)
 }
 
+export async function getMe(token) {
+  return callJson(token, 'getMe', {})
+}
+
 export async function sendChatAction(token, chatId, action = 'typing') {
   return callJson(token, 'sendChatAction', { chat_id: chatId, action })
 }

--- a/workers/telegram-bot/src/webhook.js
+++ b/workers/telegram-bot/src/webhook.js
@@ -1,8 +1,10 @@
-// Telegram webhook handler — DM flow only.
-// Channel posts and group messages are ignored.
+// Telegram webhook handler — routes DM messages, group/guest-chat @mentions,
+// and inline-button callback queries. Channel posts and edited messages are
+// silently ignored.
 
 import { findUserByTelegramId } from './supabase.js'
 import { checkRateLimit, formatCooldown } from './ratelimit.js'
+import { checkGroupRateLimit } from './groupRateLimit.js'
 import { parseRequest } from './parseRequest.js'
 import { searchSongs, fetchSong, fetchSetlistSongs, classifyMatch } from './searchClient.js'
 import {
@@ -12,8 +14,43 @@ import {
   sendMediaGroup,
   sendChatAction,
   answerCallbackQuery,
+  getMe,
 } from './telegram.js'
 import { renderSongPdf, renderSetlistPdf, renderSongJpg } from './pdfRender.js'
+
+// Bot username is needed to detect @mentions in group chats. Cache once
+// per isolate — getMe() is a single Telegram round-trip and the username
+// only changes if the maintainer renames the bot via BotFather.
+let cachedBotUsername = null
+async function getBotUsername(env) {
+  if (cachedBotUsername) return cachedBotUsername
+  try {
+    const me = await getMe(env.TELEGRAM_BOT_TOKEN)
+    cachedBotUsername = (me?.username || '').toLowerCase()
+  } catch (err) {
+    console.warn('getMe failed', err?.message || err)
+    cachedBotUsername = ''
+  }
+  return cachedBotUsername
+}
+
+// Pulls out the @bot mention (if any) and returns the remaining text. Only
+// returns non-null when this message is actually directed at the bot.
+function extractMentionPayload(message, botUsername) {
+  if (!botUsername) return null
+  const text = String(message?.text || '')
+  const entities = Array.isArray(message?.entities) ? message.entities : []
+  const want = `@${botUsername}`.toLowerCase()
+  for (const ent of entities) {
+    if (ent.type !== 'mention') continue
+    const slice = text.slice(ent.offset, ent.offset + ent.length).toLowerCase()
+    if (slice !== want) continue
+    const before = text.slice(0, ent.offset)
+    const after = text.slice(ent.offset + ent.length)
+    return (before + ' ' + after).replace(/\s+/g, ' ').trim()
+  }
+  return null
+}
 
 const USER_CACHE_TTL_S = 5 * 60
 const SETLIST_KV_TTL_S = 24 * 60 * 60
@@ -79,7 +116,7 @@ function setlistPdfCallbackData(token) {
   return `slpdf:${token}`
 }
 
-async function sendSongJpgOrPdf({ env, chatId, song, key, label }) {
+async function sendSongJpgOrPdf({ env, chatId, song, key, label, replyToMessageId }) {
   // Best-effort JPG. If the rasteriser isn't available (cold WASM, etc.)
   // fall back to sending the PDF directly.
   const jpg = await renderSongJpg(env, song, key).catch(() => null)
@@ -90,6 +127,7 @@ async function sendSongJpgOrPdf({ env, chatId, song, key, label }) {
       photo: jpg,
       filename: `${(song.slug || song.id || 'song')}.png`,
       caption,
+      replyToMessageId,
       replyMarkup: {
         inline_keyboard: [[
           { text: '📄 Get as PDF', callback_data: pdfCallbackData(song.id, key) },
@@ -104,10 +142,11 @@ async function sendSongJpgOrPdf({ env, chatId, song, key, label }) {
     document: pdf,
     filename: `${(song.slug || song.id || 'song')}.pdf`,
     caption,
+    replyToMessageId,
   })
 }
 
-async function sendSetlistResponse({ env, chatId, songs, keys }) {
+async function sendSetlistResponse({ env, chatId, songs, keys, replyToMessageId }) {
   // Build per-song JPGs (best-effort). If any fail we fall back to PDF for
   // the whole set so the user always gets something usable.
   const media = []
@@ -120,6 +159,7 @@ async function sendSetlistResponse({ env, chatId, songs, keys }) {
         document: pdf,
         filename: `setlist.pdf`,
         caption: 'Setlist',
+        replyToMessageId,
       })
       return
     }
@@ -131,10 +171,12 @@ async function sendSetlistResponse({ env, chatId, songs, keys }) {
   }
 
   // Telegram allows up to 10 in a single media group; chunk if needed.
+  // Only thread the first chunk back to the originating message.
   for (let start = 0; start < media.length; start += 10) {
     await sendMediaGroup(env.TELEGRAM_BOT_TOKEN, {
       chatId,
       media: media.slice(start, start + 10),
+      replyToMessageId: start === 0 ? replyToMessageId : undefined,
     })
   }
 
@@ -151,15 +193,29 @@ async function sendSetlistResponse({ env, chatId, songs, keys }) {
   })
 }
 
-async function handleTextMessage(env, ctx, message) {
+async function handleTextMessage(env, ctx, message, options = {}) {
+  // options.text       — pre-cleaned text (mention stripped) for group flow.
+  // options.isGroup    — true for group/supergroup/guest-chat messages.
+  // options.replyToMessageId — message_id to thread replies under in groups.
   const chatId = message.chat.id
   const telegramUserId = message.from?.id
-  const text = String(message.text || '').trim()
+  const text = String(options.text ?? message.text ?? '').trim()
+  const isGroup = !!options.isGroup
+  const replyToMessageId = options.replyToMessageId
 
   if (!telegramUserId || !text) return
 
-  // /start and /help — always responsive even when not linked.
+  // /start and /help — always responsive even when not linked. In groups
+  // we keep the message short to avoid spamming the chat with onboarding.
   if (/^\/(start|help)\b/i.test(text)) {
+    if (isGroup) {
+      await sendMessage(env.TELEGRAM_BOT_TOKEN, {
+        chat_id: chatId,
+        text: 'Mention me with a song title (e.g. "@gracechords_bot Build My Life in G") and I\'ll drop the chord chart in the chat.',
+        reply_to_message_id: replyToMessageId,
+      })
+      return
+    }
     const user = await getLinkedUser(env, telegramUserId)
     await sendMessage(env.TELEGRAM_BOT_TOKEN, {
       chat_id: chatId,
@@ -170,19 +226,32 @@ async function handleTextMessage(env, ctx, message) {
     return
   }
 
-  const user = await getLinkedUser(env, telegramUserId)
-  if (!user) {
-    await sendMessage(env.TELEGRAM_BOT_TOKEN, { chat_id: chatId, text: onboardingText() })
-    return
-  }
-
-  const limit = await checkRateLimit(env, telegramUserId)
-  if (!limit.ok) {
-    await sendMessage(env.TELEGRAM_BOT_TOKEN, {
-      chat_id: chatId,
-      text: `Whoa, slow down — try again in ${formatCooldown(limit.retryAfterSeconds)}.`,
-    })
-    return
+  // Account-link gating is DM-only. In a group chat anyone can summon the
+  // bot — we still rate-limit per chat so a single group can't flood.
+  if (!isGroup) {
+    const user = await getLinkedUser(env, telegramUserId)
+    if (!user) {
+      await sendMessage(env.TELEGRAM_BOT_TOKEN, { chat_id: chatId, text: onboardingText() })
+      return
+    }
+    const limit = await checkRateLimit(env, telegramUserId)
+    if (!limit.ok) {
+      await sendMessage(env.TELEGRAM_BOT_TOKEN, {
+        chat_id: chatId,
+        text: `Whoa, slow down — try again in ${formatCooldown(limit.retryAfterSeconds)}.`,
+      })
+      return
+    }
+  } else {
+    const groupLimit = await checkGroupRateLimit(env, chatId)
+    if (!groupLimit.ok) {
+      await sendMessage(env.TELEGRAM_BOT_TOKEN, {
+        chat_id: chatId,
+        text: `Busy chat — try again in ${formatCooldown(groupLimit.retryAfterSeconds)}.`,
+        reply_to_message_id: replyToMessageId,
+      })
+      return
+    }
   }
 
   const items = parseRequest(text)
@@ -190,6 +259,7 @@ async function handleTextMessage(env, ctx, message) {
     await sendMessage(env.TELEGRAM_BOT_TOKEN, {
       chat_id: chatId,
       text: "I couldn't read that. Try a title like \"Build My Life in G\".",
+      reply_to_message_id: replyToMessageId,
     })
     return
   }
@@ -205,6 +275,7 @@ async function handleTextMessage(env, ctx, message) {
       await sendMessage(env.TELEGRAM_BOT_TOKEN, {
         chat_id: chatId,
         text: `I couldn't find "${item.title}". Try a different spelling?`,
+        reply_to_message_id: replyToMessageId,
       })
       return
     }
@@ -217,6 +288,7 @@ async function handleTextMessage(env, ctx, message) {
         chat_id: chatId,
         text: `Which "${item.title}" did you mean?`,
         reply_markup: { inline_keyboard: keyboard },
+        reply_to_message_id: replyToMessageId,
       })
       return
     }
@@ -225,13 +297,13 @@ async function handleTextMessage(env, ctx, message) {
 
   if (resolved.length === 1) {
     const song = await fetchSong(env, resolved[0].id)
-    await sendSongJpgOrPdf({ env, chatId, song, key: resolved[0].key })
+    await sendSongJpgOrPdf({ env, chatId, song, key: resolved[0].key, replyToMessageId })
     return
   }
 
   const songs = await fetchSetlistSongs(env, resolved.map(r => ({ song_id: r.id, key: r.key })))
   const keys = resolved.map(r => r.key)
-  await sendSetlistResponse({ env, chatId, songs, keys })
+  await sendSetlistResponse({ env, chatId, songs, keys, replyToMessageId })
 }
 
 async function handleCallbackQuery(env, ctx, cbq) {
@@ -287,8 +359,11 @@ async function handleCallbackQuery(env, ctx, cbq) {
 }
 
 export async function handleTelegramUpdate(env, ctx, update) {
-  // DM-only. Anything else is silently ignored — channel/group flows are
-  // handled by separate worker paths (digest, feature post).
+  // Three flows:
+  //   private chat  → full DM experience (account link, per-user limit).
+  //   group / supergroup / guest-chat → only respond to @mentions, per-chat
+  //                                     limit, no account-link requirement.
+  //   anything else (channel_post, edited_*) → silently ignore.
   const message = update?.message
   const cbq = update?.callback_query
 
@@ -298,14 +373,36 @@ export async function handleTelegramUpdate(env, ctx, update) {
     })
   }
 
-  if (message?.chat?.type !== 'private') return
-  if (typeof message.text !== 'string') return
+  if (typeof message?.text !== 'string') return
 
-  return handleTextMessage(env, ctx, message).catch(err => {
-    console.warn('message handler error', err)
-    return sendMessage(env.TELEGRAM_BOT_TOKEN, {
-      chat_id: message.chat.id,
-      text: 'Something went wrong on my end. Try again in a moment.',
-    }).catch(() => {})
-  })
+  const chatType = message.chat?.type
+  if (chatType === 'private') {
+    return handleTextMessage(env, ctx, message).catch(err => {
+      console.warn('message handler error', err)
+      return sendMessage(env.TELEGRAM_BOT_TOKEN, {
+        chat_id: message.chat.id,
+        text: 'Something went wrong on my end. Try again in a moment.',
+      }).catch(() => {})
+    })
+  }
+
+  if (chatType === 'group' || chatType === 'supergroup') {
+    const botUsername = await getBotUsername(env)
+    const payload = extractMentionPayload(message, botUsername)
+    // No mention of this bot → not for us. Stay quiet so we don't pollute
+    // the group with replies to unrelated chatter.
+    if (payload === null) return
+    return handleTextMessage(env, ctx, message, {
+      text: payload,
+      isGroup: true,
+      replyToMessageId: message.message_id,
+    }).catch(err => {
+      console.warn('group message handler error', err)
+      return sendMessage(env.TELEGRAM_BOT_TOKEN, {
+        chat_id: message.chat.id,
+        text: 'Something went wrong on my end. Try again in a moment.',
+        reply_to_message_id: message.message_id,
+      }).catch(() => {})
+    })
+  }
 }

--- a/workers/telegram-bot/wrangler.toml
+++ b/workers/telegram-bot/wrangler.toml
@@ -33,6 +33,12 @@ id = "7c716aa9f03e4cf7bc89a3ed477270a7"
 binding = "R2_BUCKET"
 bucket_name = "gracechords-bible"
 
+# Workers AI — powers the friendly rewrite in feature.js. Free tier covers
+# the ~daily volume of feature posts; if the call fails for any reason
+# feature.js falls back to posting the raw PR body.
+[ai]
+binding = "AI"
+
 [vars]
 # Empty — every runtime value comes from `wrangler secret put`.
 


### PR DESCRIPTION
Adds a Cloudflare Workers AI binding and routes the raw PR title/body
through llama-3.3-70b before posting to the dev channel, replacing the
verbatim dump that landed in chat for non-technical users. The model is
prompted for warm, end-user-facing copy; any failure (binding missing,
quota, transient) falls back to the prior templated output so an outage
never silently drops the announcement.

Also extends the GitHub Action to fire on either the existing "post" PR
label or "#post" in the PR title or body, restoring the commit-time
trigger we used before. The marker is stripped from the title before
the worker sees it.