### PR TITLE
fix(mobile): tighten sidebar settings rows, bible chip bar, and disclaimer

### DIFF
--- a/src/components/SiteDisclaimer.jsx
+++ b/src/components/SiteDisclaimer.jsx
@@ -9,12 +9,13 @@ export default function SiteDisclaimer(){
   const inWorship = (pathname && pathname.startsWith('/worship')) || (hash && hash.includes('/worship'))
   const inReading = (pathname && pathname.startsWith('/reading')) || (hash && hash.includes('/reading'))
   if (inWorship) return null
+  if (inReading) return null
   if (!isDisclaimerEnabled()) return null
   const year = new Date().getFullYear()
   const base = 2023
   const range = year === base ? `${year}` : `${base}–${year}`
   return (
-    <footer style={{ marginTop: inReading ? '1.5rem' : '3rem' }}>
+    <footer style={{ marginTop: '3rem' }}>
       <div
         style={{
           fontSize: '0.85rem',

--- a/src/components/ui/SettingsCluster.jsx
+++ b/src/components/ui/SettingsCluster.jsx
@@ -2,29 +2,30 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSettings } from '../../hooks/useSettings'
 import { useLocale } from '../../hooks/useLocale'
-import { Sun, Moon } from '../Icons'
 
-function PillSwitch({
-  checked,
+export function PillToggle({
+  leftLabel,
+  rightLabel,
+  value,
   onChange,
-  leftContent,
-  rightContent,
   ariaLabel,
   className = '',
 }) {
+  const isRight = value === 'right'
+  const handleClick = () => onChange(isRight ? 'left' : 'right')
   return (
     <button
       type="button"
-      className={`gc-pill-switch ${checked ? 'is-right' : 'is-left'} ${className}`}
+      className={`gc-pill-toggle ${isRight ? 'is-right' : 'is-left'} ${className}`}
       role="switch"
-      aria-checked={checked}
+      aria-checked={isRight}
       aria-label={ariaLabel}
-      onClick={onChange}
+      onClick={handleClick}
     >
-      <span className="gc-pill-switch__track" aria-hidden="true">
-        <span className="gc-pill-switch__thumb" />
-        <span className="gc-pill-switch__option gc-pill-switch__option--left">{leftContent}</span>
-        <span className="gc-pill-switch__option gc-pill-switch__option--right">{rightContent}</span>
+      <span className="gc-pill-toggle__track" aria-hidden="true">
+        <span className="gc-pill-toggle__thumb" />
+        <span className="gc-pill-toggle__option gc-pill-toggle__option--left">{leftLabel}</span>
+        <span className="gc-pill-toggle__option gc-pill-toggle__option--right">{rightLabel}</span>
       </span>
     </button>
   )
@@ -35,11 +36,11 @@ export function ThemeSwitch({ className }) {
   const { theme, toggleTheme } = useSettings()
   const isDark = theme === 'dark'
   return (
-    <PillSwitch
-      checked={isDark}
+    <PillToggle
+      leftLabel={t('light')}
+      rightLabel={t('dark')}
+      value={isDark ? 'right' : 'left'}
       onChange={toggleTheme}
-      leftContent={<Sun width={14} height={14} />}
-      rightContent={<Moon width={14} height={14} />}
       ariaLabel={t('toggleDarkMode')}
       className={className}
     />
@@ -51,13 +52,13 @@ export function ChordStyleSwitch({ className }) {
   const { chordStyle, toggleChordStyle } = useSettings()
   const isSolfege = chordStyle === 'solfege'
   return (
-    <PillSwitch
-      checked={isSolfege}
+    <PillToggle
+      leftLabel="ABC"
+      rightLabel="DoReMi"
+      value={isSolfege ? 'right' : 'left'}
       onChange={toggleChordStyle}
-      leftContent={<span className="gc-pill-switch__text">ABC</span>}
-      rightContent={<span className="gc-pill-switch__text">Do</span>}
       ariaLabel={t('toggleChordStyle', { defaultValue: 'Toggle chord style' })}
-      className={`gc-pill-switch--text ${className || ''}`}
+      className={className}
     />
   )
 }
@@ -77,7 +78,6 @@ export function LocalePicker({ className = '' }) {
           <option key={loc.code} value={loc.code}>{loc.label}</option>
         ))}
       </select>
-      <span className="gc-locale-picker__chev" aria-hidden="true">▾</span>
     </div>
   )
 }

--- a/src/features/readings/readings.css
+++ b/src/features/readings/readings.css
@@ -3,7 +3,7 @@
   max-width: 1200px;
   margin: 0 auto;
   padding-top: var(--space-4);
-  padding-bottom: var(--space-6);
+  padding-bottom: var(--space-4);
   padding-inline: clamp(6px, 2vw, 14px);
   display:flex;
   flex-direction:column;
@@ -250,7 +250,7 @@
 
 @media (max-width: 720px){
   .readings-page{
-    --readings-mobile-chipbar-h: 78px;
+    --readings-mobile-chipbar-h: 52px;
   }
 
   .readings-dateblock{
@@ -289,8 +289,8 @@
     z-index: 80;
     width: auto;
     margin: 0;
-    min-height: calc(var(--readings-mobile-chipbar-h) + env(safe-area-inset-bottom, 0px));
-    padding: 10px 0 calc(10px + env(safe-area-inset-bottom, 0px));
+    min-height: var(--readings-mobile-chipbar-h);
+    padding: 8px 0 max(8px, env(safe-area-inset-bottom, 8px));
     background: var(--gc-surface-1);
     border-top: 1px solid var(--gc-separator);
     border-radius: 0;
@@ -364,6 +364,6 @@
 @media (max-width: 720px){
   .readings-copy-fab{
     /* Keep FAB above the sticky passage-chip toolbar on mobile */
-    bottom: calc(86px + var(--safe-b, env(safe-area-inset-bottom, 0px)));
+    bottom: calc(var(--readings-mobile-chipbar-h) + var(--space-3) + var(--safe-b, env(safe-area-inset-bottom, 0px)));
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -10,6 +10,8 @@
   "loading": "Loading…",
   "search": "Search",
   "language": "Language",
+  "light": "Light",
+  "dark": "Dark",
   "lightMode": "Light mode",
   "darkMode": "Dark mode",
   "toggleDarkMode": "Toggle dark mode",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -10,6 +10,8 @@
   "loading": "Cargando…",
   "search": "Buscar",
   "language": "Idioma",
+  "light": "Claro",
+  "dark": "Oscuro",
   "lightMode": "Modo claro",
   "darkMode": "Modo oscuro",
   "toggleDarkMode": "Alternar modo oscuro",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -10,6 +10,8 @@
   "loading": "불러오는 중…",
   "search": "검색",
   "language": "언어",
+  "light": "라이트",
+  "dark": "다크",
   "lightMode": "라이트 모드",
   "darkMode": "다크 모드",
   "toggleDarkMode": "다크 모드 전환",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -10,6 +10,8 @@
   "loading": "Yükleniyor…",
   "search": "Ara",
   "language": "Dil",
+  "light": "Açık",
+  "dark": "Koyu",
   "lightMode": "Açık tema",
   "darkMode": "Koyu tema",
   "toggleDarkMode": "Koyu temaya geç",

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -26,9 +26,26 @@
 }
 .gc-settings-cluster__control { display: flex; align-items: center; }
 
-/* ---------- Pill switch (theme + chord style) ---------- */
+/* Mobile drawer: row layout with consistent height across all three settings */
+.gc-drawer .gc-settings-cluster--column { gap: 0; }
+.gc-drawer .gc-settings-cluster__row {
+  min-height: 56px;
+  gap: var(--space-3);
+  border-top: 1px solid color-mix(in srgb, var(--drawer-text) 14%, transparent);
+}
+.gc-drawer .gc-settings-cluster__row:first-child { border-top: none; }
+.gc-drawer .gc-settings-cluster__label {
+  font-size: var(--gc-font-body);
+  color: var(--drawer-text);
+  font-weight: 400;
+}
+.gc-drawer .gc-settings-cluster__control { justify-content: flex-end; }
 
-.gc-pill-switch {
+/* ---------- Pill toggle (theme + chord style) ----------
+   Two-state pill: both labels always visible. Active half filled with
+   the brand/accent color; inactive half is text only. */
+
+.gc-pill-toggle {
   display: inline-block;
   background: none;
   border: none;
@@ -36,60 +53,59 @@
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
-.gc-pill-switch:focus { outline: none; }
-.gc-pill-switch:focus-visible .gc-pill-switch__track {
+.gc-pill-toggle:focus { outline: none; }
+.gc-pill-toggle:focus-visible .gc-pill-toggle__track {
   box-shadow: 0 0 0 var(--gc-focus-size) var(--gc-primary);
 }
 
-.gc-pill-switch__track {
+.gc-pill-toggle__track {
   position: relative;
   display: inline-flex;
   align-items: center;
-  width: 56px;
-  height: 28px;
+  height: 44px;
   border-radius: var(--radius-pill);
   background: var(--gc-surface-3);
   border: 1px solid var(--gc-separator);
   transition: background var(--gc-dur-quick) var(--gc-ease);
+  padding: 2px;
 }
-.gc-pill-switch--text .gc-pill-switch__track { width: 64px; }
 
-.gc-pill-switch__thumb {
+.gc-pill-toggle__thumb {
   position: absolute;
   top: 2px;
   left: 2px;
   width: calc(50% - 2px);
   height: calc(100% - 4px);
   border-radius: var(--radius-pill);
-  background: var(--gc-surface-1);
+  background: var(--gc-primary);
   box-shadow: var(--gc-shadow-1);
   transition: transform var(--gc-dur) var(--gc-ease), background var(--gc-dur-quick) var(--gc-ease);
 }
-.gc-pill-switch.is-right .gc-pill-switch__thumb {
-  transform: translateX(calc(100% + 0px));
+.gc-pill-toggle.is-right .gc-pill-toggle__thumb {
+  transform: translateX(100%);
 }
 
-.gc-pill-switch__option {
+.gc-pill-toggle__option {
   flex: 1 1 0;
+  min-width: 60px;
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
   z-index: 1;
+  padding: 0 10px;
   color: var(--gc-text-tertiary);
+  font-size: var(--gc-font-sub);
+  font-weight: 500;
+  font-family: var(--gc-font-family);
+  white-space: nowrap;
   transition: color var(--gc-dur-quick) var(--gc-ease);
   pointer-events: none;
 }
-.gc-pill-switch.is-left .gc-pill-switch__option--left,
-.gc-pill-switch.is-right .gc-pill-switch__option--right {
-  color: var(--gc-text);
-}
-
-.gc-pill-switch__text {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  font-family: var(--gc-font-family);
+.gc-pill-toggle.is-left .gc-pill-toggle__option--left,
+.gc-pill-toggle.is-right .gc-pill-toggle__option--right {
+  color: var(--primary-text);
+  font-weight: 600;
 }
 
 /* ---------- Locale picker ---------- */
@@ -108,7 +124,7 @@
   border-radius: var(--radius-pill);
   font: 500 13px/1 var(--gc-font-family);
   height: 28px;
-  padding: 0 26px 0 12px;
+  padding: 0 12px;
   cursor: pointer;
   transition: background var(--gc-dur-quick) var(--gc-ease), border-color var(--gc-dur-quick) var(--gc-ease);
 }
@@ -117,15 +133,6 @@
   outline: none;
   box-shadow: 0 0 0 var(--gc-focus-size) var(--gc-primary);
   border-color: var(--gc-primary);
-}
-.gc-locale-picker__chev {
-  position: absolute;
-  right: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 10px;
-  color: var(--gc-text-secondary);
-  pointer-events: none;
 }
 
 /* ---------- Desktop gear tray ---------- */
@@ -181,10 +188,14 @@
 /* ---------- Drawer overrides ---------- */
 
 .gc-drawer .gc-settings-cluster { width: 100%; }
-.gc-drawer .gc-settings-cluster--column { gap: var(--space-3); }
-.gc-drawer .gc-locale-picker,
-.gc-drawer .gc-locale-picker__select { width: 100%; }
-.gc-drawer .gc-locale-picker__select { height: 36px; }
+.gc-drawer .gc-locale-picker { width: auto; max-width: 140px; }
+.gc-drawer .gc-locale-picker__select {
+  width: 100%;
+  max-width: 140px;
+  height: 36px;
+  text-align: right;
+  text-align-last: right;
+}
 
 /* Sign Out gets a quieter, secondary treatment */
 .gc-drawer .gc-signout-link {


### PR DESCRIPTION
- Sidebar settings (Dark mode / Language / Chord style) render as 56px
  rows with label left, control right, divider between rows.
- Replace icon-only theme chip with a reusable two-state pill (Light/Dark)
  and use the same component for chord style (ABC/DoReMi).
- Locale picker right-aligned and capped at 140px; drop the orphan chevron
  span that duplicated the native dropdown arrow.
- Add 'light'/'dark' i18n keys for en/es/ko/tr.
- Bible reader chip toolbar: reduce vertical padding to ~52px total,
  using max(8px, safe-area-inset-bottom) so the inset isn't double-counted.
- Hide the lyrics disclaimer on the Bible reader route.
- Halve the Bible reader page's bottom padding.