### PR TITLE
fix(telegram-bot): point worker imports at apps/web after monorepo move

### DIFF
--- a/workers/telegram-bot/src/pdfRender.js
+++ b/workers/telegram-bot/src/pdfRender.js
@@ -1,5 +1,5 @@
 // Render a song to PDF (always) and JPG (best-effort). The pure PDF engine
-// from src/utils/pdf_mvp/pure.js is imported directly across the monorepo;
+// from apps/web/src/utils/pdf_mvp/pure.js is imported directly across the monorepo;
 // wrangler bundles it. Fonts fall back to jsPDF's built-in Helvetica/Courier
 // because Noto TTFs (~3.3 MB total) would bust the free-tier 3 MiB worker
 // budget — chord charts remain legible. See plan for the trade-off note.
@@ -9,7 +9,7 @@
 // encoder needed). If the WASM rasteriser fails to initialise the caller
 // gets `null` back and should send the PDF via sendDocument instead.
 
-import { renderSingleSongPdfBuffer, renderMultiSongPdfBuffer } from '../../../src/utils/pdf_mvp/pure.js'
+import { renderSingleSongPdfBuffer, renderMultiSongPdfBuffer } from '../../../apps/web/src/utils/pdf_mvp/pure.js'
 import { makeFontRegistrar } from './fontsWorker.js'
 // Bundle the pdfium WASM at deploy time. Workers block
 // WebAssembly.instantiate(buffer); only pre-compiled WebAssembly.Module
@@ -36,8 +36,8 @@ if (typeof globalThis.window === 'undefined') {
 // symbols verbatim) — the site does it in SongViewPage; we do it here.
 async function toRenderableSong(song, key) {
   const [{ parseChordProOrLegacy }, { stepsBetween, transposeSymPrefer }] = await Promise.all([
-    import('../../../src/utils/chordpro/parser.ts'),
-    import('../../../src/utils/chordpro/index.js'),
+    import('../../../apps/web/src/utils/chordpro/parser.ts'),
+    import('../../../apps/web/src/utils/chordpro/index.js'),
   ])
   const parsed = parseChordProOrLegacy(song.chordpro_content || '')
   const originalKey = song.default_key || parsed.meta?.key || ''


### PR DESCRIPTION
The "move web app into apps/web" step of the monorepo migration relocated the web source from src/ to apps/web/src/, but the telegram-bot worker still imported the PDF engine and ChordPro parser via ../../../src/utils/... Those paths no longer exist, so Cloudflare Workers Builds failed with:

  Could not resolve "../../../src/utils/pdf_mvp/pure.js"
  Could not resolve "../../../src/utils/chordpro/parser.ts"
  Could not resolve "../../../src/utils/chordpro/index.js"

Repoint the three imports at ../../../apps/web/src/utils/... These modules are still the @gracechords/core compatibility shims, so the existing wrangler [alias] entries continue to resolve the core package. Verified with `wrangler deploy --dry-run` using the pinned wrangler 3.114.17.


Claude-Session: https://claude.ai/code/session_01Bt1yLjE62L83wbEobfL5wT