### PR TITLE
fix(web): unbreak Pages Functions deploy - extension-qualified shim i…

### DIFF
--- a/apps/web/src/utils/chordpro/parser.ts
+++ b/apps/web/src/utils/chordpro/parser.ts
@@ -1,3 +1,6 @@
 // Compatibility shim — re-exports from @gracechords/core. Do not add logic here.
 // The implementation moved to packages/core/src/chordpro/parser.
-export * from '@gracechords/core/chordpro/parser'
+// Extension is required: the Cloudflare Pages Functions bundler resolves the
+// core package's `"./*": "./src/*"` exports map literally (no extension
+// guessing), and this shim is in the /api/export/song function's import chain.
+export * from '@gracechords/core/chordpro/parser.ts'

--- a/apps/web/src/utils/songs/instrumental.js
+++ b/apps/web/src/utils/songs/instrumental.js
@@ -1,3 +1,6 @@
 // Compatibility shim — re-exports from @gracechords/core. Do not add logic here.
 // The implementation moved to packages/core/src/songs/instrumental.
-export * from '@gracechords/core/songs/instrumental'
+// Extension is required: the Cloudflare Pages Functions bundler resolves the
+// core package's `"./*": "./src/*"` exports map literally (no extension
+// guessing), and this shim is in the /api/export/song function's import chain.
+export * from '@gracechords/core/songs/instrumental.js'


### PR DESCRIPTION
…mports

The Pages deploy for the export endpoint was failing to build, leaving the previous deployment (without /api/export/song) live - clients saw Cloudflare's static 405/404 instead of the function. Root cause, reproduced locally with `wrangler pages functions build`: the functions bundler resolves @gracechords/core's `"./*": "./src/*"` exports map literally, so the extensionless specifiers in two shims on the function's import chain (utils/chordpro/parser, utils/songs/ instrumental) failed to resolve and killed the build.

Add the explicit .ts/.js extensions to those two shims (Vite resolves the literal mapping identically - web build and test suite verified). The rebuilt functions bundle compiles clean with the pdfium wasm included and gzips to ~2.4 MB, under the 3 MiB Workers limit.


Claude-Session: https://claude.ai/code/session_01LzSrarHMiQpfR9BJaYMZYM