### PR TITLE
Remove users embed from post queries due to RLS policy issue

### DIFF
--- a/src/hooks/usePosts.jsx
+++ b/src/hooks/usePosts.jsx
@@ -19,10 +19,15 @@ export async function fetchPosts({ status } = {}) {
   return query
 }
 
+// NOTE: the `users(display_name)` embed is intentionally omitted. The users
+// table has an RLS policy that calls `get_user_role()` unqualified, and that
+// helper was hardened with `SET search_path = ''`, so name resolution fails
+// during the embed and PostgREST 404s the whole query. Restore the embed once
+// the users policies are rewritten to use `public.get_user_role()`.
 export async function fetchPublishedPostsWithAuthors() {
   return supabase
     .from('posts')
-    .select('id, title, slug, excerpt, tags, published_at, author_id, users(display_name)')
+    .select('id, title, slug, excerpt, tags, published_at, author_id')
     .eq('status', 'published')
     .order('published_at', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
@@ -31,7 +36,7 @@ export async function fetchPublishedPostsWithAuthors() {
 export async function fetchPostBySlug(slug) {
   return supabase
     .from('posts')
-    .select('*, users(display_name)')
+    .select('*')
     .eq('slug', slug)
     .single()
 }


### PR DESCRIPTION
## Summary
Removed the `users(display_name)` embed from post queries to work around a PostgREST 404 error caused by an RLS policy that calls an unqualified function.

## Changes
- **fetchPublishedPostsWithAuthors()**: Removed `users(display_name)` from the select clause
- **fetchPostBySlug()**: Removed `users(display_name)` from the select clause
- Added explanatory comment documenting the issue and the path to restore the embed

## Implementation Details
The users table has an RLS policy that calls `get_user_role()` without schema qualification. This function was hardened with `SET search_path = ''`, which causes name resolution to fail during the embed operation, resulting in PostgREST returning a 404 for the entire query.

The embed can be restored once the users RLS policies are rewritten to use the fully qualified `public.get_user_role()` function name.

https://claude.ai/code/session_01DxtQkH2k8zw2gykaJsPixY