### PR TITLE
Migrate song data from static JSON to Supabase via useSongs hook

### DIFF
--- a/src/__tests__/home.listbox.test.jsx
+++ b/src/__tests__/home.listbox.test.jsx
@@ -3,16 +3,21 @@ import userEvent from '@testing-library/user-event'
 import { HashRouter } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import HomeDashboard from '../pages/HomeDashboardPage.jsx'
 
-vi.mock('../data/index.json', () => ({
-  default: {
-    items: [
-      { id: 'alpha', title: 'Alpha Song', tags: [], authors: [] },
-      { id: 'alabaster', title: 'Alabaster Praise', tags: [], authors: [] }
-    ]
-  }
+// Song data comes from Supabase via useSongs(), not the deprecated
+// src/data/index.json. Mock the hook to supply the search corpus.
+const songMock = vi.hoisted(() => ({
+  songs: [
+    { dbId: 's1', id: 'alpha', songId: 'alpha', title: 'Alpha Song', language: 'en', originalKey: 'C', tags: [], authors: [], chordpro_content: 'title: Alpha Song\n' },
+    { dbId: 's2', id: 'alabaster', songId: 'alabaster', title: 'Alabaster Praise', language: 'en', originalKey: 'C', tags: [], authors: [], chordpro_content: 'title: Alabaster Praise\n' },
+  ],
 }))
+
+vi.mock('../hooks/useSongs', () => ({
+  useSongs: () => ({ songs: songMock.songs, loading: false }),
+}))
+
+import HomeDashboard from '../pages/HomeDashboardPage.jsx'
 
 describe('Home search accessibility', () => {
   beforeEach(() => {

--- a/src/__tests__/routing.smoke.test.jsx
+++ b/src/__tests__/routing.smoke.test.jsx
@@ -29,7 +29,10 @@ describe('Routing smoke', () => {
     expect(await screen.findByRole('button', { name: /download pdf/i })).toBeInTheDocument()
   })
 
-  test('admin route renders (with gate present)', async () => {
+  test('admin route is gated — anonymous users are redirected home', async () => {
+    // /admin is wrapped in <RoleGuard minRole="admin">. With no authenticated
+    // session the guard redirects to "/" instead of rendering the admin page,
+    // so the home Search field should appear and no admin content is shown.
     window.location.hash = '#/admin'
     render(
       <HelmetProvider>
@@ -38,7 +41,6 @@ describe('Routing smoke', () => {
         </HashRouter>
       </HelmetProvider>
     )
-    // Gate uses a placeholder instead of a label
-    expect(await screen.findByPlaceholderText(/password/i)).toBeInTheDocument()
+    expect(await screen.findByLabelText(/search/i)).toBeInTheDocument()
   })
 })

--- a/src/__tests__/songbook.filters.test.jsx
+++ b/src/__tests__/songbook.filters.test.jsx
@@ -1,6 +1,23 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+// Song data comes from Supabase via useSongs(), not the deprecated
+// src/data/index.json. Mock the hook to supply the searchable corpus.
+const songMock = vi.hoisted(() => ({
+  songs: [
+    { dbId: 's1', id: '10000-reasons', songId: '10000-reasons', title: '10,000 Reasons', language: 'en', originalKey: 'C', tags: [], authors: ['Matt Redman'], chordpro_content: 'title: 10,000 Reasons\n' },
+    { dbId: 's2', id: 'heart-of-worship', songId: 'heart-of-worship', title: 'Heart of Worship', language: 'en', originalKey: 'C', tags: [], authors: ['Matt Redman'], chordpro_content: 'title: Heart of Worship\n' },
+    { dbId: 's3', id: 'holy-forever', songId: 'holy-forever', title: 'Holy Forever', language: 'en', originalKey: 'C', tags: [], authors: ['Chris Tomlin'], chordpro_content: 'title: Holy Forever\n' },
+    { dbId: 's4', id: 'abba', songId: 'abba', title: 'Abba', language: 'en', originalKey: 'Am', tags: [], authors: ['Other Writer'], chordpro_content: 'title: Abba\n' },
+  ],
+}))
+
+vi.mock('../hooks/useSongs', () => ({
+  useSongs: () => ({ songs: songMock.songs, loading: false }),
+}))
+
 import Songbook from '../pages/SongbookPage.jsx'
 
 function setViewport(width){

--- a/src/components/__tests__/songTranslations.ui.test.jsx
+++ b/src/components/__tests__/songTranslations.ui.test.jsx
@@ -4,86 +4,45 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 
-vi.mock('../../data/index.json', () => ({
-  default: {
-    items: [
-      {
-        id: 'send-us-lord-en',
-        songId: 'send-us-lord',
-        language: 'en',
-        title: 'Send Us Lord',
-        filename: 'translation_demo_send_us_lord_en.chordpro',
-        originalKey: 'A',
-        tags: ['Missions'],
-        authors: ['Test Team'],
-        incomplete: false,
-      },
-      {
-        id: 'send-us-lord-tr',
-        songId: 'send-us-lord',
-        language: 'tr',
-        title: 'Rab Bizi Gönder',
-        filename: 'translation_demo_send_us_lord_tr.chordpro',
-        originalKey: 'A',
-        tags: ['Missions'],
-        authors: ['Test Team'],
-        incomplete: false,
-      },
-      {
-        id: 'only-en',
-        songId: 'only-english',
-        language: 'en',
-        title: 'Only English',
-        filename: 'only_english.chordpro',
-        originalKey: 'C',
-        tags: ['Test'],
-        authors: ['Test Team'],
-        incomplete: false,
-      },
-    ],
-  },
+// Song data (including chordpro_content and the translation grouping fields)
+// comes from Supabase via useSongs(), not the deprecated src/data/index.json
+// + per-song fetch('/songs/*.chordpro'). Mock the hook with both language
+// variants of the "send-us-lord" group plus an English-only song.
+const songMock = vi.hoisted(() => ({
+  songs: [
+    {
+      dbId: 't1', id: 'send-us-lord-en', songId: 'send-us-lord', language: 'en',
+      title: 'Send Us Lord', originalKey: 'A', tags: ['Missions'], authors: ['Test Team'],
+      incomplete: false,
+      chordpro_content: '{title: Send Us Lord}\n{key: A}\n{sov Verse}\n[A]Send us [D]Lord\n{eov}\n',
+    },
+    {
+      dbId: 't2', id: 'send-us-lord-tr', songId: 'send-us-lord', language: 'tr',
+      title: 'Rab Bizi Gönder', originalKey: 'A', tags: ['Missions'], authors: ['Test Team'],
+      incomplete: false,
+      chordpro_content: '{title: Rab Bizi Gönder}\n{key: A}\n{sov Verse}\n[A]Rab bizi [D]gönder\n[A]ıüşiçöğ [D]IÜŞİÇÖĞ\n{eov}\n',
+    },
+    {
+      dbId: 't3', id: 'only-en', songId: 'only-english', language: 'en',
+      title: 'Only English', originalKey: 'C', tags: ['Test'], authors: ['Test Team'],
+      incomplete: false,
+      chordpro_content: '{title: Only English}\n{key: C}\n{sov Verse}\n[C]Only [F]English\n{eov}\n',
+    },
+  ],
+}))
+
+vi.mock('../../hooks/useSongs', () => ({
+  useSongs: () => ({ songs: songMock.songs, loading: false }),
 }))
 
 import Songs from '../../pages/SongsPage'
 import SongView from '../../pages/SongViewPage'
 
-const SONG_TEXT = {
-  'translation_demo_send_us_lord_en.chordpro': `{title: Send Us Lord}
-{key: A}
-{sov Verse}
-[A]Send us [D]Lord
-{eov}
-`,
-  'translation_demo_send_us_lord_tr.chordpro': `{title: Rab Bizi Gönder}
-{key: A}
-{sov Verse}
-[A]Rab bizi [D]gönder
-[A]ıüşiçöğ [D]IÜŞİÇÖĞ
-{eov}
-`,
-  'only_english.chordpro': `{title: Only English}
-{key: C}
-{sov Verse}
-[C]Only [F]English
-{eov}
-`,
-}
-
+// SongView still issues HEAD/asset fetches (e.g. pptx availability). Resolve
+// them all to not-found so they don't interfere with the rendered content.
 function mockFetch() {
   const originalFetch = global.fetch
-  global.fetch = vi.fn(async (url, options = {}) => {
-    const u = String(url)
-    if (String(options?.method || '').toUpperCase() === 'HEAD') {
-      return { ok: false, text: async () => '' }
-    }
-    const hit = Object.entries(SONG_TEXT).find(([filename]) =>
-      u.includes(`/songs/${filename}`)
-    )
-    if (hit) {
-      return { ok: true, text: async () => hit[1] }
-    }
-    return { ok: false, text: async () => '' }
-  })
+  global.fetch = vi.fn(async () => ({ ok: false, text: async () => '' }))
   return () => {
     global.fetch = originalFetch
   }
@@ -154,7 +113,13 @@ describe('translation linking UI behavior', () => {
     fireEvent.click(screen.getByRole('button', { name: 'TR' }))
 
     expect(await screen.findByText('Rab Bizi Gönder')).toBeInTheDocument()
-    expect(screen.getByText('ıüşiçöğ IÜŞİÇÖĞ')).toBeInTheDocument()
+    // The chord sheet renders chord-over-lyric, so each syllable lands in its
+    // own cell — assert the Turkish lyrics (with their locale-specific glyphs)
+    // are present in the rendered sheet rather than as one contiguous node.
+    const sheet = document.querySelector('.songpage__sheet')
+    expect(sheet).toBeTruthy()
+    expect(sheet.textContent).toContain('ıüşiçöğ')
+    expect(sheet.textContent).toContain('IÜŞİÇÖĞ')
     await waitFor(() => {
       expect(localStorage.getItem('pref:songLanguage')).toBe('tr')
     })

--- a/src/components/auth/__tests__/RoleGuard.test.jsx
+++ b/src/components/auth/__tests__/RoleGuard.test.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+// useAuth is swapped per test via the mutable holder below.
+const authMock = vi.hoisted(() => ({ value: {} }))
+const navigateMock = vi.hoisted(() => ({ fn: vi.fn() }))
+const toastMock = vi.hoisted(() => ({ fn: vi.fn() }))
+
+vi.mock('../../../hooks/useAuth', () => ({ useAuth: () => authMock.value }))
+vi.mock('../../../utils/app/toast', () => ({ showToast: (...args) => toastMock.fn(...args) }))
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => navigateMock.fn,
+}))
+
+import RoleGuard from '../RoleGuard'
+
+function renderGuard(minRole = 'admin') {
+  return render(
+    <MemoryRouter>
+      <RoleGuard minRole={minRole}>
+        <div>SECRET ADMIN CONTENT</div>
+      </RoleGuard>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  navigateMock.fn.mockReset()
+  toastMock.fn.mockReset()
+})
+
+describe('RoleGuard', () => {
+  it('renders children when the user meets the minimum role', () => {
+    authMock.value = { loading: false, isLoggedIn: true, hasMinRole: () => true }
+    renderGuard('admin')
+    expect(screen.getByText('SECRET ADMIN CONTENT')).toBeInTheDocument()
+    expect(navigateMock.fn).not.toHaveBeenCalled()
+  })
+
+  it('redirects home with a toast when the user is not logged in', async () => {
+    authMock.value = { loading: false, isLoggedIn: false, hasMinRole: () => false }
+    renderGuard('admin')
+    expect(screen.queryByText('SECRET ADMIN CONTENT')).toBeNull()
+    await waitFor(() => {
+      expect(navigateMock.fn).toHaveBeenCalledWith('/', { replace: true })
+    })
+    expect(toastMock.fn).toHaveBeenCalled()
+  })
+
+  it('redirects when logged in but the role is too low', async () => {
+    authMock.value = { loading: false, isLoggedIn: true, hasMinRole: () => false }
+    renderGuard('admin')
+    expect(screen.queryByText('SECRET ADMIN CONTENT')).toBeNull()
+    await waitFor(() => {
+      expect(navigateMock.fn).toHaveBeenCalledWith('/', { replace: true })
+    })
+  })
+
+  it('renders nothing and does not redirect while auth is still loading', () => {
+    authMock.value = { loading: true, isLoggedIn: false, hasMinRole: () => false }
+    renderGuard('admin')
+    expect(screen.queryByText('SECRET ADMIN CONTENT')).toBeNull()
+    expect(navigateMock.fn).not.toHaveBeenCalled()
+  })
+
+  it('keeps showing children during a background refresh after access was confirmed', () => {
+    // First render: permitted — confirms access (sets the internal ref).
+    authMock.value = { loading: false, isLoggedIn: true, hasMinRole: () => true }
+    const { rerender } = renderGuard('admin')
+    expect(screen.getByText('SECRET ADMIN CONTENT')).toBeInTheDocument()
+
+    // A transient token refresh flips loading on without revoking access:
+    // children must stay mounted and no redirect should fire.
+    authMock.value = { loading: true, isLoggedIn: true, hasMinRole: () => true }
+    rerender(
+      <MemoryRouter>
+        <RoleGuard minRole="admin">
+          <div>SECRET ADMIN CONTENT</div>
+        </RoleGuard>
+      </MemoryRouter>
+    )
+    expect(screen.getByText('SECRET ADMIN CONTENT')).toBeInTheDocument()
+    expect(navigateMock.fn).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/__tests__/useSongs.test.jsx
+++ b/src/hooks/__tests__/useSongs.test.jsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// useSongs holds a module-level cache (_cache/_promise/_listeners). Reset the
+// module registry before each test so one test's cache can't leak into the next.
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+/**
+ * Build a supabase stub matching the query chain useSongs issues:
+ *   supabase.from('songs').select(...).eq('is_deleted', false).order('title')
+ * .order() resolves to { data, error }.
+ */
+function mockSupabase(result) {
+  const order = vi.fn().mockReturnValue(Promise.resolve(result))
+  const eq = vi.fn().mockReturnValue({ order })
+  const select = vi.fn().mockReturnValue({ eq })
+  const from = vi.fn().mockReturnValue({ select })
+  return { client: { from }, spies: { from, select, eq, order } }
+}
+
+const fullRow = {
+  id: 'uuid-1',
+  slug: 'abba',
+  title: 'Abba',
+  artist: 'Alice, Bob',
+  default_key: 'Am',
+  tags: ['worship'],
+  country: 'US',
+  youtube_id: 'abc123',
+  source_filename: 'abba_song',
+  chordpro_content: 'title: Abba\n[Am]Father',
+  star_count: 3,
+  song_group_id: 'group-1',
+  is_deleted: false,
+  has_stems: true,
+  stem_slug: 'abba-stems',
+  gracetracks_url: 'https://tracks.example/abba',
+}
+
+describe('useSongs', () => {
+  it('normalises supabase rows into the catalog shape', async () => {
+    const { client } = mockSupabase({ data: [fullRow], error: null })
+    vi.doMock('../../lib/supabase', () => ({ supabase: client }))
+    const { useSongs } = await import('../useSongs')
+
+    const { result } = renderHook(() => useSongs())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.songs).toHaveLength(1)
+    expect(result.current.songs[0]).toMatchObject({
+      dbId: 'uuid-1',          // UUID kept for FK relationships (starring)
+      id: 'abba',              // slug becomes the routing id
+      songId: 'abba',
+      title: 'Abba',
+      originalKey: 'Am',       // default_key → originalKey
+      authors: ['Alice', 'Bob'], // artist string split into an array
+      country: 'US',
+      tags: ['worship'],
+      youtube: 'https://www.youtube.com/watch?v=abc123', // youtube_id → full URL
+      chordpro_content: 'title: Abba\n[Am]Father',
+      filename: 'abba_song.chordpro', // source_filename + .chordpro
+      star_count: 3,
+      song_group_id: 'group-1',
+      has_stems: true,
+      stem_slug: 'abba-stems',
+      gracetracks_url: 'https://tracks.example/abba',
+    })
+  })
+
+  it('derives filename from the slug when source_filename is absent', async () => {
+    const row = { ...fullRow, source_filename: null, slug: 'how-great' }
+    const { client } = mockSupabase({ data: [row], error: null })
+    vi.doMock('../../lib/supabase', () => ({ supabase: client }))
+    const { useSongs } = await import('../useSongs')
+
+    const { result } = renderHook(() => useSongs())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.songs[0].filename).toBe('how_great.chordpro')
+  })
+
+  it('handles empty/missing metadata without throwing', async () => {
+    const row = { id: 'u2', slug: 'plain', title: 'Plain', is_deleted: false }
+    const { client } = mockSupabase({ data: [row], error: null })
+    vi.doMock('../../lib/supabase', () => ({ supabase: client }))
+    const { useSongs } = await import('../useSongs')
+
+    const { result } = renderHook(() => useSongs())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.songs[0]).toMatchObject({
+      authors: [],
+      tags: [],
+      youtube: null,
+      originalKey: '',
+      has_stems: false,
+      stem_slug: null,
+      gracetracks_url: null,
+    })
+  })
+
+  it('falls back to an empty list and logs when supabase returns an error', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = mockSupabase({ data: null, error: { message: 'boom' } })
+    vi.doMock('../../lib/supabase', () => ({ supabase: client }))
+    const { useSongs } = await import('../useSongs')
+
+    const { result } = renderHook(() => useSongs())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.songs).toEqual([])
+    expect(errSpy).toHaveBeenCalled()
+  })
+
+  it('serves cached data to later instances without refetching (dedupe)', async () => {
+    const { client, spies } = mockSupabase({ data: [fullRow], error: null })
+    vi.doMock('../../lib/supabase', () => ({ supabase: client }))
+    const { useSongs } = await import('../useSongs')
+
+    const first = renderHook(() => useSongs())
+    await waitFor(() => expect(first.result.current.loading).toBe(false))
+    expect(spies.from).toHaveBeenCalledTimes(1)
+
+    // A second mount within the cache window must not trigger another fetch and
+    // must not flash a loading state.
+    const second = renderHook(() => useSongs())
+    expect(second.result.current.loading).toBe(false)
+    expect(second.result.current.songs).toHaveLength(1)
+    expect(spies.from).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/pages/__tests__/WorshipMode.mobile.test.jsx
+++ b/src/pages/__tests__/WorshipMode.mobile.test.jsx
@@ -2,29 +2,29 @@ import React from 'react'
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
 import { render, screen, act, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+// Song data comes from Supabase via useSongs() (chordpro_content inline), not a
+// static fetch of /songs/*.chordpro. Mock the hook rather than global.fetch.
+const songMock = vi.hoisted(() => ({
+  songs: [
+    {
+      dbId: 's1', id: 'abba', songId: 'abba', title: 'Abba', language: 'en',
+      originalKey: 'Am', tags: [], authors: [],
+      chordpro_content: 'title: Abba\nkey: Am\n[Verse]\nFather we love You\n',
+    },
+    {
+      dbId: 's2', id: 'above-all', songId: 'above-all', title: 'Above All', language: 'en',
+      originalKey: 'A', tags: [], authors: [],
+      chordpro_content: 'title: Above All\nkey: A\n[Verse]\nAbove all powers\n',
+    },
+  ],
+}))
+
+vi.mock('../../hooks/useSongs', () => ({
+  useSongs: () => ({ songs: songMock.songs, loading: false }),
+}))
+
 import WorshipMode from '../WorshipModePage'
-
-const SONGS = {
-  abba: {
-    filename: 'abba.chordpro',
-    content: `title: Abba\nkey: Am\n[Verse]\nFather we love You\n`,
-  },
-  'above-all': {
-    filename: 'above_all.chordpro',
-    content: `title: Above All\nkey: A\n[Verse]\nAbove all powers\n`,
-  },
-}
-
-function mockFetch(){
-  const orig = global.fetch
-  global.fetch = async (url) => {
-    const u = String(url)
-    const hit = Object.values(SONGS).find(s => u.includes(`/songs/${s.filename}`))
-    if (hit) return { ok: true, text: async () => hit.content }
-    return { ok: false, text: async () => '' }
-  }
-  return () => { global.fetch = orig }
-}
 
 function setViewport(width){
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width })
@@ -32,13 +32,10 @@ function setViewport(width){
 }
 
 describe('WorshipMode — mobile toolbar and snackbar', () => {
-  let restore
   beforeEach(() => {
-    restore = mockFetch()
     localStorage.clear()
     sessionStorage.clear()
   })
-  afterEach(() => { restore?.() })
 
   it('uses icon-only toolbar and moves secondary controls to More on mobile', async () => {
     setViewport(375)

--- a/src/pages/__tests__/WorshipMode.test.jsx
+++ b/src/pages/__tests__/WorshipMode.test.jsx
@@ -1,43 +1,35 @@
 import React from 'react'
-import { describe, it, beforeEach, afterEach, expect } from 'vitest'
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+// Song data comes from Supabase via useSongs() (chordpro_content inline), not a
+// static fetch of /songs/*.chordpro. Mock the hook rather than global.fetch.
+const songMock = vi.hoisted(() => ({
+  songs: [
+    {
+      dbId: 's1', id: 'abba', songId: 'abba', title: 'Abba', language: 'en',
+      originalKey: 'Am', tags: [], authors: [],
+      chordpro_content: 'title: Abba\nkey: Am\n[Verse]\nFather we love You\n',
+    },
+    {
+      dbId: 's2', id: 'above-all', songId: 'above-all', title: 'Above All', language: 'en',
+      originalKey: 'A', tags: [], authors: [],
+      chordpro_content: 'title: Above All\nkey: A\n[Verse]\nAbove all powers\n',
+    },
+  ],
+}))
+
+vi.mock('../../hooks/useSongs', () => ({
+  useSongs: () => ({ songs: songMock.songs, loading: false }),
+}))
+
 import WorshipMode from '../WorshipModePage'
 
-const SONGS = {
-  // id -> { filename, content }
-  abba: {
-    filename: 'abba.chordpro',
-    content: `title: Abba\nkey: Am\n[Verse]\nFather we love You\n`,
-  },
-  'above-all': {
-    filename: 'above_all.chordpro',
-    content: `title: Above All\nkey: A\n[Verse]\nAbove all powers\n`,
-  },
-}
-
-function mockFetch(){
-  const orig = global.fetch
-  global.fetch = async (url) => {
-    const u = String(url)
-    const hit = Object.values(SONGS).find(s => u.includes(`/songs/${s.filename}`))
-    if (hit) {
-      return { ok: true, text: async () => hit.content }
-    }
-    return { ok: false, text: async () => '' }
-  }
-  return () => { global.fetch = orig }
-}
-
 describe('WorshipMode', () => {
-  let restore
   beforeEach(() => {
-    restore = mockFetch()
     localStorage.clear()
     document.documentElement.removeAttribute('data-theme')
-  })
-  afterEach(() => {
-    restore?.()
   })
 
   it('loads a single song', async () => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,16 +1,12 @@
 import '@testing-library/jest-dom/vitest'
 import i18n from './i18n'
 
-// Provide a lightweight fetch mock for tests that hit /src/data/index.json or /public/songs/*.chordpro
+// Lightweight default fetch stub. Song data now comes from Supabase via the
+// useSongs() hook (tests mock that hook directly), so this only needs to keep
+// incidental asset fetches (e.g. Bible manifests, pptx HEAD checks) from
+// hitting the network. Any request resolves to an empty 200.
 beforeAll(() => {
-  global.fetch = async (url) => {
-    // Minimal fake index
-    if (String(url).includes('/src/data/index.json')) {
-      return new Response(JSON.stringify({ songs: [] }), { status: 200 })
-    }
-    // Any other asset -> empty text
-    return new Response('', { status: 200 })
-  }
+  global.fetch = async () => new Response('', { status: 200 })
 })
 
 // Reset to English before each test so existing assertions on English text

--- a/src/utils/setlists/__tests__/setcode.verseTranslation.test.js
+++ b/src/utils/setlists/__tests__/setcode.verseTranslation.test.js
@@ -5,17 +5,19 @@ import { parseVerseReference } from '../../songs/verseRef'
 describe('setcode verse translation support', () => {
   it('round-trips translation-aware verse ids', () => {
     const parsed = parseVerseReference('John 3:16', { translation: 'kjv' })
-    const code = encodeSet([{ id: parsed.id, toKey: '' }])
+    // encodeSet/decodeSet take (songs, list) — verse entries don't need the
+    // song-code map, so pass an empty songs array.
+    const code = encodeSet([], [{ id: parsed.id, toKey: '' }])
     expect(code.startsWith('V_')).toBe(true)
 
-    const decoded = decodeSet(code)
+    const decoded = decodeSet([], code)
     expect(decoded.error).toBeUndefined()
     expect(decoded.entries).toEqual([{ id: 'v:kjv|John 3:16', toKey: '' }])
   })
 
   it('decodes legacy verse codes as ESV', () => {
     const legacy = `V${encodeLegacyVerse('John', '3:16')}`
-    const decoded = decodeSet(legacy)
+    const decoded = decodeSet([], legacy)
     expect(decoded.error).toBeUndefined()
     expect(decoded.entries).toEqual([{ id: 'v:esv|John 3:16', toKey: '' }])
   })


### PR DESCRIPTION
## Summary
Replaces the deprecated static `src/data/index.json` data source with a new `useSongs()` hook that fetches song data from Supabase. Song records now include inline `chordpro_content` instead of requiring separate file fetches, and the hook implements request deduplication and module-level caching.

## Key Changes

- **New `useSongs()` hook** (`src/hooks/useSongs.jsx`): Fetches songs from Supabase with automatic normalization from database schema to app schema, request deduplication, and caching to prevent redundant queries across component instances.

- **Comprehensive test suite for `useSongs()`**: Tests cover schema normalization, filename derivation, missing metadata handling, error fallbacks, and cache deduplication behavior.

- **Updated component tests** to mock `useSongs()` instead of static JSON or global fetch:
  - `songTranslations.ui.test.jsx`: Now mocks the hook with inline `chordpro_content` and simplified fetch stub
  - `WorshipMode.test.jsx` and `WorshipMode.mobile.test.jsx`: Replaced fetch mocking with hook mocks
  - `home.listbox.test.jsx` and `songbook.filters.test.jsx`: Updated to use hook mocks for search corpus

- **New `RoleGuard` component tests** (`src/components/auth/__tests__/RoleGuard.test.jsx`): Comprehensive coverage of authentication gating, role checking, redirect behavior, and background token refresh scenarios.

- **Updated routing smoke test**: Clarified that `/admin` route is gated and redirects unauthenticated users to home.

- **Simplified global fetch stub** in `setupTests.js`: Removed special handling for deprecated `index.json` and `.chordpro` files since data now comes from Supabase via the hook.

- **Minor test utility updates**: `setcode.verseTranslation.test.js` updated to match new `encodeSet`/`decodeSet` signatures.

## Implementation Details

The `useSongs()` hook normalizes Supabase rows into the app's catalog shape:
- `slug` → `id` (routing identifier)
- `default_key` → `originalKey`
- `artist` string → `authors` array (split on comma)
- `youtube_id` → full YouTube URL
- `source_filename` → filename with `.chordpro` extension (falls back to slug if absent)
- Preserves `dbId` (UUID) for foreign key relationships like starring

The hook uses module-level state to cache results and deduplicate concurrent requests, ensuring that multiple component instances within the cache window share a single fetch and avoid loading state flashing.

https://claude.ai/code/session_01ThvL95RSdpH6ZkSsfZMHS1