### PR TITLE
Fix mobile tab overflow and improve text truncation

### DIFF
--- a/src/components/ui/layout-kit/layout-kit.css
+++ b/src/components/ui/layout-kit/layout-kit.css
@@ -348,11 +348,18 @@
     margin: 8px 0 6px;
   }
   .gc-mobile-pane-tabs .gc-segmented{
+    display:flex;
     width:100%;
   }
   .gc-mobile-pane-tabs .gc-segmented__item{
     flex:1 1 0;
+    min-width:0;
+    padding-left: 8px;
+    padding-right: 8px;
     justify-content:center;
+    white-space:nowrap;
+    overflow:hidden;
+    text-overflow:ellipsis;
   }
 }
 


### PR DESCRIPTION
## Summary
Improved the mobile pane tabs layout to properly handle overflow and text truncation when tab labels are too long for the available space.

## Key Changes
- Added `display: flex` to `.gc-segmented` to ensure proper flex container behavior
- Added `min-width: 0` to `.gc-segmented__item` to allow flex items to shrink below content size
- Added horizontal padding (8px left/right) to `.gc-segmented__item` for better spacing
- Added `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` to `.gc-segmented__item` to truncate long tab labels with ellipsis

## Implementation Details
These changes ensure that tab labels in the mobile pane will gracefully truncate with an ellipsis when they exceed the available width, rather than breaking the layout or overflowing. The `min-width: 0` is particularly important for flex items to respect the text truncation rules.

https://claude.ai/code/session_01K9JJDxLKzQ5n9okCu2EQaa