### PR TITLE
fix(readings): bust ReadingsPage CSS hash to force CF Pages re-upload

### DIFF
--- a/src/features/readings/readings.css
+++ b/src/features/readings/readings.css
@@ -1,4 +1,5 @@
 .readings-page{
+  --readings-asset-rev: 2;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
The deployed ReadingsPage-BBF6f_NI.css asset has been returning a blank 500 from Cloudflare Pages origin since the previous mobile CSS commit, even though the build output is well-formed. CF Pages dedupes asset uploads by content hash and has been short-circuiting on this blob ever since (every deploy log shows it as "already uploaded"), so cache purges and redeploys can't replace the bad object.

Adding a no-op custom property changes the minified-output hash, which forces Pages to upload a fresh blob under a new asset name.