### PR TITLE
Increase height of toggle track and locale picker in settings

### DIFF
--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -20,8 +20,14 @@
   width: 100%;
 }
 .gc-settings-cluster--column .gc-pill-toggle { width: 100%; }
-.gc-settings-cluster--column .gc-pill-toggle__track { width: 100%; }
+.gc-settings-cluster--column .gc-pill-toggle__track { width: 100%; height: 40px; }
 .gc-settings-cluster--column .gc-locale-picker { width: 100%; }
+.gc-settings-cluster--column .gc-locale-picker__select {
+  width: 100%;
+  height: 40px;
+  text-align: left;
+  text-align-last: left;
+}
 
 /* ---------- Pill toggle (theme + chord style) ----------
    iOS-style segmented control. Track holds both options at fixed


### PR DESCRIPTION
## Summary
Increased the height of the pill toggle track and locale picker select elements in the settings cluster column layout to improve touch target size and usability.

## Changes
- **Pill toggle track**: Added `height: 40px` to `.gc-settings-cluster--column .gc-pill-toggle__track`
- **Locale picker select**: Added new styles to `.gc-settings-cluster--column .gc-locale-picker__select`:
  - Set `height: 40px` for consistent sizing with the toggle track
  - Added `text-align: left` and `text-align-last: left` for proper text alignment

## Implementation Details
Both interactive elements now have a minimum height of 40px, which aligns with common accessibility guidelines for touch targets and provides better visual consistency across the settings interface.

https://claude.ai/code/session_01XMkv7DBJHhh1RgCi2EHweu