### PR TITLE
Configure esbuild aliases for @gracechords/core workspace package

### DIFF
--- a/workers/telegram-bot/wrangler.toml
+++ b/workers/telegram-bot/wrangler.toml
@@ -61,5 +61,18 @@ binding = "AI"
 [alias]
 "jspdf" = "./node_modules/jspdf"
 
+# The shared ChordPro parser / transposition / song logic now lives in the
+# @gracechords/core workspace package (packages/core). The worker's own
+# `npm clean-install` only installs this package.json's deps, so the
+# workspace symlink that would normally resolve `@gracechords/core/*` is
+# absent and esbuild fails with "Could not resolve '@gracechords/core/...'".
+# Point the package and its subpaths straight at the source — esbuild
+# resolves the .js/.ts extensions. Wrangler's alias matches specifiers
+# exactly (no subpath/directory aliasing), so each subpath the worker pulls
+# in via the src/utils compatibility shims is listed explicitly.
+"@gracechords/core/chordpro/index.js" = "../../packages/core/src/chordpro/index.js"
+"@gracechords/core/chordpro/parser" = "../../packages/core/src/chordpro/parser.ts"
+"@gracechords/core/songs/instrumental" = "../../packages/core/src/songs/instrumental.js"
+
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
Add Wrangler alias configuration to resolve `@gracechords/core` workspace package imports in the Telegram bot worker. This enables the worker to access shared ChordPro parser, transposition, and song logic from the core workspace package without relying on npm workspace symlinks.

## Changes
- Added esbuild aliases in `wrangler.toml` to map `@gracechords/core` subpath imports directly to their source files in `packages/core/src/`
- Configured three explicit aliases:
  - `@gracechords/core/chordpro/index.js` → ChordPro parser entry point
  - `@gracechords/core/chordpro/parser` → ChordPro parser implementation
  - `@gracechords/core/songs/instrumental` → Instrumental song utilities

## Implementation Details
The worker's isolated `npm clean-install` environment lacks the workspace symlinks that would normally resolve `@gracechords/core` imports. By pointing aliases directly to source files, esbuild can resolve the imports and their extensions without requiring the workspace infrastructure. Each subpath is listed explicitly since Wrangler's alias matching is exact and doesn't support directory-level aliasing.

https://claude.ai/code/session_01Bt1yLjE62L83wbEobfL5wT