### PR TITLE
Redesign drawer profile and settings UI with full-width controls

### DIFF
--- a/src/components/Icons.jsx
+++ b/src/components/Icons.jsx
@@ -34,6 +34,9 @@ import {
   Pause,
   RotateCcw,
   Send,
+  Globe,
+  ChevronRight,
+  LogOut,
 } from 'lucide-react'
 
 const DEFAULT_SIZE = 18
@@ -79,3 +82,6 @@ export const PlayIcon = wrap(Play)
 export const PauseIcon = wrap(Pause)
 export const ResetIcon = wrap(RotateCcw)
 export const SendIcon = wrap(Send)
+export const GlobeIcon = wrap(Globe)
+export const ChevronRightIcon = wrap(ChevronRight)
+export const LogOutIcon = wrap(LogOut)

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { Link, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import OfflineBadge from '../OfflineBadge'
-import { GearIcon } from '../Icons'
+import { GearIcon, ChevronRightIcon, LogOutIcon } from '../Icons'
 import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
 import SpriteAvatar from './SpriteAvatar'
@@ -302,22 +302,24 @@ export default function Navbar(){
               {/* Auth slot — mobile */}
               {!authLoading && (
                 isLoggedIn ? (
-                  <div style={{ marginTop: 12 }}>
+                  <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
                     <Link
                       to="/profile"
-                      className="gc-btn gc-btn--secondary"
+                      className="gc-btn gc-btn--secondary gc-profile-link"
                       onClick={closeDrawer}
-                      style={{ width: '100%', justifyContent: 'center', display: 'flex', alignItems: 'center', gap: 8 }}
                     >
                       <SpriteAvatar sprite={profile?.preferences?.sprite} size="sm" />
-                      <span>{profile?.display_name || t('profile')}</span>
+                      <span className="gc-profile-link__label">{profile?.display_name || t('profile')}</span>
+                      <ChevronRightIcon className="gc-profile-link__chevron" />
                     </Link>
                     <button
                       type="button"
-                      className="gc-signout-link"
+                      className="gc-btn gc-btn--destructive"
+                      style={{ width: '100%', justifyContent: 'center' }}
                       onClick={async () => { await handleSignOut(); closeDrawer() }}
                     >
-                      {t('signOut')}
+                      <LogOutIcon />
+                      <span>{t('signOut')}</span>
                     </button>
                   </div>
                 ) : (

--- a/src/components/ui/SettingsCluster.jsx
+++ b/src/components/ui/SettingsCluster.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSettings } from '../../hooks/useSettings'
 import { useLocale } from '../../hooks/useLocale'
-import { Sun, Moon } from '../Icons'
+import { Sun, Moon, GlobeIcon } from '../Icons'
 
 export function PillToggle({
   leftContent,
@@ -39,12 +39,12 @@ export function ThemeSwitch({ className }) {
   const isDark = theme === 'dark'
   return (
     <PillToggle
-      leftContent={<Sun width={16} height={16} />}
-      rightContent={<Moon width={16} height={16} />}
+      leftContent={<><Sun width={16} height={16} /><span>{t('light')}</span></>}
+      rightContent={<><Moon width={16} height={16} /><span>{t('dark')}</span></>}
       value={isDark ? 'right' : 'left'}
       onChange={toggleTheme}
       ariaLabel={t('toggleDarkMode')}
-      variant="icon"
+      variant="icon-text"
       className={className}
     />
   )
@@ -72,6 +72,7 @@ export function LocalePicker({ className = '' }) {
   const { t } = useTranslation('common')
   return (
     <div className={`gc-locale-picker ${className}`}>
+      <GlobeIcon className="gc-locale-picker__icon" width={16} height={16} aria-hidden="true" />
       <select
         value={language}
         onChange={(e) => setLanguage(e.target.value)}

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -16,9 +16,12 @@
 .gc-settings-cluster--column > * {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   min-height: 44px;
+  width: 100%;
 }
+.gc-settings-cluster--column .gc-pill-toggle { width: 100%; }
+.gc-settings-cluster--column .gc-pill-toggle__track { width: 100%; }
+.gc-settings-cluster--column .gc-locale-picker { width: 100%; }
 
 /* ---------- Pill toggle (theme + chord style) ----------
    iOS-style segmented control. Track holds both options at fixed
@@ -85,6 +88,21 @@
 .gc-pill-toggle--icon .gc-pill-toggle__track { min-width: 76px; }
 .gc-pill-toggle--icon .gc-pill-toggle__option { min-width: 36px; height: 100%; }
 
+/* Icon + text variant — used for theme toggle in the drawer (Sun "Light" / Moon "Dark") */
+.gc-pill-toggle--icon-text .gc-pill-toggle__track {
+  height: 40px;
+  min-width: 160px;
+}
+.gc-pill-toggle--icon-text .gc-pill-toggle__option {
+  gap: 6px;
+  padding: 0 12px;
+  font-size: var(--gc-font-sub);
+  font-weight: 500;
+  font-family: var(--gc-font-family);
+  white-space: nowrap;
+  height: 100%;
+}
+
 /* Text variant — wider, used for chord style (ABC / DoReMi) */
 .gc-pill-toggle--text .gc-pill-toggle__option {
   min-width: 56px;
@@ -107,6 +125,14 @@
   display: inline-flex;
   align-items: center;
 }
+.gc-locale-picker__icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--gc-text-secondary);
+  pointer-events: none;
+}
 .gc-locale-picker__select {
   appearance: none;
   -webkit-appearance: none;
@@ -116,7 +142,7 @@
   border-radius: var(--radius-pill);
   font: 500 13px/1 var(--gc-font-family);
   height: 28px;
-  padding: 0 12px;
+  padding: 0 12px 0 34px;
   cursor: pointer;
   transition: background var(--gc-dur-quick) var(--gc-ease), border-color var(--gc-dur-quick) var(--gc-ease);
 }
@@ -180,28 +206,27 @@
 /* ---------- Drawer overrides ---------- */
 
 .gc-drawer .gc-settings-cluster { width: 100%; }
-.gc-drawer .gc-locale-picker { width: auto; max-width: 140px; }
+.gc-drawer .gc-locale-picker { width: 100%; }
 .gc-drawer .gc-locale-picker__select {
   width: 100%;
-  max-width: 140px;
-  height: 36px;
-  text-align: right;
-  text-align-last: right;
+  height: 40px;
+  text-align: left;
+  text-align-last: left;
 }
 
-/* Sign Out gets a quieter, secondary treatment */
-.gc-drawer .gc-signout-link {
-  display: block;
-  text-align: center;
-  margin-top: var(--space-2);
-  padding: var(--space-2);
-  background: none;
-  border: none;
-  color: var(--gc-text-secondary);
-  font-size: var(--gc-font-sub);
-  font-family: var(--gc-font-family);
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 3px;
+/* Profile button in the drawer: full-width with avatar on the left and chevron on the right. */
+.gc-drawer .gc-profile-link {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  justify-content: flex-start;
 }
-.gc-drawer .gc-signout-link:hover { color: var(--gc-danger); }
+.gc-drawer .gc-profile-link__label {
+  flex: 1 1 auto;
+  text-align: left;
+}
+.gc-drawer .gc-profile-link__chevron {
+  color: var(--gc-text-secondary);
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
## Summary
Refactors the drawer's authentication and settings UI to use full-width, left-aligned controls with improved visual hierarchy and consistency. Updates the theme toggle to display icon + text labels, and redesigns the profile link and sign-out button for better mobile UX.

## Key Changes

- **Settings cluster layout**: Removed `justify-content: flex-end` and added `width: 100%` to make child elements full-width; added explicit width rules for pill toggles and locale picker
- **Theme toggle variant**: Added new `icon-text` variant for pill toggles with 40px height, 160px min-width, and 6px gap between icon and label text
- **Locale picker**: 
  - Added globe icon positioned absolutely on the left (12px from edge)
  - Updated padding to accommodate icon (`0 12px 0 34px`)
  - Changed drawer overrides from `width: auto; max-width: 140px` to `width: 100%`
  - Changed text alignment from right to left
- **Profile link in drawer**:
  - Converted from centered button to full-width flex container with `justify-content: flex-start`
  - Added avatar on left, label in center (flex: 1), and new chevron icon on right
  - Styled with `gc-profile-link` class and subcomponents for label and chevron
- **Sign-out button**:
  - Changed from quiet secondary link to prominent `gc-btn--destructive` button
  - Added LogOutIcon alongside text
  - Positioned in flex column with profile link (gap: var(--space-2))
- **Icon exports**: Added `GlobeIcon`, `ChevronRightIcon`, and `LogOutIcon` from lucide-react

## Implementation Details
- Theme toggle now uses `variant="icon-text"` with localized labels ('light'/'dark')
- Profile section uses flexbox column layout with consistent spacing
- All drawer controls now respect full-width container with proper alignment
- Icon positioning uses absolute positioning with `translateY(-50%)` for vertical centering

https://claude.ai/code/session_01Rhgqd31ujtnR2AKh44vLLG