### PR TITLE
fix(setlist): bold 52pt edge-to-edge text with shrink-to-fit

### DIFF
--- a/src/__tests__/combinePptx.test.js
+++ b/src/__tests__/combinePptx.test.js
@@ -111,9 +111,11 @@ describe('buildPresentation', () => {
 
     const slide1 = await zip.file('ppt/slides/slide1.xml').async('string')
     expect(slide1).toMatch(/Calibri/)
-    expect(slide1).toMatch(/sz="5400"/) // 54pt
+    expect(slide1).toMatch(/sz="5200"/) // 52pt
+    expect(slide1).toMatch(/b="1"/) // bold
     expect(slide1).toMatch(/FFFFFF/i)
     expect(slide1).toMatch(/anchor="ctr"/) // text anchored to box center
+    expect(slide1).toMatch(/normAutofit/) // shrink text on overflow
     expect(slide1).toMatch(/Above all powers/)
   })
 })

--- a/src/utils/export/combinePptx.js
+++ b/src/utils/export/combinePptx.js
@@ -25,21 +25,25 @@ const LAYOUT_NAME = 'GC_16x9'
 const MASTER_NAME = 'GC_BLACK'
 const BG_COLOR = '000000'
 
-// One standardized text box per slide. Anchored to the centre of the box
-// (valign 'middle'), the box sits in the upper third of the slide and is tall
-// enough that even three 54pt lines never clip.
+// One standardized text box per slide, running nearly edge-to-edge. Text is
+// anchored to the centre of the box (valign 'middle') in the upper third, and
+// `fit: 'shrink'` (PowerPoint "shrink text on overflow") quietly scales the
+// text down so a long line stays on one line instead of wrapping — explicit
+// line breaks are still honoured.
 const TEXT_BOX = {
-  x: 0.5,
-  y: 0.5,
-  w: SLIDE_W - 1,
-  h: 3.0,
+  x: 0.1,
+  y: 0.7,
+  w: SLIDE_W - 0.2,
+  h: 2.4,
   align: 'center',
   valign: 'middle',
   fontFace: 'Calibri',
-  fontSize: 54,
+  fontSize: 52,
+  bold: true,
   color: 'FFFFFF',
-  fit: 'none',
+  fit: 'shrink',
   wrap: true,
+  margin: 2,
 }
 
 const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main'


### PR DESCRIPTION
Tune the standardized slide text to match the reference deck:
- bold Calibri, 52pt (was 54pt, non-bold)
- text box runs nearly edge-to-edge with minimal internal inset, so long lines have room instead of wrapping early
- enable PowerPoint "shrink text on overflow" (normAutofit) so a long line scales down to stay on one line; explicit line breaks are still honoured


Claude-Session: https://claude.ai/code/session_01VFwsd75dr1ddESHPrX22kz