### PR TITLE
Remove GraceTracks fields from song editor forms

### DIFF
--- a/src/components/editor/SongEditorForm.jsx
+++ b/src/components/editor/SongEditorForm.jsx
@@ -509,37 +509,7 @@ export default function SongEditorForm({ values, onChange, disabled, validationE
         )}
       </div>
 
-      {/* Row 7: GraceTracks Stem Slug (full) */}
-      <div className="gc-song-editor-form__field gc-song-editor-form__field--full">
-        <label className="gc-song-editor-form__label" htmlFor="sef-stem-slug">GraceTracks Stem Slug</label>
-        <input
-          id="sef-stem-slug"
-          className="gc-song-editor-form__input"
-          type="text"
-          value={values.stem_slug || ''}
-          onChange={e => handleChange('stem_slug', e.target.value)}
-          disabled={disabled}
-          placeholder="R2 folder name — leave blank to use song slug"
-        />
-        <p className="gc-song-editor-form__helper">R2 folder name — leave blank to use song slug</p>
-      </div>
-
-      {/* Row 8: GraceTracks URL (full) */}
-      <div className="gc-song-editor-form__field gc-song-editor-form__field--full">
-        <label className="gc-song-editor-form__label" htmlFor="sef-gracetracks-url">GraceTracks URL</label>
-        <input
-          id="sef-gracetracks-url"
-          className="gc-song-editor-form__input"
-          type="text"
-          value={values.gracetracks_url || ''}
-          onChange={e => handleChange('gracetracks_url', e.target.value)}
-          disabled={disabled}
-          placeholder="Full URL e.g. tracks.gracechords.com/song/slug"
-        />
-        <p className="gc-song-editor-form__helper">Full URL e.g. tracks.gracechords.com/song/slug</p>
-      </div>
-
-      {/* Row 9: PPTX (full) */}
+      {/* Row 7: PPTX (full) */}
       <div className="gc-song-editor-form__field gc-song-editor-form__field--full">
         <label className="gc-song-editor-form__label">Lyric PPT File</label>
         <PptxWidget

--- a/src/components/editor/mobile/MobileDetailsTab.jsx
+++ b/src/components/editor/mobile/MobileDetailsTab.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 
 const TIME_SIGNATURES = ['4/4', '3/4', '2/4', '6/8']
 const LANGUAGE_OPTIONS = ['', 'English', 'Turkish', 'Spanish', 'Arabic', 'Korean', 'Other']
@@ -18,7 +18,6 @@ function normalizeYoutubeInput(raw) {
 }
 
 export default function MobileDetailsTab({ values, onChange }) {
-  const [showAdvanced, setShowAdvanced] = useState(false)
   const tapTimestamps = useRef([])
   const tapTimeout = useRef(null)
 
@@ -133,49 +132,6 @@ export default function MobileDetailsTab({ values, onChange }) {
           autoCapitalize="none"
           autoCorrect="off"
         />
-      </div>
-
-      {/* Advanced */}
-      <div className="gc-me-advanced">
-        <button
-          type="button"
-          className="gc-me-advanced__toggle"
-          onClick={() => setShowAdvanced(v => !v)}
-          aria-expanded={showAdvanced}
-        >
-          <span>{showAdvanced ? '▼' : '▶'}</span> Advanced (GraceTracks / PPTX)
-        </button>
-        {showAdvanced && (
-          <div className="gc-me-advanced__content">
-            <div className="gc-me-field">
-              <label className="gc-me-label" htmlFor="me-stem">GraceTracks Stem Slug</label>
-              <input
-                id="me-stem"
-                className="gc-me-input"
-                type="text"
-                value={values.stem_slug || ''}
-                onChange={e => onChange({ ...values, stem_slug: e.target.value })}
-                placeholder="R2 folder override (leave blank = song slug)"
-                autoCapitalize="none"
-                autoCorrect="off"
-              />
-            </div>
-            <div className="gc-me-field">
-              <label className="gc-me-label" htmlFor="me-tracks">GraceTracks URL</label>
-              <input
-                id="me-tracks"
-                className="gc-me-input"
-                type="url"
-                value={values.gracetracks_url || ''}
-                onChange={e => onChange({ ...values, gracetracks_url: e.target.value })}
-                placeholder="https://tracks.gracechords.com/…"
-                inputMode="url"
-                autoCapitalize="none"
-                autoCorrect="off"
-              />
-            </div>
-          </div>
-        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Removes GraceTracks-related form fields (`stem_slug` and `gracetracks_url`) from both the mobile and desktop song editor interfaces, along with the associated advanced section toggle in the mobile view.

## Changes
- **MobileDetailsTab.jsx**: Removed the "Advanced" collapsible section that contained GraceTracks Stem Slug and GraceTracks URL inputs, along with the `showAdvanced` state management
- **SongEditorForm.jsx**: Removed the two full-width form fields for GraceTracks Stem Slug and GraceTracks URL from the desktop editor
- Cleaned up unused `useState` import in MobileDetailsTab

## Notes
These fields are being deprecated from the user-facing editor UI. The underlying data model fields remain intact in case they're needed for backend operations or future restoration.

https://claude.ai/code/session_017GypMwSoxdhFREyuLbMEy6