### PR TITLE
docs(agents): document mobile app conventions (theme, primitives, auth)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,13 @@ This repo is an npm-workspaces monorepo. **The web app now lives in `apps/web/`*
 and `eslint.config.js` all moved there — paths elsewhere in this doc that say
 `src/...` mean `apps/web/src/...`). Platform-agnostic logic lives in `packages/`.
 The Expo iOS app lives in `apps/mobile/` (`@gracechords/mobile`) — an Expo SDK 55
-+ Expo Router v7 vertical slice that consumes `@gracechords/core` and Supabase
-auth natively. **See [`apps/mobile/AGENTS.md`](./apps/mobile/AGENTS.md) for all
-mobile-specific conventions** (Metro monorepo resolution, CNG, env, Supabase
-wiring); it is the single mobile sub-doc — do not add competing instruction files
-under `apps/mobile/`. The repo root holds
++ Expo Router v7 native client that consumes `@gracechords/core` and Supabase
+auth. It now carries real UI (theme + primitives, a four-tab shell, the Song
+Library and Home screens, and an authenticated-only route gate), not just a
+scaffold. **See [`apps/mobile/AGENTS.md`](./apps/mobile/AGENTS.md) for all
+mobile-specific conventions** (theme/primitives, SF Symbols, auth gating, Metro
+monorepo resolution, CNG, env, Supabase wiring); it is the single mobile sub-doc
+— do not add competing instruction files under `apps/mobile/`. The repo root holds
 only the workspace `package.json` + lockfile, `packages/`, `apps/`, `workers/`,
 `supabase/`, and docs.
 - Run web tasks from the repo root via the delegating scripts (`npm run dev`,
@@ -26,8 +28,12 @@ only the workspace `package.json` + lockfile, `packages/`, `apps/`, `workers/`,
   `createGcSupabase({ url, anonKey, storage })`). Consumed as **source, no build
   step** via the `@gracechords/core` alias (`vite.config.js`) and the workspace
   symlink.
-- `packages/tokens/` (`@gracechords/tokens`): canonical design tokens
-  (`tokens.css`). The web imports it from `src/styles/index.css`.
+- `packages/tokens/` (`@gracechords/tokens`): canonical design tokens — the single
+  home for both platforms' tokens. The web imports `tokens.css` (via
+  `src/styles/index.css`; the warm-brown `--gc-*` palette). React Native imports the
+  typed token map from `@gracechords/tokens/native` (`native.ts`; the iOS
+  Signal-blue light/dark palette). The two palettes are **deliberately different**;
+  don't hardcode token values in either app.
 - **Compatibility shims:** every module moved into `packages/core` left a thin
   re-export shim at its original `src/...` path (e.g. `src/utils/chordpro/parser.ts`,
   `src/lib/roles.js`), so existing web imports are unchanged. **Edit the real

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -7,9 +7,16 @@ doc first.
 
 ## What this is
 
-A native (Expo / React Native) client for GraceChords, scaffolded as a thin
-vertical slice that proves the shared `@gracechords/core` package and Supabase
-auth run on-device. It is intentionally minimal — **not** the real/native UI.
+A native (Expo / React Native) client for GraceChords. It carries real UI built
+from the design reference: a themed four-tab shell, the **Song Library** and
+**Home** screens, a placeholder **Song Viewer** route, and an
+**authenticated-only** route gate. Build new screens on the shared theme +
+primitives below — don't add one-off styles or hardcoded colors where a
+primitive/token fits.
+
+Design source: `gc-ios-design-reference/` (repo root). Follow its
+non-negotiables — HIG/UIKit over the mockups, **SF Symbols only**, and translate
+the visual rather than porting the HTML/CSS.
 
 ## Stack
 
@@ -20,6 +27,10 @@ auth run on-device. It is intentionally minimal — **not** the real/native UI.
 - **Continuous Native Generation (CNG).** `ios/` and `android/` are **gitignored
   and never committed** — regenerate them with `npx expo prebuild`. Treat
   `app.json` (+ config plugins) as the source of truth for native config.
+- **UI deps:** `expo-symbols` (SF Symbols), `expo-linear-gradient` (the Home
+  hero), `expo-splash-screen` (auth-gate hold). Add Expo deps with
+  `npx expo install <pkg>`; if the Expo API is unreachable, pin the SDK-correct
+  version from `node_modules/expo/bundledNativeModules.json` and `npm install`.
 
 ## Commands (run from `apps/mobile/`)
 
@@ -61,7 +72,61 @@ Mobile uses core's exports only. If a query/util is missing, add an **additive**
 export to `packages/core` (see `songs/songsRepo.js` → `fetchSongList`); never
 duplicate logic here and never edit core internals to suit mobile.
 
-## Out of scope (this slice)
+## Theme & tokens
 
-Reimagined native UI, tablet master-detail, Google OAuth (see the `TODO: OAuth`
-in `src/screens/LoginScreen.tsx`), EAS Build / TestFlight, Android, GraceTracks.
+- Colors/spacing/radii/type come from `@gracechords/tokens/native`
+  (`packages/tokens/native.ts`) — the iOS Signal-blue palette, light + dark.
+  **Never hardcode hex values** in the app.
+- Consume via `useTheme()` from `src/theme/ThemeProvider.tsx`
+  (`const t = useTheme()` → `t.colors.*`, `t.spacing.*`, `t.radii.*`,
+  `t.typography.*`). The provider follows the system scheme (`app.json`
+  `userInterfaceStyle: automatic`); **both light and dark must look correct**.
+- New shared token values (e.g. the hero gradient) go in `native.ts`, not inline.
+
+## Primitives & UI conventions
+
+- Reusable primitives live in `src/components/`: `Screen`, `Button`, `Card`,
+  `ListRow`, `Chip`, `SectionHeader`. Prefer them over bespoke views.
+- **Icons are SF Symbols only**, via `src/components/SymbolIcon.tsx` (wraps
+  `expo-symbols`) — no hand-drawn/SVG glyphs. SF Symbols render on iOS/iPadOS only
+  (the current target).
+- Gradients use `expo-linear-gradient` with tokens from `native.ts`
+  (`heroGradient`/`heroGlow`). The atmospheric Home hero is the **only** sanctioned
+  gradient — never a UI-surface gradient. (RN has no radial gradient; the hero
+  approximates it with a linear gradient + a soft glow overlay.)
+- Screens live in `src/screens/`; route files under `app/` are thin wrappers that
+  render them.
+
+## Routing, screens & auth
+
+- `app/(tabs)/_layout.tsx` — the four-tab shell (Home · Songs · Setlists · Daily
+  Word), `headerShown:false` (screens draw their own large-title headers).
+- `app/viewer/[slug].tsx` — Song Viewer, **outside** the tab group (pushes over the
+  shell); currently a placeholder. `app/login.tsx` — the auth screen.
+- **Authenticated-only.** `app/_layout.tsx` gates every route on the Supabase
+  session (redirect to `/login` when signed out, into the tabs when signed in) and
+  holds the native splash (`expo-splash-screen`) until the session resolves *and*
+  the correct screen is mounted, so nothing flashes on first open. Session persists
+  via AsyncStorage until uninstall — don't add proactive sign-outs.
+
+## Data & stubs
+
+- Song data uses core's `fetchSongList` (widen columns via its `opts.columns`);
+  screen data hooks live in `src/lib/` (`useSongList`, `useStarredSongs`).
+- **Stars** are per-user Supabase data — table `user_starred_songs` (`song_id` is a
+  uuid FK to `songs.id`, RLS-scoped to `auth.uid()`). `useStarredSongs` reads them
+  via an inline joined query (read-only for now; starring/unstarring is later). This
+  inline query is the **one sanctioned exception** to "queries live in core" — kept
+  in mobile to avoid a core change; promote it to core when stars grow.
+- **Local history is stubbed.** `src/lib/recents.ts` (`getRecentlyOpened`,
+  `getLastSet`) returns empty and will be backed by the on-device history / setlist
+  layer shipping with the Setlist Builder — consume the stubs, don't mock data.
+  Editable greeting phrases live in `src/lib/greetings.ts` (`SUB_GREETINGS`).
+
+## Out of scope (for now)
+
+The real Song Viewer (chord chart), the Setlists & Daily Word/Reader screens
+(placeholders today), the on-device history/setlist storage layer + star writes,
+the full Auth screen redesign / Google OAuth (see the `TODO: OAuth` in
+`src/screens/LoginScreen.tsx`), tablet master-detail, EAS Build / TestFlight,
+Android, GraceTracks.


### PR DESCRIPTION
The Stage 0/1 mobile sub-doc predated the real UI. Update guidance to match what the app now is:

- apps/mobile/AGENTS.md: it's a real native client (themed 4-tab shell, Song Library + Home, placeholder Viewer, authenticated-only gate), not a slice. Add sections for theme/tokens (useTheme + @gracechords/tokens/native, no hardcoded colors), primitives + SF-Symbols-only + the sanctioned hero gradient, routing & the auth/splash gate, and data hooks + the starred-songs query + the stubbed local-history layer. Note the UI deps and refresh Out-of-scope.
- Root AGENTS.md: describe the mobile app as a real native client and document the native TS token map (@gracechords/tokens/native) alongside web's tokens.css.

CLAUDE.md intentionally stays a pointer to AGENTS.md (per its maintainer note).


Claude-Session: https://claude.ai/code/session_01LzxZxhd4EWDC2VdDMR3bQL