### PR TITLE
fix(setlist): raise per-slide font floor to 40pt

### DIFF
--- a/src/__tests__/combinePptx.test.js
+++ b/src/__tests__/combinePptx.test.js
@@ -99,11 +99,11 @@ describe('fitFontSize', () => {
   test('many lines shrink below the max to fit the box height', () => {
     const five = fitFontSize(['a', 'b', 'c', 'd', 'e'])
     expect(five).toBeLessThan(52)
-    expect(five).toBeGreaterThanOrEqual(28)
+    expect(five).toBeGreaterThanOrEqual(40)
   })
 
-  test('never drops below the 28pt floor', () => {
-    expect(fitFontSize(Array(40).fill('x'))).toBe(28)
+  test('never drops below the 40pt floor', () => {
+    expect(fitFontSize(Array(40).fill('x'))).toBe(40)
   })
 })
 

--- a/src/utils/export/combinePptx.js
+++ b/src/utils/export/combinePptx.js
@@ -43,7 +43,7 @@ const TEXT_BOX = {
 }
 
 const MAX_FONT = 52
-const MIN_FONT = 28
+const MIN_FONT = 40
 // Keep a little breathing room from the literal edges when sizing text.
 const FIT_WIDTH_IN = SLIDE_W - 0.4
 const LINE_HEIGHT = 1.2


### PR DESCRIPTION
Target stays 52pt; clamp the computed per-slide size no lower than 40pt.


Claude-Session: https://claude.ai/code/session_01VFwsd75dr1ddESHPrX22kz