### PR TITLE
fix(setlist): compute per-slide font size so lines never wrap

### DIFF
--- a/src/__tests__/combinePptx.test.js
+++ b/src/__tests__/combinePptx.test.js
@@ -4,6 +4,7 @@ import {
   extractLinesFromSlideXml,
   extractDeckSlides,
   buildPresentation,
+  fitFontSize,
 } from '../utils/export/combinePptx.js'
 
 const P_NS = 'http://schemas.openxmlformats.org/presentationml/2006/main'
@@ -88,6 +89,24 @@ describe('extractDeckSlides', () => {
   })
 })
 
+describe('fitFontSize', () => {
+  // No canvas in happy-dom, so only the height bound applies here.
+  test('one or two lines stay at the 52pt max', () => {
+    expect(fitFontSize(['Above all'])).toBe(52)
+    expect(fitFontSize(['line one', 'line two'])).toBe(52)
+  })
+
+  test('many lines shrink below the max to fit the box height', () => {
+    const five = fitFontSize(['a', 'b', 'c', 'd', 'e'])
+    expect(five).toBeLessThan(52)
+    expect(five).toBeGreaterThanOrEqual(28)
+  })
+
+  test('never drops below the 28pt floor', () => {
+    expect(fitFontSize(Array(40).fill('x'))).toBe(28)
+  })
+})
+
 describe('buildPresentation', () => {
   test('produces a single-master 16:9 black deck with standardized text', async () => {
     const pptx = await buildPresentation([
@@ -115,7 +134,6 @@ describe('buildPresentation', () => {
     expect(slide1).toMatch(/b="1"/) // bold
     expect(slide1).toMatch(/FFFFFF/i)
     expect(slide1).toMatch(/anchor="ctr"/) // text anchored to box center
-    expect(slide1).toMatch(/normAutofit/) // shrink text on overflow
     expect(slide1).toMatch(/Above all powers/)
   })
 })

--- a/src/utils/export/combinePptx.js
+++ b/src/utils/export/combinePptx.js
@@ -25,25 +25,62 @@ const LAYOUT_NAME = 'GC_16x9'
 const MASTER_NAME = 'GC_BLACK'
 const BG_COLOR = '000000'
 
-// One standardized text box per slide, running nearly edge-to-edge. Text is
-// anchored to the centre of the box (valign 'middle') in the upper third, and
-// `fit: 'shrink'` (PowerPoint "shrink text on overflow") quietly scales the
-// text down so a long line stays on one line instead of wrapping — explicit
-// line breaks are still honoured.
+// One standardized, bold, centred text box per slide. It spans the slide edge
+// to edge and is anchored to its centre (valign 'middle') in the upper third.
 const TEXT_BOX = {
-  x: 0.1,
-  y: 0.7,
-  w: SLIDE_W - 0.2,
-  h: 2.4,
+  x: 0,
+  y: 0.5,
+  w: SLIDE_W,
+  h: 3.2,
   align: 'center',
   valign: 'middle',
   fontFace: 'Calibri',
-  fontSize: 52,
   bold: true,
   color: 'FFFFFF',
-  fit: 'shrink',
+  fit: 'none',
   wrap: true,
-  margin: 2,
+  margin: 0,
+}
+
+const MAX_FONT = 52
+const MIN_FONT = 28
+// Keep a little breathing room from the literal edges when sizing text.
+const FIT_WIDTH_IN = SLIDE_W - 0.4
+const LINE_HEIGHT = 1.2
+
+// PowerPoint's own "shrink text on overflow" only applies a baked-in fontScale,
+// which we can't compute, so it does nothing on open. Instead we size each
+// slide's text ourselves: the largest size (<= MAX_FONT) at which every line
+// still fits on one line within the box, and the whole block fits its height.
+// Measured with a canvas; when unavailable (SSR/tests) we fall back to the
+// height-only bound. Explicit line breaks (one per source paragraph) are kept.
+let measureCtx
+function getMeasureCtx() {
+  if (measureCtx !== undefined) return measureCtx
+  try {
+    const canvas = document.createElement('canvas')
+    measureCtx = canvas.getContext ? canvas.getContext('2d') : null
+  } catch {
+    measureCtx = null
+  }
+  return measureCtx
+}
+
+export function fitFontSize(lines) {
+  let size = MAX_FONT
+  const ctx = getMeasureCtx()
+  if (ctx) {
+    for (const line of lines) {
+      ctx.font = 'bold 100px Calibri, Arial, sans-serif'
+      const widthAt100 = ctx.measureText(line).width
+      if (widthAt100 > 0) {
+        size = Math.min(size, (FIT_WIDTH_IN * 72 * 100) / widthAt100)
+      }
+    }
+  }
+  const maxForHeight = (TEXT_BOX.h * 72) / (Math.max(lines.length, 1) * LINE_HEIGHT)
+  size = Math.min(size, maxForHeight)
+  return Math.max(MIN_FONT, Math.min(MAX_FONT, Math.round(size)))
 }
 
 const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main'
@@ -193,8 +230,9 @@ export async function buildPresentation(slides = []) {
   for (const s of slides) {
     const slide = pptx.addSlide({ masterName: MASTER_NAME })
     slide.background = { color: BG_COLOR }
-    if (s && Array.isArray(s.lines) && s.lines.length) {
-      slide.addText(s.lines.join('\n'), { ...TEXT_BOX })
+    const lines = s && Array.isArray(s.lines) ? s.lines : []
+    if (lines.length) {
+      slide.addText(lines.join('\n'), { ...TEXT_BOX, fontSize: fitFontSize(lines) })
     }
   }
   return pptx


### PR DESCRIPTION
PowerPoint's "shrink text on overflow" (normAutofit) does nothing on open unless a fontScale is baked in, so 52pt text still wrapped. Instead, size each slide's text deterministically: measure every line with a canvas and pick the largest size (<= 52pt, floor 28pt) at which each line fits on one line and the block fits the box height. When canvas metrics are unavailable (tests/SSR), fall back to the height-only bound.

Also make the text box literally edge-to-edge (full slide width, zero inset).


Claude-Session: https://claude.ai/code/session_01VFwsd75dr1ddESHPrX22kz