### PR TITLE
fix(telegram-bot): sync core aliases with extension-qualified shims

### DIFF
--- a/workers/telegram-bot/wrangler.toml
+++ b/workers/telegram-bot/wrangler.toml
@@ -66,13 +66,16 @@ binding = "AI"
 # `npm clean-install` only installs this package.json's deps, so the
 # workspace symlink that would normally resolve `@gracechords/core/*` is
 # absent and esbuild fails with "Could not resolve '@gracechords/core/...'".
-# Point the package and its subpaths straight at the source — esbuild
-# resolves the .js/.ts extensions. Wrangler's alias matches specifiers
-# exactly (no subpath/directory aliasing), so each subpath the worker pulls
-# in via the src/utils compatibility shims is listed explicitly.
+# Point the package and its subpaths straight at the source. Wrangler's alias
+# matches specifiers exactly (no subpath/directory aliasing), so each subpath
+# the worker pulls in via the src/utils compatibility shims is listed
+# explicitly. The keys carry the .js/.ts extension because the shims import
+# the extension-qualified specifier — required so the Cloudflare Pages
+# Functions bundler (which resolves core's "./*": "./src/*" exports map
+# literally) can resolve the same shims for /api/export/song.
 "@gracechords/core/chordpro/index.js" = "../../packages/core/src/chordpro/index.js"
-"@gracechords/core/chordpro/parser" = "../../packages/core/src/chordpro/parser.ts"
-"@gracechords/core/songs/instrumental" = "../../packages/core/src/songs/instrumental.js"
+"@gracechords/core/chordpro/parser.ts" = "../../packages/core/src/chordpro/parser.ts"
+"@gracechords/core/songs/instrumental.js" = "../../packages/core/src/songs/instrumental.js"
 
 [observability]
 enabled = true


### PR DESCRIPTION
The previous commit added .ts/.js extensions to two src/utils shims so the Pages Functions bundler (literal "./*": "./src/*" exports-map resolution) could resolve them for /api/export/song. That broke the telegram-bot worker, which resolves the same shims through EXACT-match [alias] keys in wrangler.toml written for the extensionless specifiers.

Update the two alias keys to carry the matching .ts/.js extension so both consumers resolve: Pages via the exports map, the worker via the alias. Verified locally: `wrangler pages functions build` and the worker `wrangler deploy --dry-run` both compile (worker bundle 2.42 MiB gzip, under the 3 MiB limit).


Claude-Session: https://claude.ai/code/session_01LzSrarHMiQpfR9BJaYMZYM