### PR TITLE
Add SendIcon export to Icons component

### DIFF
--- a/src/components/Icons.jsx
+++ b/src/components/Icons.jsx
@@ -33,6 +33,7 @@ import {
   Play,
   Pause,
   RotateCcw,
+  Send,
 } from 'lucide-react'
 
 const DEFAULT_SIZE = 18
@@ -77,3 +78,4 @@ export const HomeIcon = wrap(Home)
 export const PlayIcon = wrap(Play)
 export const PauseIcon = wrap(Pause)
 export const ResetIcon = wrap(RotateCcw)
+export const SendIcon = wrap(Send)


### PR DESCRIPTION
## Summary
Adds a new `SendIcon` export to the Icons component by importing the `Send` icon from lucide-react and wrapping it with the existing icon wrapper utility.

## Changes
- Import `Send` icon from lucide-react
- Export `SendIcon` as a wrapped icon component following the existing pattern

## Implementation Details
The change follows the established convention in the Icons component where lucide-react icons are imported and re-exported as wrapped components (e.g., `HomeIcon`, `PlayIcon`, `PauseIcon`, `ResetIcon`). The `SendIcon` is now available for use throughout the application with consistent styling and sizing via the wrapper function.

https://claude.ai/code/session_01Mb3HRbtDznriU76Uk1iLiK