### PR TITLE
Rebuild PPTX export with pptxgenjs for valid, uniform output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "jszip": "^3.10.1",
         "lucide-react": "^1.16.0",
         "pako": "^2.1.0",
+        "pptxgenjs": "^4.0.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-helmet-async": "^2.0.5",
@@ -6955,6 +6956,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7057,6 +7064,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {
@@ -9193,6 +9215,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9412,6 +9461,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/raf": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jszip": "^3.10.1",
     "lucide-react": "^1.16.0",
     "pako": "^2.1.0",
+    "pptxgenjs": "^4.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-helmet-async": "^2.0.5",

--- a/src/__tests__/combinePptx.test.js
+++ b/src/__tests__/combinePptx.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'vitest'
+import JSZip from 'jszip'
+import {
+  extractLinesFromSlideXml,
+  extractDeckSlides,
+  buildPresentation,
+} from '../utils/export/combinePptx.js'
+
+const P_NS = 'http://schemas.openxmlformats.org/presentationml/2006/main'
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main'
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+
+function slideXml(paragraphs) {
+  const body = paragraphs
+    .map((runs) => {
+      const texts = (Array.isArray(runs) ? runs : [runs])
+        .map((t) => `<a:r><a:t>${t}</a:t></a:r>`)
+        .join('')
+      return `<a:p>${texts}</a:p>`
+    })
+    .join('')
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:p="${P_NS}" xmlns:a="${A_NS}" xmlns:r="${R_NS}">
+  <p:cSld><p:spTree><p:sp><p:txBody>${body}</p:txBody></p:sp></p:spTree></p:cSld>
+</p:sld>`
+}
+
+// Build a minimal valid-enough source deck where slide *file* numbering is the
+// reverse of presentation order, to prove we honor sldIdLst rather than names.
+function makeSourceDeck(slidesInOrder) {
+  const zip = new JSZip()
+  // file slideN.xml holds slidesInOrder[N-1] reversed vs. presentation order
+  const fileForOrder = (i) => slidesInOrder.length - i // 1-based file number
+  const sldIds = slidesInOrder
+    .map((_, i) => `<p:sldId id="${256 + i}" r:id="rId${i + 2}"/>`)
+    .join('')
+  const rels = slidesInOrder
+    .map(
+      (_, i) =>
+        `<Relationship Id="rId${i + 2}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide${fileForOrder(i)}.xml"/>`
+    )
+    .join('')
+
+  zip.file(
+    'ppt/presentation.xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="${P_NS}" xmlns:r="${R_NS}"><p:sldIdLst>${sldIds}</p:sldIdLst></p:presentation>`
+  )
+  zip.file(
+    'ppt/_rels/presentation.xml.rels',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${rels}</Relationships>`
+  )
+  slidesInOrder.forEach((paras, i) => {
+    zip.file(`ppt/slides/slide${fileForOrder(i)}.xml`, slideXml(paras))
+  })
+  return zip
+}
+
+describe('extractLinesFromSlideXml', () => {
+  test('one line per non-empty paragraph, runs concatenated', () => {
+    const xml = slideXml([['Above all powers, ', 'above all kings'], ['Above all nature and all created things']])
+    expect(extractLinesFromSlideXml(xml)).toEqual([
+      'Above all powers, above all kings',
+      'Above all nature and all created things',
+    ])
+  })
+
+  test('empty paragraphs (blank separator slide) yield no lines', () => {
+    expect(extractLinesFromSlideXml(slideXml([['']]))).toEqual([])
+    expect(extractLinesFromSlideXml(slideXml([]))).toEqual([])
+  })
+})
+
+describe('extractDeckSlides', () => {
+  test('reads slides in presentation order, not filename order', async () => {
+    const deck = makeSourceDeck([
+      [['Above all']],
+      [['']], // blank separator
+      [['Verse line one'], ['Verse line two']],
+    ])
+    const slides = await extractDeckSlides(deck)
+    expect(slides.map((s) => s.lines)).toEqual([
+      ['Above all'],
+      [],
+      ['Verse line one', 'Verse line two'],
+    ])
+  })
+})
+
+describe('buildPresentation', () => {
+  test('produces a single-master 16:9 black deck with standardized text', async () => {
+    const pptx = await buildPresentation([
+      { lines: ['Above all powers, above all kings', 'Above all nature and all created things'] },
+      { lines: [] },
+      { lines: ['Above all'] },
+    ])
+    const b64 = await pptx.write({ outputType: 'base64' })
+    const zip = await JSZip.loadAsync(b64, { base64: true })
+    const names = Object.keys(zip.files)
+
+    const masters = names.filter((n) => /ppt\/slideMasters\/slideMaster\d+\.xml$/.test(n))
+    expect(masters).toHaveLength(1)
+
+    const slideFiles = names.filter((n) => /ppt\/slides\/slide\d+\.xml$/.test(n))
+    expect(slideFiles).toHaveLength(3)
+
+    const pres = await zip.file('ppt/presentation.xml').async('string')
+    // 13.333in x 7.5in => 12191995?ish x 6858000 EMU; assert height is exactly 7.5in.
+    expect(pres).toMatch(/cy="6858000"/)
+
+    const slide1 = await zip.file('ppt/slides/slide1.xml').async('string')
+    expect(slide1).toMatch(/Calibri/)
+    expect(slide1).toMatch(/sz="5400"/) // 54pt
+    expect(slide1).toMatch(/FFFFFF/i)
+    expect(slide1).toMatch(/anchor="ctr"/) // text anchored to box center
+    expect(slide1).toMatch(/Above all powers/)
+  })
+})

--- a/src/utils/export/combinePptx.js
+++ b/src/utils/export/combinePptx.js
@@ -1,45 +1,50 @@
 /*
- * DIAGNOSIS (fix-pptx-export-y1y0r)
+ * Setlist PPTX export.
  *
- * Root causes of ~50% corrupt/mis-formatted PPTX exports:
+ * Earlier versions merged each song deck's slides *with* their original
+ * slideMasters / slideLayouts / themes into one ZIP. Because the source decks
+ * are hand-made and never byte-identical, that produced mismatched master
+ * references and subtly invalid OOXML — the cause of both the "PowerPoint found
+ * a problem… Repair?" prompt and the inconsistent formatting between songs.
  *
- * 1. SLIDE MASTER MISMATCH — `clonePart` contained four early-return short-circuits
- *    (for PPT_SLIDE_LAYOUT_CT, PPT_SLIDE_MASTER_CT, PPT_NOTES_MASTER_CT, PPT_THEME_CT)
- *    that returned the *base* file's equivalent asset instead of copying the source
- *    file's asset.  Every song after the first had its slides rendered with song-1's
- *    visual theme → black text, wrong sizes, wrong colours.
+ * This implementation instead reads only the *text* out of every source slide
+ * (in true presentation order) and rebuilds a brand-new, single-master deck
+ * with pptxgenjs. The output is therefore valid by construction (no repair
+ * prompt) and uniformly formatted: black 16:9 background, one shared
+ * master/theme, and 54pt white centered Calibri anchored in the upper third.
  *
- * 2. LAYOUT REDIRECT — `processSlideRelationships` also forced every incoming slide's
- *    slideLayout relationship to point at `context.defaultLayoutTarget` (base file's
- *    first layout), compounding the master mismatch.
- *
- * 3. MIME TYPE — `generateAsync({ type: 'blob' })` produced a Blob with no MIME type;
- *    some readers flagged this as damaged.
- *
- * 4. SEQUENTIAL / NO-SKIP FETCH — A single 404 aborted the entire export; all files
- *    should be fetched in parallel with per-file error suppression.
- *
- * FIX SUMMARY:
- *   • Removed the four short-circuit blocks in clonePart so source layouts/masters/
- *     themes are actually copied and renumbered into the output ZIP.
- *   • Replaced the forced-redirect layout handling in processSlideRelationships with
- *     a proper clonePart call, matching how other relationship types are handled.
- *   • Changed generateAsync to uint8array + explicit Blob with the correct MIME type.
- *   • Fetch all files in parallel (Promise.all) with per-file failure suppression.
- *   • Appended `_worship` to the download filename per spec.
+ * Blank source slides (the single separator slide each song deck carries
+ * between songs) carry no text, so they become blank black slides — preserving
+ * the separators without us adding or removing any.
  */
-const PPT_SLIDE_CT = 'application/vnd.openxmlformats-officedocument.presentationml.slide+xml'
-const PPT_NOTES_CT = 'application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml'
-const PPT_SLIDE_MASTER_CT = 'application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml'
-const PPT_SLIDE_LAYOUT_CT = 'application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml'
-const PPT_THEME_CT = 'application/vnd.openxmlformats-officedocument.theme+xml'
-const PRESENTATION_NS = 'http://schemas.openxmlformats.org/presentationml/2006/main'
-const RELS_NS = 'http://schemas.openxmlformats.org/package/2006/relationships'
-const OFFICE_REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
-const PPT_NOTES_MASTER_CT = 'application/vnd.openxmlformats-officedocument.presentationml.notesMaster+xml'
+
+// 16:9 widescreen, in inches (13.333 x 7.5).
+const SLIDE_W = 13.333
+const SLIDE_H = 7.5
+const LAYOUT_NAME = 'GC_16x9'
+const MASTER_NAME = 'GC_BLACK'
+const BG_COLOR = '000000'
+
+// One standardized text box per slide. Anchored to the centre of the box
+// (valign 'middle'), the box sits in the upper third of the slide and is tall
+// enough that even three 54pt lines never clip.
+const TEXT_BOX = {
+  x: 0.5,
+  y: 0.5,
+  w: SLIDE_W - 1,
+  h: 3.0,
+  align: 'center',
+  valign: 'middle',
+  fontFace: 'Calibri',
+  fontSize: 54,
+  color: 'FFFFFF',
+  fit: 'none',
+  wrap: true,
+}
+
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main'
 
 const parser = new DOMParser()
-const serializer = new XMLSerializer()
 
 function sanitizeFilename(input) {
   const fallback = 'setlist'
@@ -54,705 +59,141 @@ function sanitizeFilename(input) {
   return safe || fallback
 }
 
-async function fetchArrayBuffer(url) {
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`Failed to load PPTX: ${url}`)
-  return res.arrayBuffer()
-}
-
 function parseXml(xml) {
   const doc = parser.parseFromString(xml, 'application/xml')
   const parseError = doc.getElementsByTagName('parsererror')[0]
-  if (parseError) {
-    throw new Error(parseError.textContent || 'Failed to parse XML')
-  }
+  if (parseError) throw new Error(parseError.textContent || 'Failed to parse XML')
   return doc
 }
 
-function serializeXml(doc) {
-  return serializer.serializeToString(doc)
-}
-
 function getNumericSuffix(value) {
-  const match = String(value || '').match(/(\d+)$/)
+  const match = String(value || '').match(/(\d+)/)
   return match ? Number(match[1]) : 0
 }
 
-function findMaxNumber(zip, regex) {
-  let max = 0
-  zip.filter((path) => regex.test(path)).forEach((file) => {
-    const match = file.name.match(regex)
-    if (!match) return
-    const num = Number(match[1])
-    if (!Number.isNaN(num)) max = Math.max(max, num)
-  })
-  return max
+// Namespace-aware element select that works in both real browsers and the
+// happy-dom test environment (whose getElementsByTagNameNS is unreliable),
+// matching on localName + namespaceURI in document order.
+function selectNS(root, ns, local) {
+  const out = []
+  const all = root.getElementsByTagName('*')
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i]
+    if (el.localName === local && el.namespaceURI === ns) out.push(el)
+  }
+  return out
 }
 
-function ensureContentOverride(doc, partName, contentType) {
-  const overrides = Array.from(doc.getElementsByTagName('Override'))
-  if (overrides.some((node) => node.getAttribute('PartName') === partName)) return
-  const override = doc.createElement('Override')
-  override.setAttribute('PartName', partName)
-  override.setAttribute('ContentType', contentType)
-  doc.documentElement.appendChild(override)
-}
-
-function resolveTargetPath(ownerPath, target) {
+// Resolve a relationship Target (declared relative to ppt/presentation.xml)
+// to a full path inside the ZIP.
+function resolveSlideTarget(target) {
   if (!target) return null
   if (target.startsWith('/')) return target.slice(1)
-  const ownerParts = ownerPath.split('/')
-  ownerParts.pop()
-  const targetSegments = target.split('/')
-  for (const segment of targetSegments) {
-    if (segment === '..') ownerParts.pop()
-    else if (segment === '.') continue
-    else ownerParts.push(segment)
-  }
-  return ownerParts.join('/')
+  return `ppt/${target.replace(/^\.\//, '')}`
 }
 
-function getRelativePath(fromPath, toPath) {
-  const fromParts = fromPath.split('/')
-  fromParts.pop()
-  const toParts = toPath.split('/')
-  let i = 0
-  while (i < fromParts.length && i < toParts.length && fromParts[i] === toParts[i]) {
-    i++
-  }
-  const upMoves = fromParts.length - i
-  const parts = []
-  for (let j = 0; j < upMoves; j++) parts.push('..')
-  parts.push(...toParts.slice(i))
-  return parts.join('/')
-}
+// Return slide part paths in true presentation order (from presentation.xml's
+// sldIdLst → relationship targets), falling back to a numeric filename sort.
+//
+// Parsed via regex on the raw XML rather than the DOM: the relationship id on
+// <p:sldId> is a namespace-prefixed attribute (r:id), and not every XML parser
+// (happy-dom included) preserves prefixed attributes reliably.
+async function getOrderedSlidePaths(zip) {
+  const presEntry = zip.file('ppt/presentation.xml')
+  const relsEntry = zip.file('ppt/_rels/presentation.xml.rels')
+  if (presEntry && relsEntry) {
+    try {
+      const presXml = await presEntry.async('string')
+      const relsXml = await relsEntry.async('string')
 
-function parseNumberedPath(path) {
-  const match = path.match(/^(.*\/)([^/]*?)(\d+)(\.[^.]+)$/)
-  if (!match) return null
-  return {
-    dir: match[1],
-    prefix: match[2],
-    number: Number(match[3]),
-    ext: match[4],
-  }
-}
+      // Ordered relationship ids referenced by <p:sldId r:id="…"> (any prefix).
+      const order = []
+      const sldIdRe = /<[\w]*:?sldId\b[^>]*?\b[A-Za-z][\w-]*:id="([^"]+)"/g
+      let m
+      while ((m = sldIdRe.exec(presXml))) order.push(m[1])
 
-function ensureCounter(store, key, value) {
-  const current = Number(store[key] || 0)
-  if (value > current) {
-    store[key] = value
-  }
-}
+      // Map relationship id → target for slide relationships.
+      const relMap = new Map()
+      const relRe = /<Relationship\b[^>]*\/?>/g
+      let r
+      while ((r = relRe.exec(relsXml))) {
+        const tag = r[0]
+        const id = (tag.match(/\bId="([^"]+)"/) || [])[1]
+        const type = (tag.match(/\bType="([^"]+)"/) || [])[1] || ''
+        const target = (tag.match(/\bTarget="([^"]+)"/) || [])[1]
+        if (id && target && type.endsWith('/slide')) relMap.set(id, target)
+      }
 
-function allocateNumber(store, key) {
-  const current = Number(store[key] || 0)
-  const next = current + 1
-  store[key] = next
-  return next
-}
-
-function getZipEntry(zip, selector) {
-  if (!zip) return null
-  const result = zip.file(selector)
-  if (Array.isArray(result)) return result.length ? result[0] : null
-  return result || null
-}
-
-function getRelationshipsPath(partPath) {
-  const lastSlash = partPath.lastIndexOf('/')
-  const dir = lastSlash >= 0 ? partPath.slice(0, lastSlash + 1) : ''
-  const file = lastSlash >= 0 ? partPath.slice(lastSlash + 1) : partPath
-  return `${dir}_rels/${file}.rels`
-}
-
-function getContentTypeInfo(doc, partPath) {
-  if (!doc || !partPath) return { contentType: '', fromOverride: false, extension: '' }
-  const partName = `/${partPath}`
-  const overrides = Array.from(doc.getElementsByTagName('Override'))
-  const overrideNode = overrides.find((node) => node.getAttribute('PartName') === partName)
-  if (overrideNode) {
-    return {
-      contentType: overrideNode.getAttribute('ContentType') || '',
-      fromOverride: true,
-      extension: partPath.split('.').pop() || '',
+      const seen = new Set()
+      const paths = []
+      for (const rid of order) {
+        if (seen.has(rid)) continue
+        seen.add(rid)
+        const resolved = resolveSlideTarget(relMap.get(rid))
+        if (resolved && zip.file(resolved)) paths.push(resolved)
+      }
+      if (paths.length) return paths
+    } catch {
+      /* fall through to filename sort */
     }
   }
-  const defaults = Array.from(doc.getElementsByTagName('Default'))
-  const extension = partPath.split('.').pop() || ''
-  const defaultNode = defaults.find((node) => node.getAttribute('Extension') === extension)
-  if (defaultNode) {
-    return {
-      contentType: defaultNode.getAttribute('ContentType') || '',
-      fromOverride: false,
-      extension,
-    }
-  }
-  return { contentType: '', fromOverride: false, extension }
-}
 
-function ensureDefaultContentType(targetDoc, sourceDoc, extension) {
-  if (!extension) return
-  const existing = Array.from(targetDoc.getElementsByTagName('Default')).some(
-    (node) => node.getAttribute('Extension') === extension
-  )
-  if (existing) return
-  const sourceNode = Array.from(sourceDoc?.getElementsByTagName?.('Default') || []).find(
-    (node) => node.getAttribute('Extension') === extension
-  )
-  if (!sourceNode) return
-  const clone = targetDoc.createElement('Default')
-  clone.setAttribute('Extension', extension)
-  clone.setAttribute('ContentType', sourceNode.getAttribute('ContentType') || '')
-  targetDoc.documentElement.appendChild(clone)
-}
-
-function isBinaryContentType(contentType) {
-  if (!contentType) return false
-  return !/xml|text|application\/(.*\+xml)/i.test(contentType)
-}
-
-function makeNumberedTargetFactory(sample) {
-  const regex = /(.*\D)(\d+)(\.\w+)$/
-  const match = sample && sample.match(regex)
-  if (match) {
-    const [, prefix, , suffix] = match
-    return (n) => `${prefix}${n}${suffix}`
-  }
-  return (n) => `slides/slide${n}.xml`
-}
-
-async function prepareContext(zip) {
-  const presentationXmlPath = 'ppt/presentation.xml'
-  const presentationEntry = getZipEntry(zip, presentationXmlPath)
-  if (!presentationEntry) throw new Error('Base PPTX missing ppt/presentation.xml')
-  const presentationXml = await presentationEntry.async('string')
-  const presentationDoc = parseXml(presentationXml)
-
-  const sldIdList =
-    presentationDoc.getElementsByTagNameNS(PRESENTATION_NS, 'sldIdLst')[0] ||
-    presentationDoc.getElementsByTagName('p:sldIdLst')[0]
-
-  const slideIdNodes = sldIdList
-    ? Array.from(
-        sldIdList.getElementsByTagNameNS(PRESENTATION_NS, 'sldId')
-      ).concat(Array.from(sldIdList.getElementsByTagName('p:sldId')))
-    : []
-  const maxSlideId = slideIdNodes.reduce((max, node) => {
-    const id = Number(node.getAttribute('id'))
-    return Number.isNaN(id) ? max : Math.max(max, id)
-  }, 255)
-
-  const presentationRelsPath = 'ppt/_rels/presentation.xml.rels'
-  const presentationRelsEntry = getZipEntry(zip, presentationRelsPath)
-  if (!presentationRelsEntry) throw new Error('Base PPTX missing ppt/_rels/presentation.xml.rels')
-  const presentationRelsXml = await presentationRelsEntry.async('string')
-  const presentationRelsDoc = parseXml(presentationRelsXml)
-  const relationshipNodes = Array.from(presentationRelsDoc.getElementsByTagName('Relationship'))
-  const maxRelId = relationshipNodes.reduce((max, node) => {
-    const num = getNumericSuffix(node.getAttribute('Id'))
-    return Math.max(max, num)
-  }, 0)
-
-  const slideRelationshipNodes = relationshipNodes.filter((node) => {
-    const type = node.getAttribute('Type') || ''
-    return type.endsWith('/slide')
-  })
-  const slideTargetSample = slideRelationshipNodes.length
-    ? slideRelationshipNodes[0].getAttribute('Target') || ''
-    : ''
-  const getSlideTarget = makeNumberedTargetFactory(slideTargetSample)
-
-  const masterList =
-    presentationDoc.getElementsByTagNameNS(PRESENTATION_NS, 'sldMasterIdLst')[0] ||
-    presentationDoc.getElementsByTagName('p:sldMasterIdLst')[0] ||
-    null
-  const masterIdNodes = masterList
-    ? Array.from(
-        masterList.getElementsByTagNameNS(PRESENTATION_NS, 'sldMasterId')
-      ).concat(Array.from(masterList.getElementsByTagName('p:sldMasterId')))
-    : []
-  const maxMasterId = masterIdNodes.reduce((max, node) => {
-    const id = Number(node.getAttribute('id'))
-    return Number.isNaN(id) ? max : Math.max(max, id)
-  }, 2147483647)
-
-  const notesMasterList =
-    presentationDoc.getElementsByTagNameNS(PRESENTATION_NS, 'notesMasterIdLst')[0] ||
-    presentationDoc.getElementsByTagName('p:notesMasterIdLst')[0] ||
-    null
-
-  let defaultNotesMasterPath = null
-  const notesMasterRel = relationshipNodes.find((node) => {
-    const type = node.getAttribute('Type') || ''
-    return type.endsWith('/notesMaster')
-  })
-  if (notesMasterRel) {
-    const target = notesMasterRel.getAttribute('Target') || ''
-    defaultNotesMasterPath = resolveTargetPath('ppt/presentation.xml', target)
-  }
-
-  let defaultThemePath = null
-  const themeRel = relationshipNodes.find((node) => {
-    const type = node.getAttribute('Type') || ''
-    return type.endsWith('/theme')
-  })
-  if (themeRel) {
-    const target = themeRel.getAttribute('Target') || ''
-    defaultThemePath = resolveTargetPath('ppt/presentation.xml', target)
-  }
-
-  const contentTypesPath = '[Content_Types].xml'
-  const contentTypesEntry = getZipEntry(zip, contentTypesPath)
-  if (!contentTypesEntry) throw new Error('Base PPTX missing [Content_Types].xml')
-  const contentTypesXml = await contentTypesEntry.async('string')
-  const contentTypesDoc = parseXml(contentTypesXml)
-
-  const counters = {}
-  zip.filter(() => true).forEach((file) => {
-    const info = parseNumberedPath(file.name)
-    if (!info) return
-    const key = `${info.dir}${info.prefix}`
-    ensureCounter(counters, key, info.number)
-  })
-
-  ensureCounter(counters, 'ppt/slides/slide', findMaxNumber(zip, /^ppt\/slides\/slide(\d+)\.xml$/))
-  ensureCounter(
-    counters,
-    'ppt/notesSlides/notesSlide',
-    findMaxNumber(zip, /^ppt\/notesSlides\/notesSlide(\d+)\.xml$/)
-  )
-  ensureCounter(
-    counters,
-    'ppt/slideMasters/slideMaster',
-    findMaxNumber(zip, /^ppt\/slideMasters\/slideMaster(\d+)\.xml$/)
-  )
-  ensureCounter(
-    counters,
-    'ppt/slideLayouts/slideLayout',
-    findMaxNumber(zip, /^ppt\/slideLayouts\/slideLayout(\d+)\.xml$/)
-  )
-  ensureCounter(counters, 'ppt/theme/theme', findMaxNumber(zip, /^ppt\/theme\/theme(\d+)\.xml$/))
-  ensureCounter(
-    counters,
-    'ppt/notesMasters/notesMaster',
-    findMaxNumber(zip, /^ppt\/notesMasters\/notesMaster(\d+)\.xml$/)
-  )
-  ensureCounter(
-    counters,
-    'ppt/media/image',
-    findMaxNumber(zip, /^ppt\/media\/image(\d+)\.[^.]+$/)
-  )
-
-  const slideEntries = zip
+  return zip
     .file(/^ppt\/slides\/slide\d+\.xml$/)
     .sort((a, b) => getNumericSuffix(a.name) - getNumericSuffix(b.name))
-
-  let defaultLayoutTarget = ''
-  let defaultLayoutPath = ''
-  let defaultMasterPath = ''
-
-  if (slideEntries.length) {
-    const firstSlide = slideEntries[0]
-    const slideRelEntry = getZipEntry(zip, getRelationshipsPath(firstSlide.name))
-    if (slideRelEntry) {
-      const slideRelDoc = parseXml(await slideRelEntry.async('string'))
-      const relNodes = Array.from(slideRelDoc.getElementsByTagName('Relationship'))
-      const layoutRel = relNodes.find((node) => {
-        const type = node.getAttribute('Type') || ''
-        return type.endsWith('/slideLayout')
-      })
-      if (layoutRel) {
-        defaultLayoutTarget = layoutRel.getAttribute('Target') || ''
-        const resolved = resolveTargetPath(firstSlide.name, defaultLayoutTarget)
-        if (resolved && getZipEntry(zip, resolved)) {
-          defaultLayoutPath = resolved
-        }
-      }
-    }
-  }
-
-  if (!defaultLayoutPath) {
-    const layoutEntries = zip
-      .file(/^ppt\/slideLayouts\/.*\.xml$/)
-      .sort((a, b) => getNumericSuffix(a.name) - getNumericSuffix(b.name))
-    if (layoutEntries.length) {
-      defaultLayoutPath = layoutEntries[0].name
-      defaultLayoutTarget = slideEntries.length
-        ? getRelativePath(slideEntries[0].name, defaultLayoutPath)
-        : '../slideLayouts/slideLayout1.xml'
-    }
-  } else if (!defaultLayoutTarget && slideEntries.length) {
-    defaultLayoutTarget = getRelativePath(slideEntries[0].name, defaultLayoutPath)
-  }
-
-  if (defaultLayoutPath) {
-    const layoutRelEntry = getZipEntry(zip, getRelationshipsPath(defaultLayoutPath))
-    if (layoutRelEntry) {
-      const layoutRelDoc = parseXml(await layoutRelEntry.async('string'))
-      const layoutRelNodes = Array.from(layoutRelDoc.getElementsByTagName('Relationship'))
-      const masterRel = layoutRelNodes.find((node) => {
-        const type = node.getAttribute('Type') || ''
-        return type.endsWith('/slideMaster')
-      })
-      if (masterRel) {
-        const target = masterRel.getAttribute('Target') || ''
-        const resolved = resolveTargetPath(defaultLayoutPath, target)
-        if (resolved && getZipEntry(zip, resolved)) {
-          defaultMasterPath = resolved
-        }
-      }
-    }
-  }
-
-  if (!defaultMasterPath) {
-    const masterEntries = zip
-      .file(/^ppt\/slideMasters\/.*\.xml$/)
-      .sort((a, b) => getNumericSuffix(a.name) - getNumericSuffix(b.name))
-    if (masterEntries.length) {
-      defaultMasterPath = masterEntries[0].name
-    }
-  }
-
-  if (!defaultNotesMasterPath) {
-    const notesMasterEntries = zip
-      .file(/^ppt\/notesMasters\/.*\.xml$/)
-      .sort((a, b) => getNumericSuffix(a.name) - getNumericSuffix(b.name))
-    if (notesMasterEntries.length) {
-      defaultNotesMasterPath = notesMasterEntries[0].name
-    }
-  }
-
-  return {
-    zip,
-    presentationXmlPath,
-    presentationDoc,
-    sldIdList,
-    sldMasterList: masterList,
-    notesMasterList,
-    presentationRelsPath,
-    presentationRelsDoc,
-    contentTypesPath,
-    contentTypesDoc,
-    nextSlideId: maxSlideId,
-    nextRelId: maxRelId,
-    nextMasterId: maxMasterId,
-    counters,
-    partMap: new Map(),
-    masterRelMap: new Map(),
-    notesMasterRelMap: new Map(),
-    getSlideTarget,
-    defaultLayoutTarget,
-    defaultLayoutPath,
-    defaultMasterPath,
-    defaultNotesMasterPath,
-    defaultThemePath,
-  }
+    .map((f) => f.name)
 }
 
-function createSlideRelationship(context, slideIndex, relId) {
-  const relationshipsEl = context.presentationRelsDoc.documentElement
-  const rel = context.presentationRelsDoc.createElement('Relationship')
-  rel.setAttribute('Id', relId)
-  rel.setAttribute('Type', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide')
-  const target = context.getSlideTarget
-    ? context.getSlideTarget(slideIndex)
-    : `slides/slide${slideIndex}.xml`
-  rel.setAttribute('Target', target)
-  relationshipsEl.appendChild(rel)
+// Pull the visible lines from one slide's XML: each <a:p> paragraph becomes one
+// line (its <a:t> runs concatenated). Empty paragraphs are dropped.
+export function extractLinesFromSlideXml(xml) {
+  let doc
+  try {
+    doc = parseXml(xml)
+  } catch {
+    return []
+  }
+  const paragraphs = selectNS(doc, A_NS, 'p')
+  const lines = []
+  for (const p of paragraphs) {
+    const runs = selectNS(p, A_NS, 't')
+    const line = runs.map((t) => t.textContent || '').join('').replace(/\s+/g, ' ').trim()
+    if (line) lines.push(line)
+  }
+  return lines
 }
 
-function appendSlideId(context, relId) {
-  const doc = context.presentationDoc
-  const list =
-    context.sldIdList ||
-    (() => {
-      const node = doc.createElementNS(PRESENTATION_NS, 'p:sldIdLst')
-      doc.documentElement.appendChild(node)
-      context.sldIdList = node
-      return node
-    })()
-  const node = doc.createElementNS(PRESENTATION_NS, 'p:sldId')
-  context.nextSlideId += 1
-  node.setAttribute('id', String(context.nextSlideId))
-  node.setAttributeNS(OFFICE_REL_NS, 'r:id', relId)
-  list.appendChild(node)
+// Extract every slide of one source deck as { lines } in presentation order.
+export async function extractDeckSlides(zip) {
+  const paths = await getOrderedSlidePaths(zip)
+  const slides = []
+  for (const path of paths) {
+    const entry = zip.file(path)
+    if (!entry) continue
+    const xml = await entry.async('string')
+    slides.push({ lines: extractLinesFromSlideXml(xml) })
+  }
+  return slides
 }
 
-function registerMaster(context, masterPath) {
-  if (context.masterRelMap.has(masterPath)) return context.masterRelMap.get(masterPath)
+// Build a clean, standardized presentation from extracted slides.
+export async function buildPresentation(slides = []) {
+  const mod = await import('pptxgenjs')
+  const PptxGenJS = mod.default || mod
+  const pptx = new PptxGenJS()
 
-  const doc = context.presentationDoc
-  const relDoc = context.presentationRelsDoc
+  pptx.defineLayout({ name: LAYOUT_NAME, width: SLIDE_W, height: SLIDE_H })
+  pptx.layout = LAYOUT_NAME
+  pptx.defineSlideMaster({ title: MASTER_NAME, background: { color: BG_COLOR } })
 
-  let list = context.sldMasterList
-  if (!list) {
-    list = doc.createElementNS(PRESENTATION_NS, 'p:sldMasterIdLst')
-    const firstChild = doc.documentElement.firstChild
-    if (firstChild) doc.documentElement.insertBefore(list, firstChild)
-    else doc.documentElement.appendChild(list)
-    context.sldMasterList = list
-  }
-
-  context.nextMasterId = Number(context.nextMasterId || 2147483647)
-  context.nextMasterId += 1
-  context.nextRelId += 1
-  const relId = `rId${context.nextRelId}`
-
-  const masterNode = doc.createElementNS(PRESENTATION_NS, 'p:sldMasterId')
-  masterNode.setAttribute('id', String(context.nextMasterId))
-  masterNode.setAttributeNS(OFFICE_REL_NS, 'r:id', relId)
-  list.appendChild(masterNode)
-
-  const relElement = relDoc.createElement('Relationship')
-  relElement.setAttribute('Id', relId)
-  relElement.setAttribute('Type', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster')
-  relElement.setAttribute('Target', getRelativePath('ppt/presentation.xml', masterPath))
-  relDoc.documentElement.appendChild(relElement)
-
-  context.masterRelMap.set(masterPath, relId)
-  return relId
-}
-
-function registerNotesMaster(context, notesMasterPath) {
-  if (context.notesMasterRelMap.has(notesMasterPath)) return context.notesMasterRelMap.get(notesMasterPath)
-
-  const doc = context.presentationDoc
-  const relDoc = context.presentationRelsDoc
-
-  let list = context.notesMasterList
-  if (!list) {
-    list = doc.createElementNS(PRESENTATION_NS, 'p:notesMasterIdLst')
-    const parent = doc.documentElement
-    const beforeNode = context.sldIdList || parent.firstChild
-    if (beforeNode) parent.insertBefore(list, beforeNode)
-    else parent.appendChild(list)
-    context.notesMasterList = list
-  }
-
-  context.nextRelId += 1
-  const relId = `rId${context.nextRelId}`
-
-  const node = doc.createElementNS(PRESENTATION_NS, 'p:notesMasterId')
-  node.setAttributeNS(OFFICE_REL_NS, 'r:id', relId)
-  list.appendChild(node)
-
-  const relElement = relDoc.createElement('Relationship')
-  relElement.setAttribute('Id', relId)
-  relElement.setAttribute(
-    'Type',
-    'http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster'
-  )
-  relElement.setAttribute('Target', getRelativePath('ppt/presentation.xml', notesMasterPath))
-  relDoc.documentElement.appendChild(relElement)
-
-  context.notesMasterRelMap.set(notesMasterPath, relId)
-  return relId
-}
-
-async function clonePart(
-  context,
-  srcZip,
-  sourceContentTypesDoc,
-  sourceKey,
-  originalPath,
-  options = {}
-) {
-  if (!originalPath) return null
-  const mapKey = `${sourceKey}:${originalPath}`
-  if (context.partMap.has(mapKey)) return context.partMap.get(mapKey)
-
-  const typeInfo = getContentTypeInfo(sourceContentTypesDoc, originalPath)
-  const entry = getZipEntry(srcZip, originalPath)
-  if (!entry) return null
-
-  const info = parseNumberedPath(originalPath)
-  let newPath
-
-  if (info) {
-    const counterKey = `${info.dir}${info.prefix}`
-    const newNumber = allocateNumber(context.counters, counterKey)
-    newPath = `${info.dir}${info.prefix}${newNumber}${info.ext}`
-  } else {
-    if (getZipEntry(context.zip, originalPath)) {
-      context.partMap.set(mapKey, originalPath)
-      return originalPath
-    }
-    newPath = originalPath
-  }
-
-  context.partMap.set(mapKey, newPath)
-
-  if (typeInfo.fromOverride) {
-    ensureContentOverride(context.contentTypesDoc, `/${newPath}`, typeInfo.contentType)
-  } else if (typeInfo.extension) {
-    ensureDefaultContentType(context.contentTypesDoc, sourceContentTypesDoc, typeInfo.extension)
-  }
-
-  const data = await entry.async(isBinaryContentType(typeInfo.contentType) ? 'uint8array' : 'string')
-  context.zip.file(newPath, data)
-
-  const relPath = getRelationshipsPath(originalPath)
-  const relEntry = getZipEntry(srcZip, relPath)
-  if (relEntry) {
-    const relXml = await relEntry.async('string')
-    const relDoc = parseXml(relXml)
-    const relNodes = Array.from(relDoc.getElementsByTagName('Relationship'))
-
-    for (const node of relNodes) {
-      const targetMode = (node.getAttribute('TargetMode') || '').toLowerCase()
-      if (targetMode === 'external') continue
-      const target = node.getAttribute('Target') || ''
-      const absolute = resolveTargetPath(originalPath, target)
-      if (!absolute) continue
-
-      let explicitTarget = null
-      if (typeof options.relationshipMutator === 'function') {
-        const result = await options.relationshipMutator({
-          node,
-          type: node.getAttribute('Type') || '',
-          absolutePath: absolute,
-          newPartPath: newPath,
-          originalPartPath: originalPath,
-        })
-        if (result === false) continue
-        if (result && result.targetPath) {
-          explicitTarget = result.targetPath
-        }
-      }
-
-      const clonedPath =
-        explicitTarget || (await clonePart(context, srcZip, sourceContentTypesDoc, sourceKey, absolute))
-      if (!clonedPath) continue
-      const relative = getRelativePath(newPath, clonedPath)
-      node.setAttribute('Target', relative)
-    }
-
-    const newRelPath = getRelationshipsPath(newPath)
-    context.zip.file(newRelPath, serializeXml(relDoc))
-  }
-
-  if (typeInfo.contentType === PPT_SLIDE_MASTER_CT) {
-    registerMaster(context, newPath)
-  } else if (typeInfo.contentType === PPT_NOTES_MASTER_CT) {
-    registerNotesMaster(context, newPath)
-  }
-
-  return newPath
-}
-
-async function processSlideRelationships(
-  context,
-  srcZip,
-  sourceContentTypesDoc,
-  sourceKey,
-  originalSlidePath,
-  newSlidePath
-) {
-  const relPath = getRelationshipsPath(originalSlidePath)
-  const relEntry = getZipEntry(srcZip, relPath)
-  if (!relEntry) return
-
-  const relXml = await relEntry.async('string')
-  const relDoc = parseXml(relXml)
-  const relNodes = Array.from(relDoc.getElementsByTagName('Relationship'))
-  const relationshipsEl = relDoc.documentElement
-
-  for (const node of relNodes) {
-    const type = node.getAttribute('Type') || ''
-    const target = node.getAttribute('Target') || ''
-    if (!target) continue
-    const absolute = resolveTargetPath(originalSlidePath, target)
-    if (!absolute) continue
-
-    if (type.endsWith('/slideLayout')) {
-      const layoutPath = await clonePart(context, srcZip, sourceContentTypesDoc, sourceKey, absolute)
-      if (layoutPath) {
-        node.setAttribute('Target', getRelativePath(newSlidePath, layoutPath))
-      }
-      continue
-    }
-
-    if (type.endsWith('/notesSlide')) {
-      const notePath = await clonePart(context, srcZip, sourceContentTypesDoc, sourceKey, absolute, {
-        relationshipMutator: ({ type: relType }) => {
-          if (relType.endsWith('/slide')) {
-            return { targetPath: newSlidePath }
-          }
-          return null
-        },
-      })
-      if (!notePath) continue
-      node.setAttribute('Target', getRelativePath(newSlidePath, notePath))
-    } else if (type.includes('/image') || type.includes('/audio') || type.includes('/video')) {
-      const mediaPath = await clonePart(context, srcZip, sourceContentTypesDoc, sourceKey, absolute)
-      if (!mediaPath) continue
-      node.setAttribute('Target', getRelativePath(newSlidePath, mediaPath))
-    } else {
-      const dependencyPath = await clonePart(context, srcZip, sourceContentTypesDoc, sourceKey, absolute)
-      if (!dependencyPath) continue
-      node.setAttribute('Target', getRelativePath(newSlidePath, dependencyPath))
+  for (const s of slides) {
+    const slide = pptx.addSlide({ masterName: MASTER_NAME })
+    slide.background = { color: BG_COLOR }
+    if (s && Array.isArray(s.lines) && s.lines.length) {
+      slide.addText(s.lines.join('\n'), { ...TEXT_BOX })
     }
   }
-
-  const newRelPath = getRelationshipsPath(newSlidePath)
-  context.zip.file(newRelPath, serializeXml(relDoc))
-}
-
-async function appendSlides(context, srcZip, sourceKey) {
-  const slides = srcZip
-    .file(/^ppt\/slides\/slide\d+\.xml$/)
-    .sort((a, b) => {
-      const aNum = getNumericSuffix(a.name)
-      const bNum = getNumericSuffix(b.name)
-      return aNum - bNum
-    })
-
-  if (!slides.length) return
-
-  const contentTypesEntry = getZipEntry(srcZip, '[Content_Types].xml')
-  if (!contentTypesEntry) throw new Error('Source PPTX missing [Content_Types].xml')
-  const sourceContentTypesDoc = parseXml(await contentTypesEntry.async('string'))
-
-  for (const slideEntry of slides) {
-    const newSlideNumber = allocateNumber(context.counters, 'ppt/slides/slide')
-    const newSlidePath = `ppt/slides/slide${newSlideNumber}.xml`
-    const xml = await slideEntry.async('string')
-    context.zip.file(newSlidePath, xml)
-
-    ensureContentOverride(context.contentTypesDoc, `/${newSlidePath}`, PPT_SLIDE_CT)
-
-    context.nextRelId += 1
-    const relId = `rId${context.nextRelId}`
-    createSlideRelationship(context, newSlideNumber, relId)
-    appendSlideId(context, relId)
-
-    const originalSlidePath = slideEntry.name
-    context.partMap.set(`${sourceKey}:${originalSlidePath}`, newSlidePath)
-    await processSlideRelationships(
-      context,
-      srcZip,
-      sourceContentTypesDoc,
-      sourceKey,
-      originalSlidePath,
-      newSlidePath
-    )
-  }
-}
-
-function persistXml(context) {
-  context.zip.file(context.presentationXmlPath, serializeXml(context.presentationDoc))
-  context.zip.file(context.presentationRelsPath, serializeXml(context.presentationRelsDoc))
-  context.zip.file(context.contentTypesPath, serializeXml(context.contentTypesDoc))
-}
-
-function saveBlob(blob, filename) {
-  const link = document.createElement('a')
-  link.href = URL.createObjectURL(blob)
-  link.download = filename
-  link.rel = 'noopener'
-  link.click()
-  URL.revokeObjectURL(link.href)
+  return pptx
 }
 
 export async function combinePptxFiles(songFileUrls = [], setlistName = 'Setlist') {
@@ -761,7 +202,8 @@ export async function combinePptxFiles(songFileUrls = [], setlistName = 'Setlist
   }
   const JSZip = (await import('jszip')).default
 
-  // Fetch all files in parallel; skip any that fail (404, network error, etc.)
+  // Fetch all decks in parallel; preserve order and silently skip any that
+  // fail (404 / network error) so missing songs don't abort the export.
   const results = await Promise.all(
     songFileUrls.map((url) =>
       fetch(url)
@@ -772,21 +214,19 @@ export async function combinePptxFiles(songFileUrls = [], setlistName = 'Setlist
   const buffers = results.filter(Boolean)
   if (!buffers.length) throw new Error('No PPTX files could be loaded')
 
-  const [firstBuffer, ...restBuffers] = buffers
-  const baseZip = await JSZip.loadAsync(firstBuffer)
-  const context = await prepareContext(baseZip)
-
-  for (let i = 0; i < restBuffers.length; i++) {
-    const srcZip = await JSZip.loadAsync(restBuffers[i])
-    await appendSlides(context, srcZip, `src${i + 1}`)
+  const slides = []
+  for (const buffer of buffers) {
+    try {
+      const zip = await JSZip.loadAsync(buffer)
+      const deck = await extractDeckSlides(zip)
+      slides.push(...deck)
+    } catch {
+      /* skip a deck we can't read rather than failing the whole export */
+    }
   }
+  if (!slides.length) throw new Error('No slides could be extracted from the PPTX files')
 
-  persistXml(context)
-  const uint8 = await baseZip.generateAsync({ type: 'uint8array' })
-  const blob = new Blob([uint8], {
-    type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-  })
+  const pptx = await buildPresentation(slides)
   const safeName = sanitizeFilename(setlistName || 'Setlist')
-
-  saveBlob(blob, `${safeName}_worship.pptx`)
+  await pptx.writeFile({ fileName: `${safeName}_worship.pptx` })
 }


### PR DESCRIPTION
## Summary

Replaces the complex ZIP-merging approach to PPTX export with a simpler, more robust implementation that extracts text from source slides and rebuilds a clean, single-master presentation using pptxgenjs. This eliminates the root causes of corrupt/misformatted exports and the "PowerPoint found a problem… Repair?" prompt.

## Key Changes

- **New extraction pipeline**: `extractLinesFromSlideXml()` and `extractDeckSlides()` read only visible text from source slides in true presentation order (honoring `sldIdLst` rather than filename order)
- **Standardized output**: `buildPresentation()` uses pptxgenjs to construct a brand-new deck with:
  - Single shared master/theme (no mismatched references)
  - Uniform 16:9 black background
  - Standardized text formatting: 54pt white Calibri, centered, anchored in upper third
- **Simplified main flow**: `combinePptxFiles()` now fetches all decks in parallel, extracts slides with per-deck error suppression, and generates output via pptxgenjs instead of manipulating XML/ZIP internals
- **Blank slide preservation**: Empty paragraphs (separator slides) become blank black slides, preserving deck structure without manual intervention
- **Proper MIME type**: Output Blob now has correct `application/vnd.openxmlformats-officedocument.presentationml.presentation` type

## Implementation Details

- Removed ~650 lines of complex ZIP/XML manipulation (clonePart, processSlideRelationships, prepareContext, etc.)
- Added namespace-aware element selection (`selectNS()`) to work reliably across browsers and test environments
- Regex-based relationship parsing for `sldIdLst` order to avoid DOM parser inconsistencies with prefixed attributes
- Added pptxgenjs as a dependency
- Comprehensive test coverage for extraction, deck building, and presentation generation

## Testing

New test suite (`combinePptx.test.js`) validates:
- Line extraction from slide XML with multiple runs and empty paragraphs
- Presentation order preservation despite reversed filename numbering
- Output deck structure (single master, correct dimensions, standardized formatting)

https://claude.ai/code/session_01VFwsd75dr1ddESHPrX22kz