### PR TITLE
Fix Admin Portal user list 404: re-qualify RLS helper functions

### DIFF
--- a/supabase/migrations/20260609000000_admin_read_all_users.sql
+++ b/supabase/migrations/20260609000000_admin_read_all_users.sql
@@ -1,25 +1,57 @@
 -- =============================================================================
--- GraceChords: Allow admins/owners to read all users (Admin Portal fix)
+-- GraceChords: Fix Admin Portal user list — repair RLS helper functions
 --
--- Symptom: the Admin Portal showed "No users found" for admins and owners.
--- The base SELECT policy on public.users (created in the dashboard) only
--- exposes the caller's own row (id = auth.uid()), which is correct for the
--- profile page but hides every other account from admin tooling.
+-- Symptom: GET /rest/v1/users (the Admin Portal user list) failed with HTTP 404
+--   { code: 42883, message: "function get_user_role() does not exist" }
+-- while the profile page (a single-row read filtered by id = auth.uid()) worked.
 --
--- Fix: ADD a permissive SELECT policy so anyone at admin rank or above can
--- read all rows. RLS permissive policies are OR'd together, so the existing
--- self-read policy is left untouched — regular users still see only their own
--- profile, and the profile page keeps working.
+-- Root cause: the live public.has_min_role() / public.get_user_role() bodies
+-- were defined with `SET search_path = ''` but referenced each other (and
+-- auth.uid() / public.users) WITHOUT schema qualification. Under an empty
+-- search_path an unqualified `get_user_role()` cannot resolve, raising 42883.
+-- The full-table admin scan forces has_min_role('admin') to be evaluated for
+-- rows where id <> auth.uid(); the profile read short-circuits on id = auth.uid()
+-- and never hits the broken function, which is why only the admin list failed.
 --
--- Safety: public.has_min_role() is SECURITY DEFINER and reads public.users with
--- the definer's privileges, so referencing it in a policy on public.users does
--- NOT cause RLS recursion.
+-- Fix: re-create both helpers with fully schema-qualified bodies (matching
+-- supabase/migrations/20260313_fix_function_search_paths.sql, which the live
+-- DB had drifted from). search_path stays '' for the Advisor 0011 lint.
+--
+-- Also drop the redundant "Admins can view all users" SELECT policy added in an
+-- earlier revision of this migration: the pre-existing `users_select` policy
+-- ((id = auth.uid()) OR has_min_role('admin')) already grants admin read access.
 -- =============================================================================
 
-alter table public.users enable row level security;
+CREATE OR REPLACE FUNCTION public.get_user_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT role FROM public.users WHERE id = auth.uid();
+$$;
 
-drop policy if exists "Admins can view all users" on public.users;
+CREATE OR REPLACE FUNCTION public.has_min_role(min_role text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT CASE public.get_user_role()
+    WHEN 'owner'        THEN true
+    WHEN 'admin'        THEN min_role IN ('admin','editor','collaborator','user')
+    WHEN 'editor'       THEN min_role IN ('editor','collaborator','user')
+    WHEN 'collaborator' THEN min_role IN ('collaborator','user')
+    WHEN 'user'         THEN min_role = 'user'
+    ELSE false
+  END;
+$$;
 
-create policy "Admins can view all users"
-  on public.users for select
-  using (public.has_min_role('admin'));
+-- Helpers are invoked during RLS evaluation, so the caller needs EXECUTE.
+GRANT EXECUTE ON FUNCTION public.get_user_role()    TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.has_min_role(text) TO anon, authenticated;
+
+-- Remove the redundant policy added earlier; users_select already covers admins.
+DROP POLICY IF EXISTS "Admins can view all users" ON public.users;


### PR DESCRIPTION
## Summary

Fixes the Admin Portal user list, which failed with an HTTP 404 / `{ code: 42883, message: "function get_user_role() does not exist" }` while the profile page worked fine.

This supersedes #325, which merged an earlier (incorrect) version of the migration. That version added a redundant `Admins can view all users` SELECT policy — but the diagnostic showed the existing `users_select` policy (`(id = auth.uid()) OR has_min_role('admin')`) already granted admin read access, so RLS was never the cause. This PR replaces that no-op with the real fix and drops the redundant policy.

## Root cause

`public.has_min_role()` / `public.get_user_role()` are defined with `SET search_path = ''`, but the **live** bodies referenced `get_user_role()` (and `auth.uid()` / `public.users`) **without** schema qualification. Under an empty search_path the unqualified name can't resolve, raising SQLSTATE `42883`, which PostgREST surfaces as a 404.

- The **profile** read filters `id = eq.<uid>`; that row matches `id = auth.uid()`, the `OR` short-circuits, and `has_min_role()` is never evaluated — so it worked.
- The **admin list** scans all rows; for rows where `id <> auth.uid()` it must evaluate `has_min_role('admin')`, which tripped the unresolved function.

The repo's `20260313_fix_function_search_paths.sql` already qualifies these calls (`public.get_user_role()`); the live DB had drifted from it, likely via a dashboard edit.

## Changes

`supabase/migrations/20260609000000_admin_read_all_users.sql`:
- Re-create `get_user_role()` and `has_min_role()` with fully schema-qualified bodies (`search_path = ''` retained for Advisor lint 0011).
- Re-grant `EXECUTE` on both helpers to `anon, authenticated` (needed for RLS evaluation).
- Drop the redundant `Admins can view all users` policy introduced in #325.

## Verification

In the Supabase SQL editor, `select public.has_min_role('admin');` errored with `42883` before and returns cleanly after. End-to-end: apply the migration, refresh the Admin Portal, and the user list loads.

https://claude.ai/code/session_01A3ozg4u7zFZZrLxmjRqXyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3ozg4u7zFZZrLxmjRqXyC)_