### PR TITLE
Share auth session across gracechords.com subdomains (cross-site SSO)

### DIFF
--- a/src/lib/cookieStorage.js
+++ b/src/lib/cookieStorage.js
@@ -1,0 +1,98 @@
+// Cookie-backed storage adapter for the Supabase auth client.
+//
+// By default supabase-js persists the session in localStorage, which is
+// isolated per-origin — so a login on gracechords.com is invisible to
+// tracks.gracechords.com and vice-versa. Storing the session in a cookie
+// scoped to the parent domain (`.gracechords.com`) instead makes it visible to
+// every subdomain, giving single sign-on across both sites (and shared
+// sign-out). Supabase sessions can exceed the ~4KB per-cookie limit, so values
+// are split across numbered chunk cookies and reassembled on read.
+//
+// IMPORTANT: this file must stay byte-for-byte equivalent in the GraceTracks
+// repo (src/lib/cookieStorage.js). Both apps share the Supabase project ref, so
+// they derive the same default storage key and read the same cookie.
+//
+// Security note: like localStorage, these cookies are readable by page JS
+// (not httpOnly) — there is no shared backend to issue httpOnly cookies for a
+// pure SPA, so this is the same exposure as the previous localStorage setup.
+
+const MAX_CHUNK = 3000 // chars per cookie, comfortably under the ~4KB limit
+const COOKIE_DAYS = 400 // browsers cap persistent cookies near this
+
+const hasDocument = typeof document !== 'undefined'
+
+function parentDomainAttr() {
+  if (typeof location === 'undefined') return ''
+  // Only pin to the shared parent domain on gracechords.com hosts; on localhost
+  // / preview deploys fall back to a host-only cookie so dev still works.
+  return /(^|\.)gracechords\.com$/.test(location.hostname) ? '; domain=.gracechords.com' : ''
+}
+
+function secureAttr() {
+  if (typeof location === 'undefined') return ''
+  return location.protocol === 'https:' ? '; Secure' : ''
+}
+
+function writeCookie(name, value) {
+  const maxAge = COOKIE_DAYS * 24 * 60 * 60
+  document.cookie =
+    `${name}=${encodeURIComponent(value)}; path=/${parentDomainAttr()}` +
+    `; max-age=${maxAge}; SameSite=Lax${secureAttr()}`
+}
+
+function deleteCookie(name) {
+  document.cookie =
+    `${name}=; path=/${parentDomainAttr()}; max-age=0; SameSite=Lax${secureAttr()}`
+}
+
+function readAllCookies() {
+  const out = {}
+  if (!hasDocument || !document.cookie) return out
+  for (const part of document.cookie.split('; ')) {
+    const idx = part.indexOf('=')
+    if (idx === -1) continue
+    out[part.slice(0, idx)] = decodeURIComponent(part.slice(idx + 1))
+  }
+  return out
+}
+
+export const cookieStorage = {
+  getItem(key) {
+    const all = readAllCookies()
+    if (all[`${key}.0`] !== undefined) {
+      let i = 0
+      let value = ''
+      while (all[`${key}.${i}`] !== undefined) {
+        value += all[`${key}.${i}`]
+        i++
+      }
+      return value
+    }
+    return all[key] ?? null
+  },
+
+  setItem(key, value) {
+    if (!hasDocument) return
+    // Clear any previous representation (single ⇄ chunked) before writing.
+    this.removeItem(key)
+    if (value.length <= MAX_CHUNK) {
+      writeCookie(key, value)
+      return
+    }
+    const chunks = Math.ceil(value.length / MAX_CHUNK)
+    for (let i = 0; i < chunks; i++) {
+      writeCookie(`${key}.${i}`, value.slice(i * MAX_CHUNK, (i + 1) * MAX_CHUNK))
+    }
+  },
+
+  removeItem(key) {
+    if (!hasDocument) return
+    const all = readAllCookies()
+    deleteCookie(key)
+    let i = 0
+    while (all[`${key}.${i}`] !== undefined) {
+      deleteCookie(`${key}.${i}`)
+      i++
+    }
+  },
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,6 +1,19 @@
 import { createClient } from '@supabase/supabase-js'
+import { cookieStorage } from './cookieStorage'
 
+// Persist the auth session in a cookie scoped to `.gracechords.com` so the login
+// is shared across gracechords.com and tracks.gracechords.com (single sign-on).
+// storageKey is left at the supabase default — derived from the shared project
+// ref — so both apps read the same cookie.
 export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      storage: cookieStorage,
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
+  }
 )


### PR DESCRIPTION
## Summary

Stores the Supabase auth session in a cookie scoped to `.gracechords.com` instead of per-origin `localStorage`, so a login on gracechords.com is shared with tracks.gracechords.com (single sign-on), and sign-out propagates across both.

## Changes
- `src/lib/cookieStorage.js` (new) — cookie-backed Supabase storage adapter, scoped to `.gracechords.com`, with chunking for sessions larger than the ~4KB cookie limit. Falls back to host-only cookies off the gracechords.com domain so local dev/preview still works.
- `src/lib/supabase.js` — pass the adapter via `auth.storage` (default `storageKey` retained so both apps read the same cookie).

## Pairs with
- GraceTracks PR (same change on its Supabase client). **Both must deploy together** for SSO to work; deploying only one leaves the two apps reading different storage.

## Notes / caveats
- One-time re-login expected after deploy (session moves from localStorage to cookie).
- Security: like localStorage, these cookies are page-JS readable (not httpOnly) — a pure SPA has no shared backend to issue httpOnly cookies, so exposure is unchanged from before.

## Verification
- `npx vite build` clean; `vitest run src/hooks/__tests__/useAuth.test.jsx` passes (2/2).

https://claude.ai/code/session_016c88QZWsagDyqDY8914Fo1

---
_Generated by [Claude Code](https://claude.ai/code/session_016c88QZWsagDyqDY8914Fo1)_