### PR TITLE
Fix Admin Portal by allowing admins to read all users

### DIFF
--- a/supabase/migrations/20260609000000_admin_read_all_users.sql
+++ b/supabase/migrations/20260609000000_admin_read_all_users.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- GraceChords: Allow admins/owners to read all users (Admin Portal fix)
+--
+-- Symptom: the Admin Portal showed "No users found" for admins and owners.
+-- The base SELECT policy on public.users (created in the dashboard) only
+-- exposes the caller's own row (id = auth.uid()), which is correct for the
+-- profile page but hides every other account from admin tooling.
+--
+-- Fix: ADD a permissive SELECT policy so anyone at admin rank or above can
+-- read all rows. RLS permissive policies are OR'd together, so the existing
+-- self-read policy is left untouched — regular users still see only their own
+-- profile, and the profile page keeps working.
+--
+-- Safety: public.has_min_role() is SECURITY DEFINER and reads public.users with
+-- the definer's privileges, so referencing it in a policy on public.users does
+-- NOT cause RLS recursion.
+-- =============================================================================
+
+alter table public.users enable row level security;
+
+drop policy if exists "Admins can view all users" on public.users;
+
+create policy "Admins can view all users"
+  on public.users for select
+  using (public.has_min_role('admin'));


### PR DESCRIPTION
## Summary
Adds a row-level security (RLS) policy to allow admins and owners to view all user records in the `public.users` table. This fixes the Admin Portal showing "No users found" for admin-level accounts.

## Changes
- Added migration `20260609000000_admin_read_all_users.sql` that:
  - Creates a new permissive SELECT policy on `public.users` for users with admin rank or above
  - Uses the existing `public.has_min_role('admin')` function to check authorization
  - Preserves the existing self-read policy so regular users continue to see only their own profile

## Implementation Details
- The policy uses a permissive approach (OR'd with existing policies) rather than replacing the base policy, ensuring backward compatibility
- `public.has_min_role()` is SECURITY DEFINER, preventing RLS recursion when referenced in policies on the same table
- The existing self-read policy remains unchanged, keeping the profile page functional for all users

https://claude.ai/code/session_01A3ozg4u7zFZZrLxmjRqXyC