### PR TITLE
fix(readings): stop clipping chip tops on desktop

### DIFF
--- a/src/features/readings/readings.css
+++ b/src/features/readings/readings.css
@@ -1,5 +1,4 @@
 .readings-page{
-  --readings-asset-rev: 2;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
@@ -113,7 +112,7 @@
 
 .readings-list{
   list-style:none;
-  padding:0;
+  padding: 4px 0;
   margin:0;
   display:flex;
   flex-wrap: nowrap;


### PR DESCRIPTION
.readings-list uses overflow-x: auto for horizontal scroll, which the browser pairs with an implicit overflow-y, clipping the top of the chips by a sub-pixel. Add 4px vertical padding inside the list so the pills have clearance within the scroll viewport. Mobile overrides overflow-x to visible already, so behavior there is unchanged.

Also drop the temporary --readings-asset-rev custom property added to force a CF Pages re-upload; this commit changes the CSS hash naturally.