### PR TITLE
Setlist Builder, Performer Mode & whole-set PDF export (mobile)

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -130,8 +130,8 @@ duplicate logic here and never edit core internals to suit mobile.
 
 ## Out of scope (for now)
 
-The Setlist Viewer / performer mode ("Start set"), the setlist share-sheet
-export backends (set PDF / Charts ZIP / ChordPro), the Daily Word/Reader screen
+The whole-set Charts ZIP / ChordPro export backends (whole-set PDF ships via
+`/api/export/setlist`), the Daily Word/Reader screen
 (placeholder today), the on-device history layer + star writes,
 the full Auth screen redesign / Google OAuth (see the `TODO: OAuth` in
 `src/screens/LoginScreen.tsx`), tablet master-detail, EAS Build / TestFlight,

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -118,15 +118,21 @@ duplicate logic here and never edit core internals to suit mobile.
   via an inline joined query (read-only for now; starring/unstarring is later). This
   inline query is the **one sanctioned exception** to "queries live in core" — kept
   in mobile to avoid a core change; promote it to core when stars grow.
-- **Local history is stubbed.** `src/lib/recents.ts` (`getRecentlyOpened`,
-  `getLastSet`) returns empty and will be backed by the on-device history / setlist
-  layer shipping with the Setlist Builder — consume the stubs, don't mock data.
+- **Setlists are per-user Supabase data** — tables `setlists` / `setlist_songs`
+  (per-entry key override in `setlist_songs.key_override`, exposed app-side as
+  `toKey`). Queries live in core's `setlistsRepo` (injected client); mobile hooks
+  are `useSetlists`, `useSetlistBuilder` (debounced wipe-and-replace autosave),
+  and `useLastSet` (Home's "Last set" card).
+- **Local history is stubbed.** `src/lib/recents.ts` (`getRecentlyOpened`) returns
+  empty and will be backed by an on-device history of opened songs — the Viewer
+  should record opens when that layer ships; consume the stub, don't mock data.
   Editable greeting phrases live in `src/lib/greetings.ts` (`SUB_GREETINGS`).
 
 ## Out of scope (for now)
 
-The real Song Viewer (chord chart), the Setlists & Daily Word/Reader screens
-(placeholders today), the on-device history/setlist storage layer + star writes,
+The Setlist Viewer / performer mode ("Start set"), the setlist share-sheet
+export backends (set PDF / Charts ZIP / ChordPro), the Daily Word/Reader screen
+(placeholder today), the on-device history layer + star writes,
 the full Auth screen redesign / Google OAuth (see the `TODO: OAuth` in
 `src/screens/LoginScreen.tsx`), tablet master-detail, EAS Build / TestFlight,
 Android, GraceTracks.

--- a/apps/mobile/app/(tabs)/setlists.tsx
+++ b/apps/mobile/app/(tabs)/setlists.tsx
@@ -1,5 +1,5 @@
-import Placeholder from '../../src/components/Placeholder'
+import SetlistsScreen from '../../src/screens/SetlistsScreen'
 
 export default function SetlistsTab() {
-  return <Placeholder title="Setlists" />
+  return <SetlistsScreen />
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -81,6 +81,7 @@ export default function RootLayout() {
             <Stack.Screen name="login" />
             <Stack.Screen name="viewer/[slug]" />
             <Stack.Screen name="setlist/[id]" />
+            <Stack.Screen name="perform/[id]" />
           </Stack>
         </SafeAreaProvider>
       </ThemeProvider>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Stack, useRouter, useSegments } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import * as SplashScreen from 'expo-splash-screen'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import type { Session } from '@supabase/supabase-js'
 import { ThemeProvider } from '../src/theme/ThemeProvider'
@@ -71,15 +72,18 @@ export default function RootLayout() {
   useProtectedRoute(session, ready)
 
   return (
-    <ThemeProvider>
-      <SafeAreaProvider>
-        <StatusBar style="auto" />
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="login" />
-          <Stack.Screen name="viewer/[slug]" />
-        </Stack>
-      </SafeAreaProvider>
-    </ThemeProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <ThemeProvider>
+        <SafeAreaProvider>
+          <StatusBar style="auto" />
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="(tabs)" />
+            <Stack.Screen name="login" />
+            <Stack.Screen name="viewer/[slug]" />
+            <Stack.Screen name="setlist/[id]" />
+          </Stack>
+        </SafeAreaProvider>
+      </ThemeProvider>
+    </GestureHandlerRootView>
   )
 }

--- a/apps/mobile/app/perform/[id].tsx
+++ b/apps/mobile/app/perform/[id].tsx
@@ -1,0 +1,9 @@
+import { useLocalSearchParams } from 'expo-router'
+import PerformerScreen from '../../src/screens/PerformerScreen'
+
+// Performer / Setlist Viewer route, pushed over the tab shell like
+// viewer/[slug] and setlist/[id].
+export default function PerformerRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  return <PerformerScreen setlistId={id} />
+}

--- a/apps/mobile/app/setlist/[id].tsx
+++ b/apps/mobile/app/setlist/[id].tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router'
+import SetlistBuilderScreen from '../../src/screens/SetlistBuilderScreen'
+
+// Builder route, pushed over the tab shell like viewer/[slug].
+export default function SetlistBuilderRoute() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  return <SetlistBuilderScreen setlistId={id} />
+}

--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
-import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import { ActivityIndicator, Alert, Animated, Linking, Pressable, ScrollView, Text, View } from 'react-native'
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import { runOnJS } from 'react-native-reanimated'
 import * as Haptics from 'expo-haptics'
 import * as Sharing from 'expo-sharing'
 import type { SongDoc } from '@gracechords/core'
@@ -24,6 +26,7 @@ import ViewOptionsSheet from '../../src/components/ViewOptionsSheet'
 import { exportSong } from '../../src/lib/exportSong'
 import { pushSongToTelegram, TELEGRAM_BOT_URL } from '../../src/lib/telegramPush'
 import { useSong } from '../../src/lib/useSong'
+import { useAutoHideChrome, useAutoHidePref } from '../../src/lib/autoHideChrome'
 import { useTheme } from '../../src/theme/ThemeProvider'
 
 // Song Viewer. Pass 1 built the static monospaced chart; pass 2 adds the live
@@ -77,8 +80,22 @@ export default function ViewerScreen() {
   const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
   const [sheet, setSheet] = useState<null | 'options' | 'export'>(null)
 
+  // Chrome auto-hide (persisted preference). Pinned visible while a sheet is
+  // open so it can't hide behind one. Tap the chart to bring it back.
+  const [autoHide, setAutoHide] = useAutoHidePref()
+  // Only arm auto-hide when there's a chart to tap (tap-to-reveal lives on the
+  // chart); otherwise the header could hide with no way to bring it back.
+  const { visible: chromeVisible, opacity: chromeOpacity, reveal } = useAutoHideChrome(
+    autoHide && sheet === null && !!doc,
+  )
+  const tapReveal = useMemo(
+    () => Gesture.Tap().onEnd(() => runOnJS(reveal)()),
+    [reveal],
+  )
+
   const transposeBy = (dir: 1 | -1) => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {})
+    reveal()
     setDelta((d) => d + dir)
   }
 
@@ -149,7 +166,10 @@ export default function ViewerScreen() {
   return (
     <Screen edges={['top', 'left', 'right', 'bottom']}>
       <Stack.Screen options={{ headerShown: false }} />
-      <View style={{ paddingHorizontal: t.spacing.lg, paddingTop: t.spacing.sm }}>
+      <Animated.View
+        pointerEvents={chromeVisible ? 'auto' : 'none'}
+        style={{ opacity: chromeOpacity, paddingHorizontal: t.spacing.lg, paddingTop: t.spacing.sm }}
+      >
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
           <Pressable
             onPress={() => router.back()}
@@ -229,7 +249,7 @@ export default function ViewerScreen() {
             <Text style={{ fontSize: 12.5, color: t.colors.muted }}>{song.tempo} BPM</Text>
           ) : null}
         </View>
-      </View>
+      </Animated.View>
 
       {loading ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
@@ -246,29 +266,32 @@ export default function ViewerScreen() {
         </View>
       ) : doc ? (
         <View style={{ flex: 1 }}>
-          <ScrollView
-            style={{ flex: 1 }}
-            contentContainerStyle={{
-              padding: t.spacing.lg,
-              paddingBottom: t.spacing.xxl * 2 + TRANSPOSE_BAR_CLEARANCE,
-            }}
-          >
-            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-              <ChordChart
-                doc={doc}
-                steps={steps}
-                preferFlat={preferFlat}
-                showChords={showChords}
-                showSections={showSections}
-                fontScale={fontScale}
-                chordStyle={chordStyle}
-              />
+          <GestureDetector gesture={tapReveal}>
+            <ScrollView
+              style={{ flex: 1 }}
+              contentContainerStyle={{
+                padding: t.spacing.lg,
+                paddingBottom: t.spacing.xxl * 2 + TRANSPOSE_BAR_CLEARANCE,
+              }}
+            >
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <ChordChart
+                  doc={doc}
+                  steps={steps}
+                  preferFlat={preferFlat}
+                  showChords={showChords}
+                  showSections={showSections}
+                  fontScale={fontScale}
+                  chordStyle={chordStyle}
+                />
+              </ScrollView>
             </ScrollView>
-          </ScrollView>
+          </GestureDetector>
           {keyLabel ? (
-            <View
-              pointerEvents="box-none"
+            <Animated.View
+              pointerEvents={chromeVisible ? 'box-none' : 'none'}
               style={{
+                opacity: chromeOpacity,
                 position: 'absolute',
                 left: 0,
                 right: 0,
@@ -277,7 +300,7 @@ export default function ViewerScreen() {
               }}
             >
               <TransposeBar keyLabel={keyLabel} onDown={() => transposeBy(-1)} onUp={() => transposeBy(1)} />
-            </View>
+            </Animated.View>
           ) : null}
         </View>
       ) : (
@@ -295,6 +318,8 @@ export default function ViewerScreen() {
         onFontScale={setFontScale}
         chordStyle={chordStyle}
         onChordStyle={setChordStyle}
+        autoHide={autoHide}
+        onAutoHide={setAutoHide}
       />
       <ExportSheet
         visible={sheet === 'export'}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@supabase/supabase-js": "^2.98.0",
     "expo": "~55.0.27",
+    "expo-clipboard": "~55.0.14",
     "expo-constants": "~55.0.16",
     "expo-file-system": "~55.0.23",
     "expo-haptics": "~55.0.15",
@@ -29,9 +30,12 @@
     "expo-symbols": "~55.0.9",
     "react": "19.2.0",
     "react-native": "0.83.6",
+    "react-native-gesture-handler": "~2.30.0",
+    "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
-    "react-native-url-polyfill": "^2.0.0"
+    "react-native-url-polyfill": "^2.0.0",
+    "react-native-worklets": "0.7.4"
   },
   "devDependencies": {
     "@types/react": "~19.2.0",

--- a/apps/mobile/src/components/BottomSheet.tsx
+++ b/apps/mobile/src/components/BottomSheet.tsx
@@ -14,6 +14,7 @@ export default function BottomSheet({
   title,
   actionLabel = 'Done',
   onAction,
+  onDismissed,
   closeAccessibilityLabel,
   children,
 }: {
@@ -23,6 +24,11 @@ export default function BottomSheet({
   actionLabel?: string
   /** Header action; defaults to closing the sheet. */
   onAction?: () => void
+  /**
+   * Fires once the exit animation finishes and the Modal unmounts — the safe
+   * moment to present another modal (iOS refuses while one is dismissing).
+   */
+  onDismissed?: () => void
   closeAccessibilityLabel?: string
   children: ReactNode
 }) {
@@ -30,6 +36,10 @@ export default function BottomSheet({
   const { height } = useWindowDimensions()
   const [mounted, setMounted] = useState(visible)
   const progress = useRef(new Animated.Value(0)).current
+  // Ref so the exit animation's completion callback always sees the latest
+  // handler without retriggering the effect.
+  const onDismissedRef = useRef(onDismissed)
+  onDismissedRef.current = onDismissed
 
   useEffect(() => {
     if (visible) {
@@ -47,7 +57,10 @@ export default function BottomSheet({
         easing: Easing.in(Easing.cubic),
         useNativeDriver: true,
       }).start(({ finished }) => {
-        if (finished) setMounted(false)
+        if (finished) {
+          setMounted(false)
+          onDismissedRef.current?.()
+        }
       })
     }
   }, [visible, progress])

--- a/apps/mobile/src/components/ListRow.tsx
+++ b/apps/mobile/src/components/ListRow.tsx
@@ -1,15 +1,20 @@
+import type { ReactNode } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { useTheme } from '../theme/ThemeProvider'
 
 // The dense, text-only list row from the design: a title + optional subtitle on
 // the left, and an optional two-line trailing block on the right (used for
-// key / time signature). Nothing else — density and scan-speed over decoration.
+// key / time signature). `trailing` renders a custom accessory after that
+// block (e.g. the add-songs +/✓ badge). Density and scan-speed over decoration.
 
 export type ListRowProps = {
   title: string
   subtitle?: string | null
   trailingTop?: string | null
   trailingBottom?: string | null
+  /** Custom accessory rendered at the far right. */
+  trailing?: ReactNode
+  accessibilityLabel?: string
   onPress?: () => void
 }
 
@@ -18,6 +23,8 @@ export default function ListRow({
   subtitle,
   trailingTop,
   trailingBottom,
+  trailing,
+  accessibilityLabel,
   onPress,
 }: ListRowProps) {
   const t = useTheme()
@@ -25,6 +32,7 @@ export default function ListRow({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
       style={({ pressed }) => ({
         flexDirection: 'row',
         alignItems: 'center',
@@ -88,6 +96,8 @@ export default function ListRow({
           ) : null}
         </View>
       ) : null}
+
+      {trailing}
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -94,6 +94,8 @@ export default function ViewOptionsSheet({
   onFontScale,
   chordStyle,
   onChordStyle,
+  autoHide,
+  onAutoHide,
 }: {
   visible: boolean
   onClose: () => void
@@ -105,6 +107,10 @@ export default function ViewOptionsSheet({
   onFontScale: (v: number) => void
   chordStyle: ChordStyle
   onChordStyle: (v: ChordStyle) => void
+  // Optional "hide controls when idle" toggle — rendered only when the screen
+  // wires it (Song Viewer + Setlist Performer).
+  autoHide?: boolean
+  onAutoHide?: (v: boolean) => void
 }) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
@@ -221,6 +227,30 @@ export default function ViewOptionsSheet({
           value={chordStyle}
           onChange={onChordStyle}
         />
+
+        {/* Hide controls when idle — persists across launches (unlike the
+            options above). Rendered only when the screen wires it. */}
+        {onAutoHide ? (
+          <>
+            <OverlineLabel>Screen</OverlineLabel>
+            <View
+              style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
+            >
+              <View style={{ flex: 1, paddingRight: t.spacing.md }}>
+                <Text style={{ fontSize: 16, color: t.colors.ink }}>Hide controls when idle</Text>
+                <Text style={{ marginTop: 2, fontSize: 12.5, color: t.colors.muted }}>
+                  Full-page view after a few seconds. Tap to bring them back.
+                </Text>
+              </View>
+              <Switch
+                value={!!autoHide}
+                onValueChange={onAutoHide}
+                trackColor={{ true: t.colors.accent }}
+                accessibilityLabel="Hide controls when idle"
+              />
+            </View>
+          </>
+        ) : null}
       </View>
     </BottomSheet>
   )

--- a/apps/mobile/src/components/setlist/ActionSheetRow.tsx
+++ b/apps/mobile/src/components/setlist/ActionSheetRow.tsx
@@ -1,0 +1,43 @@
+import { Pressable, Text, View } from 'react-native'
+import SymbolIcon, { type SymbolIconProps } from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// One tappable action row inside a setlist bottom sheet (icon + label),
+// matching the reference's stacked sheet actions. `destructive` renders in
+// the danger color for delete/remove actions.
+export default function ActionSheetRow({
+  icon,
+  label,
+  onPress,
+  destructive = false,
+}: {
+  icon: SymbolIconProps['name']
+  label: string
+  onPress: () => void
+  destructive?: boolean
+}) {
+  const t = useTheme()
+  const color = destructive ? t.colors.danger : t.colors.ink
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        padding: t.spacing.md,
+        borderRadius: t.radii.md,
+        backgroundColor: pressed ? t.colors.border : t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+      })}
+    >
+      <View style={{ width: 26, alignItems: 'center' }}>
+        <SymbolIcon name={icon} size={18} color={destructive ? t.colors.danger : t.colors.accent} />
+      </View>
+      <Text style={{ fontSize: 15.5, fontWeight: '600', color }}>{label}</Text>
+    </Pressable>
+  )
+}

--- a/apps/mobile/src/components/setlist/AddSongsModal.tsx
+++ b/apps/mobile/src/components/setlist/AddSongsModal.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState } from 'react'
+import { FlatList, Modal, Pressable, Text, TextInput, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import SymbolIcon from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+import type { Song } from '../../lib/useSongList'
+
+// Full-screen "Add songs" picker (slides up over the builder): the Song
+// Library's search-filter pattern in add-mode — each row's trailing + flips
+// to a ✓ while the set count ticks up behind the sheet. The caller owns the
+// song list (already fetched for the builder) and the toggle mutation.
+export default function AddSongsModal({
+  visible,
+  onClose,
+  songs,
+  addedSongIds,
+  onToggle,
+}: {
+  visible: boolean
+  onClose: () => void
+  songs: Song[]
+  addedSongIds: Set<string>
+  onToggle: (song: Song) => void
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const [query, setQuery] = useState('')
+
+  const trimmed = query.trim().toLowerCase()
+  const results = useMemo(() => {
+    const base = trimmed
+      ? songs.filter(
+          (s) =>
+            s.title.toLowerCase().includes(trimmed) ||
+            (s.artist ?? '').toLowerCase().includes(trimmed),
+        )
+      : songs
+    return base.slice().sort((a, b) => a.title.localeCompare(b.title))
+  }, [songs, trimmed])
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={{ flex: 1, backgroundColor: t.colors.bg, paddingTop: insets.top }}>
+        {/* Header */}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingHorizontal: t.spacing.lg,
+            paddingVertical: t.spacing.sm,
+          }}
+        >
+          <Text style={{ fontSize: 18, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
+            Add songs
+          </Text>
+          <Pressable onPress={onClose} accessibilityRole="button" accessibilityLabel="Done adding songs" hitSlop={8}>
+            <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.textAccent }}>Done</Text>
+          </Pressable>
+        </View>
+
+        {/* Search field */}
+        <View style={{ paddingHorizontal: t.spacing.lg, paddingBottom: t.spacing.sm }}>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 8,
+              backgroundColor: t.colors.surfaceAlt,
+              borderRadius: t.radii.sm,
+              paddingHorizontal: 12,
+              height: 44,
+            }}
+          >
+            <SymbolIcon name="magnifyingglass" size={18} color={t.colors.muted} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Search songs, artists, themes…"
+              placeholderTextColor={t.colors.muted}
+              returnKeyType="search"
+              autoCorrect={false}
+              style={{ flex: 1, fontSize: 16, color: t.colors.ink, padding: 0 }}
+            />
+            {query ? (
+              <Pressable onPress={() => setQuery('')} accessibilityRole="button" accessibilityLabel="Clear search" hitSlop={8}>
+                <SymbolIcon name="xmark.circle.fill" size={17} color={t.colors.muted} />
+              </Pressable>
+            ) : null}
+          </View>
+        </View>
+
+        {/* Results */}
+        <FlatList
+          data={results}
+          keyExtractor={(item) => item.id}
+          keyboardShouldPersistTaps="handled"
+          ListEmptyComponent={
+            <View style={{ alignItems: 'center', padding: t.spacing.xl }}>
+              <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+                {trimmed ? `No songs match “${query.trim()}”.` : 'Your library is empty.'}
+              </Text>
+            </View>
+          }
+          renderItem={({ item }) => {
+            const added = addedSongIds.has(item.id)
+            return (
+              <Pressable
+                onPress={() => onToggle(item)}
+                accessibilityRole="button"
+                accessibilityLabel={added ? `Remove ${item.title} from set` : `Add ${item.title} to set`}
+                style={({ pressed }) => ({
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: t.spacing.md,
+                  paddingVertical: 11,
+                  paddingHorizontal: t.spacing.xl,
+                  borderBottomWidth: 0.5,
+                  borderBottomColor: t.colors.border,
+                  backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
+                })}
+              >
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text
+                    numberOfLines={1}
+                    style={{
+                      fontSize: t.typography.rowTitle.fontSize,
+                      fontWeight: t.typography.rowTitle.fontWeight,
+                      letterSpacing: t.typography.rowTitle.letterSpacing,
+                      color: t.colors.ink,
+                    }}
+                  >
+                    {item.title}
+                  </Text>
+                  {item.artist ? (
+                    <Text
+                      numberOfLines={1}
+                      style={{ marginTop: 2, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}
+                    >
+                      {item.artist}
+                    </Text>
+                  ) : null}
+                </View>
+                {item.default_key ? (
+                  <Text
+                    style={{
+                      fontSize: t.typography.rowKey.fontSize,
+                      fontWeight: t.typography.rowKey.fontWeight,
+                      color: t.colors.textAccent,
+                    }}
+                  >
+                    {item.default_key}
+                  </Text>
+                ) : null}
+                <View
+                  style={{
+                    width: 30,
+                    height: 30,
+                    borderRadius: t.radii.pill,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: added ? t.colors.accent : t.colors.accentSoft,
+                  }}
+                >
+                  <SymbolIcon
+                    name={added ? 'checkmark' : 'plus'}
+                    size={15}
+                    weight="semibold"
+                    color={added ? t.colors.onAccent : t.colors.textAccent}
+                  />
+                </View>
+              </Pressable>
+            )
+          }}
+          contentContainerStyle={{ paddingBottom: insets.bottom + t.spacing.lg, flexGrow: 1 }}
+        />
+      </View>
+    </Modal>
+  )
+}

--- a/apps/mobile/src/components/setlist/AddSongsModal.tsx
+++ b/apps/mobile/src/components/setlist/AddSongsModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { FlatList, Modal, Pressable, Text, TextInput, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import ListRow from '../ListRow'
 import SymbolIcon from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
 import type { Song } from '../../lib/useSongList'
@@ -105,71 +106,32 @@ export default function AddSongsModal({
           renderItem={({ item }) => {
             const added = addedSongIds.has(item.id)
             return (
-              <Pressable
-                onPress={() => onToggle(item)}
-                accessibilityRole="button"
+              <ListRow
+                title={item.title}
+                subtitle={item.artist}
+                trailingTop={item.default_key}
                 accessibilityLabel={added ? `Remove ${item.title} from set` : `Add ${item.title} to set`}
-                style={({ pressed }) => ({
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: t.spacing.md,
-                  paddingVertical: 11,
-                  paddingHorizontal: t.spacing.xl,
-                  borderBottomWidth: 0.5,
-                  borderBottomColor: t.colors.border,
-                  backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
-                })}
-              >
-                <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text
-                    numberOfLines={1}
+                onPress={() => onToggle(item)}
+                trailing={
+                  <View
                     style={{
-                      fontSize: t.typography.rowTitle.fontSize,
-                      fontWeight: t.typography.rowTitle.fontWeight,
-                      letterSpacing: t.typography.rowTitle.letterSpacing,
-                      color: t.colors.ink,
+                      width: 30,
+                      height: 30,
+                      borderRadius: t.radii.pill,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: added ? t.colors.accent : t.colors.accentSoft,
                     }}
                   >
-                    {item.title}
-                  </Text>
-                  {item.artist ? (
-                    <Text
-                      numberOfLines={1}
-                      style={{ marginTop: 2, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}
-                    >
-                      {item.artist}
-                    </Text>
-                  ) : null}
-                </View>
-                {item.default_key ? (
-                  <Text
-                    style={{
-                      fontSize: t.typography.rowKey.fontSize,
-                      fontWeight: t.typography.rowKey.fontWeight,
-                      color: t.colors.textAccent,
-                    }}
-                  >
-                    {item.default_key}
-                  </Text>
-                ) : null}
-                <View
-                  style={{
-                    width: 30,
-                    height: 30,
-                    borderRadius: t.radii.pill,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: added ? t.colors.accent : t.colors.accentSoft,
-                  }}
-                >
-                  <SymbolIcon
-                    name={added ? 'checkmark' : 'plus'}
-                    size={15}
-                    weight="semibold"
-                    color={added ? t.colors.onAccent : t.colors.textAccent}
-                  />
-                </View>
-              </Pressable>
+                    <SymbolIcon
+                      name={added ? 'checkmark' : 'plus'}
+                      size={15}
+                      weight="semibold"
+                      color={added ? t.colors.onAccent : t.colors.textAccent}
+                    />
+                  </View>
+                }
+              />
             )
           }}
           contentContainerStyle={{ paddingBottom: insets.bottom + t.spacing.lg, flexGrow: 1 }}

--- a/apps/mobile/src/components/setlist/KeyPickerSheet.tsx
+++ b/apps/mobile/src/components/setlist/KeyPickerSheet.tsx
@@ -1,27 +1,36 @@
 import { Pressable, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { KEYS } from '@gracechords/core'
+import { KEYS, normKey } from '@gracechords/core'
 import BottomSheet from '../BottomSheet'
 import { useTheme } from '../../theme/ThemeProvider'
 
-// "Play this song in…" — a 4-column grid of the 12 keys, current highlighted.
-// Picking a key sets the entry's setlist-scoped override and closes.
+// "Play this song in…" — a 4-column grid of the 12 keys, current highlighted
+// (flat spellings like "Bb" normalize to their sharp cell). Picking a key sets
+// the entry's setlist-scoped override and closes; "Use native key" clears the
+// override so the entry follows the song's default key again.
 export default function KeyPickerSheet({
   visible,
   onClose,
   songTitle,
   currentKey,
+  nativeKey,
+  hasOverride,
   onPick,
 }: {
   visible: boolean
   onClose: () => void
   songTitle: string | null
   currentKey: string | null
-  onPick: (key: string) => void
+  /** The song's own key, shown on the reset row. */
+  nativeKey: string | null
+  /** Whether the entry currently stores an override (enables the reset row). */
+  hasOverride: boolean
+  onPick: (key: string | null) => void
 }) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
   const keys = KEYS as readonly string[]
+  const current = currentKey ? (normKey(currentKey) as string) : null
 
   return (
     <BottomSheet visible={visible} onClose={onClose} title="Key" closeAccessibilityLabel="Close key picker">
@@ -33,7 +42,7 @@ export default function KeyPickerSheet({
         ) : null}
         <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: t.spacing.sm }}>
           {keys.map((key) => {
-            const selected = key === currentKey
+            const selected = key === current
             return (
               <Pressable
                 key={key}
@@ -70,6 +79,29 @@ export default function KeyPickerSheet({
             )
           })}
         </View>
+        {hasOverride ? (
+          <Pressable
+            onPress={() => {
+              onPick(null)
+              onClose()
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Use the song's native key"
+            style={({ pressed }) => ({
+              height: 44,
+              borderRadius: t.radii.sm,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: pressed ? t.colors.border : t.colors.surfaceAlt,
+              borderWidth: 1,
+              borderColor: t.colors.border,
+            })}
+          >
+            <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.textAccent }}>
+              Use native key{nativeKey ? ` (${nativeKey})` : ''}
+            </Text>
+          </Pressable>
+        ) : null}
       </View>
     </BottomSheet>
   )

--- a/apps/mobile/src/components/setlist/KeyPickerSheet.tsx
+++ b/apps/mobile/src/components/setlist/KeyPickerSheet.tsx
@@ -1,0 +1,76 @@
+import { Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { KEYS } from '@gracechords/core'
+import BottomSheet from '../BottomSheet'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// "Play this song in…" — a 4-column grid of the 12 keys, current highlighted.
+// Picking a key sets the entry's setlist-scoped override and closes.
+export default function KeyPickerSheet({
+  visible,
+  onClose,
+  songTitle,
+  currentKey,
+  onPick,
+}: {
+  visible: boolean
+  onClose: () => void
+  songTitle: string | null
+  currentKey: string | null
+  onPick: (key: string) => void
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const keys = KEYS as readonly string[]
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} title="Key" closeAccessibilityLabel="Close key picker">
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.md }}>
+        {songTitle ? (
+          <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
+            Play {songTitle} in…
+          </Text>
+        ) : null}
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: t.spacing.sm }}>
+          {keys.map((key) => {
+            const selected = key === currentKey
+            return (
+              <Pressable
+                key={key}
+                onPress={() => {
+                  onPick(key)
+                  onClose()
+                }}
+                accessibilityRole="button"
+                accessibilityLabel={`Key of ${key}`}
+                accessibilityState={{ selected }}
+                style={{
+                  // 4 columns with the wrap gap accounted for.
+                  flexBasis: '22%',
+                  flexGrow: 1,
+                  height: 44,
+                  borderRadius: t.radii.sm,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: selected ? t.colors.accent : t.colors.surfaceAlt,
+                  borderWidth: 1,
+                  borderColor: selected ? t.colors.accent : t.colors.border,
+                }}
+              >
+                <Text
+                  style={{
+                    fontSize: 15,
+                    fontWeight: '700',
+                    color: selected ? t.colors.onAccent : t.colors.ink,
+                  }}
+                >
+                  {key}
+                </Text>
+              </Pressable>
+            )
+          })}
+        </View>
+      </View>
+    </BottomSheet>
+  )
+}

--- a/apps/mobile/src/components/setlist/PerformerShareSheet.tsx
+++ b/apps/mobile/src/components/setlist/PerformerShareSheet.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import BottomSheet from '../BottomSheet'
+import SymbolIcon, { type SymbolIconProps } from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// Performer "Export & share" sheet with a This song / Whole set scope toggle.
+// This-song mirrors the Song Viewer's ExportSheet (system share + PDF/JPG +
+// Telegram, no ChordPro). Whole-set offers the combined PDF (server endpoint),
+// Copy link and Telegram — all working today — with Charts ZIP / ChordPro /
+// Set list rendered disabled ("Coming soon") pending backends. The screen owns
+// the async work and error alerts; this component only tracks which action is
+// busy.
+
+type Scope = 'song' | 'set'
+type Busy = string | null
+
+export type PerformerShareHandlers = {
+  // This song
+  onShareSong: () => Promise<void>
+  onExportSong: (format: 'pdf' | 'jpg') => Promise<void>
+  onTelegramSong: () => Promise<void>
+  // Whole set
+  onExportSet: () => Promise<void>
+  onCopyLink: () => Promise<void>
+  onTelegramSet: () => Promise<void>
+}
+
+export default function PerformerShareSheet({
+  visible,
+  onClose,
+  songCount,
+  initialScope,
+  handlers,
+}: {
+  visible: boolean
+  onClose: () => void
+  songCount: number
+  /** Defaults the toggle: whole set for multi-song, this song otherwise. */
+  initialScope: Scope
+  handlers: PerformerShareHandlers
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const [scope, setScope] = useState<Scope>(initialScope)
+  const [busy, setBusy] = useState<Busy>(null)
+
+  // Re-seed the scope each time the sheet opens (single-song sets shouldn't
+  // land on "Whole set").
+  useEffect(() => {
+    if (visible) setScope(initialScope)
+  }, [visible, initialScope])
+
+  const run = (which: string, fn: () => Promise<void>) => async () => {
+    if (busy) return
+    setBusy(which)
+    try {
+      await fn()
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const primaryButton = (label: string, icon: SymbolIconProps['name'], which: string, fn: () => Promise<void>) => (
+    <Pressable
+      onPress={run(which, fn)}
+      disabled={!!busy}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={{
+        height: 50,
+        borderRadius: 13,
+        backgroundColor: t.colors.accent,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: t.spacing.sm,
+        opacity: busy && busy !== which ? 0.5 : 1,
+      }}
+    >
+      {busy === which ? (
+        <ActivityIndicator color={t.colors.onAccent} />
+      ) : (
+        <SymbolIcon name={icon} size={19} color={t.colors.onAccent} />
+      )}
+      <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.onAccent }}>{label}</Text>
+    </Pressable>
+  )
+
+  const actionTile = (label: string, icon: SymbolIconProps['name'], which: string, fn: () => Promise<void>) => (
+    <Pressable
+      key={label}
+      onPress={run(which, fn)}
+      disabled={!!busy}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        gap: 6,
+        paddingVertical: 14,
+        borderRadius: 13,
+        backgroundColor: t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+        opacity: busy && busy !== which ? 0.5 : 1,
+      }}
+    >
+      {busy === which ? (
+        <ActivityIndicator color={t.colors.accent} />
+      ) : (
+        <SymbolIcon name={icon} size={24} color={t.colors.accent} />
+      )}
+      <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+    </Pressable>
+  )
+
+  const disabledTile = (label: string, icon: SymbolIconProps['name']) => (
+    <View
+      key={label}
+      accessibilityLabel={`${label} — coming soon`}
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        gap: 6,
+        paddingVertical: 14,
+        borderRadius: 13,
+        backgroundColor: t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+        opacity: 0.45,
+      }}
+    >
+      <SymbolIcon name={icon} size={24} color={t.colors.accent} />
+      <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+      <Text style={{ fontSize: 10.5, color: t.colors.muted }}>Coming soon</Text>
+    </View>
+  )
+
+  const telegramRow = (label: string, which: string, fn: () => Promise<void>) => (
+    <Pressable
+      onPress={run(which, fn)}
+      disabled={!!busy}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 11,
+        padding: t.spacing.md,
+        borderRadius: 13,
+        backgroundColor: t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+        opacity: busy && busy !== which ? 0.5 : 1,
+      }}
+    >
+      <View
+        style={{
+          width: 30,
+          height: 30,
+          borderRadius: 15,
+          backgroundColor: t.colors.accentSoft,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {busy === which ? (
+          <ActivityIndicator size="small" color={t.colors.accent} />
+        ) : (
+          <SymbolIcon name="paperplane.fill" size={15} color={t.colors.accent} />
+        )}
+      </View>
+      <View style={{ flex: 1 }}>
+        <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+        <Text style={{ fontSize: 11.5, color: t.colors.muted }}>Optional bot</Text>
+      </View>
+      <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+    </Pressable>
+  )
+
+  const segment = (value: Scope, label: string) => {
+    const active = scope === value
+    return (
+      <Pressable
+        onPress={() => setScope(value)}
+        accessibilityRole="button"
+        accessibilityState={{ selected: active }}
+        style={{
+          flex: 1,
+          height: 34,
+          borderRadius: 8,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: active ? t.colors.surface : 'transparent',
+        }}
+      >
+        <Text style={{ fontSize: 14, fontWeight: '600', color: active ? t.colors.ink : t.colors.sec }}>
+          {label}
+        </Text>
+      </Pressable>
+    )
+  }
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      title="Export & share"
+      closeAccessibilityLabel="Close export and share"
+    >
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.md }}>
+        {/* Scope toggle */}
+        <View
+          style={{
+            flexDirection: 'row',
+            padding: 3,
+            borderRadius: 10,
+            backgroundColor: t.colors.surfaceAlt,
+          }}
+        >
+          {segment('song', 'This song')}
+          {segment('set', 'Whole set')}
+        </View>
+
+        {scope === 'song' ? (
+          <>
+            {primaryButton('Open share sheet…', 'square.and.arrow.up', 'song-share', handlers.onShareSong)}
+            <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+              {actionTile('PDF', 'doc.text', 'song-pdf', () => handlers.onExportSong('pdf'))}
+              {actionTile('JPG', 'photo', 'song-jpg', () => handlers.onExportSong('jpg'))}
+            </View>
+            {telegramRow('Send to Telegram', 'song-telegram', handlers.onTelegramSong)}
+          </>
+        ) : (
+          <>
+            {primaryButton(
+              `Export set as PDF · ${songCount} ${songCount === 1 ? 'song' : 'songs'}`,
+              'square.and.arrow.down',
+              'set-pdf',
+              handlers.onExportSet,
+            )}
+            <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+              {disabledTile('Charts ZIP', 'folder')}
+              {disabledTile('ChordPro', 'music.note.list')}
+              {actionTile('Copy link', 'link', 'set-link', handlers.onCopyLink)}
+            </View>
+            {telegramRow('Send set to Telegram', 'set-telegram', handlers.onTelegramSet)}
+          </>
+        )}
+      </View>
+    </BottomSheet>
+  )
+}

--- a/apps/mobile/src/components/setlist/RowActionsSheet.tsx
+++ b/apps/mobile/src/components/setlist/RowActionsSheet.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '../../theme/ThemeProvider'
 export default function RowActionsSheet({
   visible,
   onClose,
+  onDismissed,
   songTitle,
   onChangeKey,
   onDuplicate,
@@ -15,6 +16,8 @@ export default function RowActionsSheet({
 }: {
   visible: boolean
   onClose: () => void
+  /** Fires once fully dismissed — safe to present a follow-up sheet. */
+  onDismissed?: () => void
   songTitle: string
   onChangeKey: () => void
   onDuplicate: () => void
@@ -32,6 +35,7 @@ export default function RowActionsSheet({
     <BottomSheet
       visible={visible}
       onClose={onClose}
+      onDismissed={onDismissed}
       title={songTitle}
       closeAccessibilityLabel="Close song options"
     >

--- a/apps/mobile/src/components/setlist/RowActionsSheet.tsx
+++ b/apps/mobile/src/components/setlist/RowActionsSheet.tsx
@@ -1,0 +1,45 @@
+import { View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import BottomSheet from '../BottomSheet'
+import ActionSheetRow from './ActionSheetRow'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// Per-song ••• sheet: Change key / Duplicate / Remove from set.
+export default function RowActionsSheet({
+  visible,
+  onClose,
+  songTitle,
+  onChangeKey,
+  onDuplicate,
+  onRemove,
+}: {
+  visible: boolean
+  onClose: () => void
+  songTitle: string
+  onChangeKey: () => void
+  onDuplicate: () => void
+  onRemove: () => void
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+
+  const run = (fn: () => void) => () => {
+    onClose()
+    fn()
+  }
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      title={songTitle}
+      closeAccessibilityLabel="Close song options"
+    >
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.sm }}>
+        <ActionSheetRow icon="music.note" label="Change key" onPress={run(onChangeKey)} />
+        <ActionSheetRow icon="plus.square.on.square" label="Duplicate" onPress={run(onDuplicate)} />
+        <ActionSheetRow icon="trash" label="Remove from set" destructive onPress={run(onRemove)} />
+      </View>
+    </BottomSheet>
+  )
+}

--- a/apps/mobile/src/components/setlist/SetOptionsSheet.tsx
+++ b/apps/mobile/src/components/setlist/SetOptionsSheet.tsx
@@ -1,0 +1,43 @@
+import { View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import BottomSheet from '../BottomSheet'
+import ActionSheetRow from './ActionSheetRow'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// The setlist ••• sheet: Rename set / Saved sets… / New set / Delete set.
+// "Saved sets…" navigates back to the Setlists tab (the saved-sets list
+// screen) rather than opening a nested sheet.
+export default function SetOptionsSheet({
+  visible,
+  onClose,
+  onRename,
+  onSavedSets,
+  onNewSet,
+  onDeleteSet,
+}: {
+  visible: boolean
+  onClose: () => void
+  onRename: () => void
+  onSavedSets: () => void
+  onNewSet: () => void
+  onDeleteSet: () => void
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+
+  const run = (fn: () => void) => () => {
+    onClose()
+    fn()
+  }
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} title="Setlist" closeAccessibilityLabel="Close setlist options">
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.sm }}>
+        <ActionSheetRow icon="pencil" label="Rename set" onPress={run(onRename)} />
+        <ActionSheetRow icon="list.bullet" label="Saved sets…" onPress={run(onSavedSets)} />
+        <ActionSheetRow icon="plus" label="New set" onPress={run(onNewSet)} />
+        <ActionSheetRow icon="trash" label="Delete set" destructive onPress={run(onDeleteSet)} />
+      </View>
+    </BottomSheet>
+  )
+}

--- a/apps/mobile/src/components/setlist/SetlistTimeline.tsx
+++ b/apps/mobile/src/components/setlist/SetlistTimeline.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { memo, useCallback } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable'
@@ -38,7 +38,10 @@ function clampWorklet(value: number, lo: number, hi: number) {
   return Math.max(lo, Math.min(hi, value))
 }
 
-function Row({
+// Memoized so screen-level state churn (rename keystrokes, toasts) doesn't
+// re-render every row and rebuild its gesture/worklet chain — callers must
+// pass a stable `callbacks` object.
+const Row = memo(function Row({
   item,
   index,
   count,
@@ -276,7 +279,7 @@ function Row({
       </Animated.View>
     </Animated.View>
   )
-}
+})
 
 export default function SetlistTimeline({
   items,

--- a/apps/mobile/src/components/setlist/SetlistTimeline.tsx
+++ b/apps/mobile/src/components/setlist/SetlistTimeline.tsx
@@ -1,0 +1,312 @@
+import { useCallback } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable'
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated'
+import * as Haptics from 'expo-haptics'
+import SymbolIcon from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+import type { SetlistItem } from '../../lib/useSetlistBuilder'
+
+// The builder's numbered timeline: drag grip + numbered badge on a vertical
+// rail + title/artist + key chip + per-row menu. Reordering is a hand-rolled
+// long-press pan on the grip (react-native-draggable-flatlist is not
+// maintained against reanimated v4 / the New Architecture): the active row
+// follows the finger while the others animate out of the way by whole row
+// heights, and the move commits on release. Rows are fixed-height so the
+// drag math is pure arithmetic. Swiping the row body left past the threshold
+// removes the entry — horizontal, so it never fights the vertical grip drag.
+
+export const ROW_HEIGHT = 64
+
+export type TimelineCallbacks = {
+  onPressRow: (index: number) => void
+  onKeyTap: (index: number) => void
+  onRowMenu: (index: number) => void
+  onMove: (from: number, to: number) => void
+  onRemove: (index: number) => void
+}
+
+function clampWorklet(value: number, lo: number, hi: number) {
+  'worklet'
+  return Math.max(lo, Math.min(hi, value))
+}
+
+function Row({
+  item,
+  index,
+  count,
+  effectiveKey,
+  activeIndex,
+  proposedIndex,
+  dragY,
+  callbacks,
+}: {
+  item: SetlistItem
+  index: number
+  count: number
+  effectiveKey: string | null
+  activeIndex: SharedValue<number>
+  proposedIndex: SharedValue<number>
+  dragY: SharedValue<number>
+  callbacks: TimelineCallbacks
+}) {
+  const t = useTheme()
+
+  const startDragHaptic = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {})
+  }, [])
+
+  const commitMove = useCallback(
+    (from: number, to: number) => {
+      if (from !== to) callbacks.onMove(from, to)
+    },
+    [callbacks],
+  )
+
+  const pan = Gesture.Pan()
+    .activateAfterLongPress(150)
+    .onStart(() => {
+      activeIndex.value = index
+      proposedIndex.value = index
+      dragY.value = 0
+      runOnJS(startDragHaptic)()
+    })
+    .onUpdate((e) => {
+      dragY.value = e.translationY
+      proposedIndex.value = clampWorklet(
+        index + Math.round(e.translationY / ROW_HEIGHT),
+        0,
+        count - 1,
+      )
+    })
+    .onEnd(() => {
+      runOnJS(commitMove)(index, proposedIndex.value)
+    })
+    .onFinalize(() => {
+      activeIndex.value = -1
+      dragY.value = 0
+    })
+
+  const animatedStyle = useAnimatedStyle(() => {
+    if (activeIndex.value === index) {
+      return {
+        zIndex: 10,
+        transform: [{ translateY: dragY.value }, { scale: 1.02 }],
+      }
+    }
+    let offset = 0
+    if (activeIndex.value >= 0) {
+      const from = activeIndex.value
+      const to = proposedIndex.value
+      if (from < index && index <= to) offset = -ROW_HEIGHT
+      else if (to <= index && index < from) offset = ROW_HEIGHT
+    }
+    return {
+      zIndex: 0,
+      transform: [{ translateY: withTiming(offset, { duration: 140 }) }, { scale: 1 }],
+    }
+  })
+
+  const liftedStyle = useAnimatedStyle(() => ({
+    backgroundColor: activeIndex.value === index ? t.colors.surface : t.colors.bg,
+    shadowOpacity: withTiming(activeIndex.value === index ? 0.25 : 0, { duration: 120 }),
+  }))
+
+  const renderRightActions = () => (
+    <View
+      style={{
+        width: 88,
+        height: '100%',
+        backgroundColor: t.colors.danger,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 4,
+      }}
+    >
+      <SymbolIcon name="trash" size={20} color={t.colors.onDanger} />
+      <Text style={{ fontSize: 12, fontWeight: '600', color: t.colors.onDanger }}>Remove</Text>
+    </View>
+  )
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <Animated.View
+        style={[
+          {
+            borderRadius: t.radii.md,
+            shadowColor: '#000',
+            shadowOffset: { width: 0, height: 6 },
+            shadowRadius: 12,
+            elevation: 4,
+          },
+          liftedStyle,
+        ]}
+      >
+        <ReanimatedSwipeable
+          friction={2}
+          rightThreshold={64}
+          overshootRight={false}
+          renderRightActions={renderRightActions}
+          onSwipeableWillOpen={() => callbacks.onRemove(index)}
+        >
+          <View
+            style={{
+              height: ROW_HEIGHT,
+              flexDirection: 'row',
+              alignItems: 'center',
+              backgroundColor: 'transparent',
+            }}
+          >
+            {/* Drag grip */}
+            <GestureDetector gesture={pan}>
+              <View
+                accessibilityLabel={`Reorder ${item.song.title}`}
+                style={{
+                  width: 40,
+                  height: '100%',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <SymbolIcon name="line.3.horizontal" size={17} color={t.colors.muted} />
+              </View>
+            </GestureDetector>
+
+            {/* Numbered badge on the rail */}
+            <View style={{ width: 34, height: '100%', alignItems: 'center' }}>
+              <View
+                style={{
+                  position: 'absolute',
+                  top: index === 0 ? ROW_HEIGHT / 2 : 0,
+                  bottom: index === count - 1 ? ROW_HEIGHT / 2 : 0,
+                  width: 2,
+                  backgroundColor: t.colors.border,
+                  opacity: count > 1 ? 1 : 0,
+                }}
+              />
+              <View
+                style={{
+                  marginTop: ROW_HEIGHT / 2 - 13,
+                  width: 26,
+                  height: 26,
+                  borderRadius: t.radii.pill,
+                  backgroundColor: t.colors.accentSoft,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Text style={{ fontSize: 12.5, fontWeight: '700', color: t.colors.textAccent }}>
+                  {index + 1}
+                </Text>
+              </View>
+            </View>
+
+            {/* Title + artist */}
+            <Pressable
+              onPress={() => callbacks.onPressRow(index)}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${item.song.title}`}
+              style={{ flex: 1, minWidth: 0, paddingHorizontal: t.spacing.md }}
+            >
+              <Text
+                numberOfLines={1}
+                style={{
+                  fontSize: t.typography.rowTitle.fontSize,
+                  fontWeight: t.typography.rowTitle.fontWeight,
+                  letterSpacing: t.typography.rowTitle.letterSpacing,
+                  color: t.colors.ink,
+                }}
+              >
+                {item.song.title}
+              </Text>
+              {item.song.artist ? (
+                <Text
+                  numberOfLines={1}
+                  style={{
+                    marginTop: 2,
+                    fontSize: t.typography.rowSubtitle.fontSize,
+                    color: t.colors.sec,
+                  }}
+                >
+                  {item.song.artist}
+                </Text>
+              ) : null}
+            </Pressable>
+
+            {/* Key chip */}
+            <Pressable
+              onPress={() => callbacks.onKeyTap(index)}
+              accessibilityRole="button"
+              accessibilityLabel={`Change key for ${item.song.title}`}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 3,
+                paddingHorizontal: 10,
+                height: 30,
+                borderRadius: t.radii.sm,
+                backgroundColor: t.colors.accentSoft,
+              }}
+            >
+              <Text style={{ fontSize: 13.5, fontWeight: '700', color: t.colors.textAccent }}>
+                {effectiveKey ?? '—'}
+              </Text>
+              <SymbolIcon name="chevron.up.chevron.down" size={10} color={t.colors.textAccent} />
+            </Pressable>
+
+            {/* Row menu */}
+            <Pressable
+              onPress={() => callbacks.onRowMenu(index)}
+              accessibilityRole="button"
+              accessibilityLabel={`More options for ${item.song.title}`}
+              hitSlop={8}
+              style={{ width: 40, height: '100%', alignItems: 'center', justifyContent: 'center' }}
+            >
+              <SymbolIcon name="ellipsis" size={17} color={t.colors.muted} />
+            </Pressable>
+          </View>
+        </ReanimatedSwipeable>
+      </Animated.View>
+    </Animated.View>
+  )
+}
+
+export default function SetlistTimeline({
+  items,
+  effectiveKeys,
+  callbacks,
+}: {
+  items: SetlistItem[]
+  /** Per-item effective key (override ?? native), same order as items. */
+  effectiveKeys: Array<string | null>
+  callbacks: TimelineCallbacks
+}) {
+  const activeIndex = useSharedValue(-1)
+  const proposedIndex = useSharedValue(-1)
+  const dragY = useSharedValue(0)
+
+  return (
+    <View>
+      {items.map((item, index) => (
+        <Row
+          key={item.entryKey}
+          item={item}
+          index={index}
+          count={items.length}
+          effectiveKey={effectiveKeys[index] ?? null}
+          activeIndex={activeIndex}
+          proposedIndex={proposedIndex}
+          dragY={dragY}
+          callbacks={callbacks}
+        />
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/src/components/setlist/ShareSetSheet.tsx
+++ b/apps/mobile/src/components/setlist/ShareSetSheet.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import BottomSheet from '../BottomSheet'
+import SymbolIcon, { type SymbolIconProps } from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// The setlist "Export & share" sheet (modeled on the viewer's ExportSheet).
+// Copy link and Telegram work today; the set-PDF / Charts ZIP / ChordPro
+// exports need backend endpoints that don't exist yet, so those tiles render
+// disabled as "Coming soon" (a later pass, alongside the Setlist Viewer's
+// export work).
+
+type Busy = 'link' | 'telegram' | null
+
+export default function ShareSetSheet({
+  visible,
+  onClose,
+  songCount,
+  onCopyLink,
+  onTelegram,
+}: {
+  visible: boolean
+  onClose: () => void
+  songCount: number
+  onCopyLink: () => Promise<void>
+  onTelegram: () => Promise<void>
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const [busy, setBusy] = useState<Busy>(null)
+
+  const run = (which: Exclude<Busy, null>, fn: () => Promise<void>) => async () => {
+    if (busy) return
+    setBusy(which)
+    try {
+      await fn()
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const disabledTile = (label: string, icon: SymbolIconProps['name']) => (
+    <View
+      key={label}
+      accessibilityLabel={`${label} — coming soon`}
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        gap: 6,
+        paddingVertical: 14,
+        borderRadius: 13,
+        backgroundColor: t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+        opacity: 0.45,
+      }}
+    >
+      <SymbolIcon name={icon} size={24} color={t.colors.accent} />
+      <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+      <Text style={{ fontSize: 10.5, color: t.colors.muted }}>Coming soon</Text>
+    </View>
+  )
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={onClose}
+      title="Export & share"
+      closeAccessibilityLabel="Close export and share"
+    >
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.md }}>
+        {/* Primary set-PDF export — endpoint not built yet. */}
+        <View
+          accessibilityLabel="Export set as PDF — coming soon"
+          style={{
+            height: 50,
+            borderRadius: 13,
+            backgroundColor: t.colors.accent,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: t.spacing.sm,
+            opacity: 0.45,
+          }}
+        >
+          <SymbolIcon name="square.and.arrow.down" size={19} color={t.colors.onAccent} />
+          <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.onAccent }}>
+            Export set as PDF · {songCount} {songCount === 1 ? 'song' : 'songs'} (soon)
+          </Text>
+        </View>
+
+        <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+          {disabledTile('Charts ZIP', 'folder')}
+          {disabledTile('ChordPro', 'music.note.list')}
+
+          {/* Copy link — works today via the web setlist URL. */}
+          <Pressable
+            onPress={run('link', onCopyLink)}
+            disabled={!!busy}
+            accessibilityRole="button"
+            accessibilityLabel="Copy set link"
+            style={{
+              flex: 1,
+              alignItems: 'center',
+              gap: 6,
+              paddingVertical: 14,
+              borderRadius: 13,
+              backgroundColor: t.colors.surfaceAlt,
+              borderWidth: 1,
+              borderColor: t.colors.border,
+              opacity: busy && busy !== 'link' ? 0.5 : 1,
+            }}
+          >
+            {busy === 'link' ? (
+              <ActivityIndicator color={t.colors.accent} />
+            ) : (
+              <SymbolIcon name="link" size={24} color={t.colors.accent} />
+            )}
+            <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.ink }}>Copy link</Text>
+          </Pressable>
+        </View>
+
+        {/* Telegram */}
+        <Pressable
+          onPress={run('telegram', onTelegram)}
+          disabled={!!busy}
+          accessibilityRole="button"
+          accessibilityLabel="Send set to Telegram"
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 11,
+            padding: t.spacing.md,
+            borderRadius: 13,
+            backgroundColor: t.colors.surfaceAlt,
+            borderWidth: 1,
+            borderColor: t.colors.border,
+            opacity: busy && busy !== 'telegram' ? 0.5 : 1,
+          }}
+        >
+          <View
+            style={{
+              width: 30,
+              height: 30,
+              borderRadius: 15,
+              backgroundColor: t.colors.accentSoft,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            {busy === 'telegram' ? (
+              <ActivityIndicator size="small" color={t.colors.accent} />
+            ) : (
+              <SymbolIcon name="paperplane.fill" size={15} color={t.colors.accent} />
+            )}
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>
+              Send set to Telegram
+            </Text>
+            <Text style={{ fontSize: 11.5, color: t.colors.muted }}>Optional bot</Text>
+          </View>
+          <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+        </Pressable>
+      </View>
+    </BottomSheet>
+  )
+}

--- a/apps/mobile/src/lib/autoHideChrome.ts
+++ b/apps/mobile/src/lib/autoHideChrome.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Animated } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+// "Hide controls when idle" — shared by the Song Viewer and the Setlist
+// Performer. Unlike the other view options (transpose, font, chord style),
+// this preference PERSISTS across launches, so it lives in AsyncStorage.
+
+const PREF_KEY = 'gc.viewer.autoHideChrome'
+const HIDE_DELAY_MS = 6500
+
+// Persisted on/off toggle. Defaults OFF; loads asynchronously so the toggle
+// reflects the stored value once it resolves, and writes through on change.
+export function useAutoHidePref(): [boolean, (v: boolean) => void] {
+  const [value, setValue] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    AsyncStorage.getItem(PREF_KEY)
+      .then((v) => {
+        if (alive && v != null) setValue(v === '1')
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const set = useCallback((v: boolean) => {
+    setValue(v)
+    AsyncStorage.setItem(PREF_KEY, v ? '1' : '0').catch(() => {})
+  }, [])
+
+  return [value, set]
+}
+
+// Drives the fade: when `enabled`, chrome auto-hides after an idle delay and
+// `reveal()` (called on a tap / active control use / song change) brings it
+// back and restarts the countdown. When disabled, chrome is pinned visible.
+// Returns an Animated opacity for the chrome layers plus `visible` for
+// pointerEvents gating and the tap-to-reveal overlay.
+export function useAutoHideChrome(enabled: boolean) {
+  const [visible, setVisible] = useState(true)
+  const opacity = useRef(new Animated.Value(1)).current
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current)
+      timer.current = null
+    }
+  }, [])
+
+  const schedule = useCallback(() => {
+    clearTimer()
+    if (enabled) timer.current = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
+  }, [enabled, clearTimer])
+
+  const reveal = useCallback(() => {
+    setVisible(true)
+    schedule()
+  }, [schedule])
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: visible ? 1 : 0,
+      duration: 260,
+      useNativeDriver: true,
+    }).start()
+  }, [visible, opacity])
+
+  // Enabling starts the hide countdown; disabling pins chrome visible.
+  useEffect(() => {
+    if (enabled) {
+      setVisible(true)
+      schedule()
+    } else {
+      clearTimer()
+      setVisible(true)
+    }
+    return clearTimer
+  }, [enabled, schedule, clearTimer])
+
+  return { visible, opacity, reveal }
+}

--- a/apps/mobile/src/lib/exportSong.ts
+++ b/apps/mobile/src/lib/exportSong.ts
@@ -37,3 +37,26 @@ export async function exportSong(opts: {
   file.write(new Uint8Array(await res.arrayBuffer()))
   return file.uri
 }
+
+// Whole-set export: renders the ordered setlist to one combined PDF via the
+// web app's POST /api/export/setlist (the multi-song counterpart of
+// /api/export/song), writes the bytes to the app cache, and returns the local
+// URI for expo-sharing. PDF only — sets have no image scope.
+export async function exportSetlist(
+  items: Array<{ songId: string; key?: string | null }>,
+): Promise<string> {
+  const res = await apiPost('/api/export/setlist', {
+    items: items.map((it) => ({ song_id: it.songId, key: it.key || '' })),
+  })
+
+  if (!res.ok) throw await apiError(res, 'export_failed')
+
+  const disposition = res.headers.get('content-disposition') || ''
+  const nameMatch = disposition.match(/filename="([^"]+)"/)
+  const filename = nameMatch?.[1] || 'setlist.pdf'
+
+  const file = new File(Paths.cache, filename)
+  if (file.exists) file.delete()
+  file.write(new Uint8Array(await res.arrayBuffer()))
+  return file.uri
+}

--- a/apps/mobile/src/lib/recents.ts
+++ b/apps/mobile/src/lib/recents.ts
@@ -1,37 +1,17 @@
 import type { Song } from './useSongList'
 
-// Local-history accessors for Home's "Continue where you left off" and "Last
-// set" cards.
+// Local-history accessor for Home's "Continue where you left off" card.
 //
-// STUBS FOR NOW — both return empty. The backing store (an on-device history of
-// recently opened songs, and the user's last-used setlist) ships later with the
-// Setlist Builder / local-storage layer. When it lands, implement these two
-// functions against it and Home fills in with NO screen changes: Home already
-// renders the Continue card only when getRecentlyOpened() has an item, and the
-// Last set card only when getLastSet() is non-null.
+// STUB FOR NOW — returns empty. The backing store (an on-device history of
+// recently opened songs) ships with a later stage: the Viewer should record
+// opened songs so this has data. Home already renders the Continue card only
+// when there is an item, so implementing this against the history layer needs
+// no screen changes.
 //
-// The Viewer (a later stage) should record opened songs so getRecentlyOpened()
-// has data; the Setlist Builder should record the last-used set.
-
-/** A minimal setlist summary for the "Last set" card. */
-// NOTE: placeholder shape — replace/relocate this type when the real Setlist
-// model arrives with the Setlist Builder.
-export type Setlist = {
-  id: string
-  name: string
-  songCount: number
-  durationMin: number
-  /** e.g. "G–D" for the key range badge; optional. */
-  keys?: string
-  updatedAt?: string
-}
+// (The former getLastSet() stub was retired by the Setlist Builder — Home's
+// "Last set" card now reads real Supabase data via src/lib/useLastSet.ts.)
 
 /** Most-recently-opened songs, newest first. Empty until the history layer ships. */
 export function getRecentlyOpened(): Song[] {
   return []
-}
-
-/** The setlist the user last used/worked on, or null if none/not yet available. */
-export function getLastSet(): Setlist | null {
-  return null
 }

--- a/apps/mobile/src/lib/relativeTime.ts
+++ b/apps/mobile/src/lib/relativeTime.ts
@@ -1,0 +1,15 @@
+// Compact relative timestamp for setlist metadata: "just now", "5m ago",
+// "3h ago", "2d ago", then "Mar 16" beyond a month.
+export function timeAgo(iso: string | null | undefined): string | null {
+  if (!iso) return null
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return null
+  const mins = Math.floor((Date.now() - then) / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 31) return `${days}d ago`
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}

--- a/apps/mobile/src/lib/setlistShare.ts
+++ b/apps/mobile/src/lib/setlistShare.ts
@@ -1,0 +1,11 @@
+import { apiBase } from './api'
+
+// Build the web setlist share URL that the Builder and Performer both copy.
+// The web catalog is keyed by SLUG (normaliseSong maps id -> slug), so the
+// link carries slugs — not the Supabase uuids — with each entry's key_override
+// in the parallel `toKeys` list.
+export function buildSetlistShareUrl(items: Array<{ song: { slug: string }; toKey: string | null }>): string {
+  const ids = items.map((item) => encodeURIComponent(item.song.slug)).join(',')
+  const keys = items.map((item) => encodeURIComponent(item.toKey || '')).join(',')
+  return `${apiBase()}/setlist/${ids}?toKeys=${keys}`
+}

--- a/apps/mobile/src/lib/telegramPush.ts
+++ b/apps/mobile/src/lib/telegramPush.ts
@@ -20,3 +20,18 @@ export async function pushSongToTelegram(opts: {
   if (!res.ok) throw await apiError(res, 'telegram_failed')
   return 'sent'
 }
+
+// Same endpoint, multi-item: send a whole setlist (the API accepts
+// items[] with context 'setlist' and the bot delivers each chart).
+export async function pushSetToTelegram(
+  items: Array<{ songId: string; key?: string | null }>,
+): Promise<'sent' | 'not_linked'> {
+  const res = await apiPost('/api/telegram/push', {
+    items: items.map((item) => ({ song_id: item.songId, key: item.key || '' })),
+    context: 'setlist',
+  })
+
+  if (res.status === 409) return 'not_linked'
+  if (!res.ok) throw await apiError(res, 'telegram_failed')
+  return 'sent'
+}

--- a/apps/mobile/src/lib/telegramPush.ts
+++ b/apps/mobile/src/lib/telegramPush.ts
@@ -21,17 +21,22 @@ export async function pushSongToTelegram(opts: {
   return 'sent'
 }
 
-// Same endpoint, multi-item: send a whole setlist (the API accepts
-// items[] with context 'setlist' and the bot delivers each chart).
+// Same endpoint, multi-item: send a whole setlist (the API accepts items[]
+// with context 'setlist'). The endpoint caps a request at 25 items, so
+// longer sets go out in order as multiple requests.
+const TELEGRAM_MAX_ITEMS = 25
+
 export async function pushSetToTelegram(
   items: Array<{ songId: string; key?: string | null }>,
 ): Promise<'sent' | 'not_linked'> {
-  const res = await apiPost('/api/telegram/push', {
-    items: items.map((item) => ({ song_id: item.songId, key: item.key || '' })),
-    context: 'setlist',
-  })
-
-  if (res.status === 409) return 'not_linked'
-  if (!res.ok) throw await apiError(res, 'telegram_failed')
+  const payload = items.map((item) => ({ song_id: item.songId, key: item.key || '' }))
+  for (let i = 0; i < payload.length; i += TELEGRAM_MAX_ITEMS) {
+    const res = await apiPost('/api/telegram/push', {
+      items: payload.slice(i, i + TELEGRAM_MAX_ITEMS),
+      context: 'setlist',
+    })
+    if (res.status === 409) return 'not_linked'
+    if (!res.ok) throw await apiError(res, 'telegram_failed')
+  }
   return 'sent'
 }

--- a/apps/mobile/src/lib/useLastSet.ts
+++ b/apps/mobile/src/lib/useLastSet.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
+import { fetchLastSetSummary, summarizeSet } from '@gracechords/core'
+import { supabase } from './supabase'
+import { errMessage } from './errors'
+
+// Summary of the user's most recently edited setlist for Home's "Last set"
+// card (replaces the getLastSet() stub that lived in recents.ts).
+export type Setlist = {
+  id: string
+  name: string
+  songCount: number
+  durationMin: number
+  /** e.g. "G–D" for the key range badge; optional. */
+  keys?: string
+  updatedAt?: string
+}
+
+// The most recently updated personal setlist, summarized. Refetches whenever
+// the owning screen regains focus so edits in the builder show up on Home.
+export function useLastSet() {
+  const [lastSet, setLastSet] = useState<Setlist | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useFocusEffect(
+    useCallback(() => {
+      let alive = true
+      fetchLastSetSummary(supabase)
+        .then((data: Awaited<ReturnType<typeof fetchLastSetSummary>>) => {
+          if (!alive) return
+          if (!data) {
+            setLastSet(null)
+            setError(null)
+            return
+          }
+          const summary = summarizeSet(data.entries)
+          setLastSet({
+            id: data.id,
+            name: data.name,
+            songCount: summary.songCount,
+            durationMin: summary.durationMin,
+            // The card renders "Keys {keys}", so strip the label prefix.
+            keys: summary.keyRange?.replace(/^Keys? /, '') ?? undefined,
+            updatedAt: data.updated_at,
+          })
+          setError(null)
+        })
+        .catch((err: unknown) => {
+          if (alive) setError(errMessage(err))
+        })
+        .finally(() => {
+          if (alive) setLoading(false)
+        })
+      return () => {
+        alive = false
+      }
+    }, []),
+  )
+
+  return { lastSet, loading, error }
+}

--- a/apps/mobile/src/lib/useLastSet.ts
+++ b/apps/mobile/src/lib/useLastSet.ts
@@ -40,8 +40,7 @@ export function useLastSet() {
             name: data.name,
             songCount: summary.songCount,
             durationMin: summary.durationMin,
-            // The card renders "Keys {keys}", so strip the label prefix.
-            keys: summary.keyRange?.replace(/^Keys? /, '') ?? undefined,
+            keys: summary.keys ?? undefined,
             updatedAt: data.updated_at,
           })
           setError(null)

--- a/apps/mobile/src/lib/useSetlistBuilder.ts
+++ b/apps/mobile/src/lib/useSetlistBuilder.ts
@@ -37,7 +37,6 @@ export function useSetlistBuilder(setlistId: string) {
   const [serviceDate, setServiceDate] = useState<string | null>(null)
   const [updatedAt, setUpdatedAt] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notFound, setNotFound] = useState(false)
 
@@ -57,13 +56,23 @@ export function useSetlistBuilder(setlistId: string) {
   const hydrated = useRef(false)
 
   const runSave = useCallback(async () => {
-    if (deleted.current || !hydrated.current) return
+    if (deleted.current) return
+    if (!hydrated.current) {
+      // An edit landed before the initial load resolved — defer rather than
+      // drop it, so nothing written could clobber entries not yet fetched.
+      if (!timer.current) {
+        timer.current = setTimeout(() => {
+          timer.current = null
+          runSave()
+        }, SAVE_DEBOUNCE_MS)
+      }
+      return
+    }
     if (inFlight.current) {
       trailing.current = true
       return
     }
     inFlight.current = true
-    setSaving(true)
     try {
       const { name: n, serviceDate: d, entries: e } = latest.current
       await updateSetlist(supabase, setlistId, {
@@ -76,7 +85,6 @@ export function useSetlistBuilder(setlistId: string) {
       setError(errMessage(err))
     } finally {
       inFlight.current = false
-      setSaving(false)
       if (trailing.current) {
         trailing.current = false
         runSave()
@@ -149,17 +157,11 @@ export function useSetlistBuilder(setlistId: string) {
     }
   }, [flushSave])
 
-  // Entries hydrated against the song catalog. Entries whose song no longer
-  // exists (deleted since) are dropped from the working state once, at
-  // hydration, so list indexes always match what's rendered.
-  useEffect(() => {
-    if (songsLoading || songs.length === 0) return
-    setEntries((prev) => {
-      const kept = prev.filter((e) => songsById.has(e.songId))
-      return kept.length === prev.length ? prev : kept
-    })
-  }, [songsLoading, songs.length, songsById])
-
+  // Entries hydrated against the song catalog. Entries whose song isn't in
+  // the catalog (e.g. soft-deleted) are hidden from the UI but KEPT in the
+  // working state, so wipe-and-replace saves never silently erase them —
+  // which is also why every mutation below is keyed by entryKey, not index:
+  // rendered indexes and entry indexes can diverge.
   const items: SetlistItem[] = useMemo(
     () =>
       entries
@@ -182,8 +184,10 @@ export function useSetlistBuilder(setlistId: string) {
   const toggleSong = useCallback(
     (song: Song) => {
       setEntries((prev) => {
-        const has = prev.some((e) => e.songId === song.id)
-        if (has) return prev.filter((e) => e.songId !== song.id)
+        // Untoggling removes only the LAST entry for that song, so duplicates
+        // created on purpose (a reprise) aren't wiped in one tap.
+        const last = prev.map((e) => e.songId).lastIndexOf(song.id)
+        if (last >= 0) return prev.filter((_, i) => i !== last)
         return [...prev, { entryKey: makeEntryKey(song.id), songId: song.id, toKey: null }]
       })
       scheduleSave()
@@ -191,20 +195,20 @@ export function useSetlistBuilder(setlistId: string) {
     [makeEntryKey, scheduleSave],
   )
 
-  const removeAt = useCallback(
-    (index: number) => {
-      setEntries((prev) => prev.filter((_, i) => i !== index))
+  const removeEntry = useCallback(
+    (entryKey: string) => {
+      setEntries((prev) => prev.filter((e) => e.entryKey !== entryKey))
       scheduleSave()
     },
     [scheduleSave],
   )
 
-  const duplicateAt = useCallback(
-    (index: number) => {
+  const duplicateEntry = useCallback(
+    (entryKey: string) => {
       setEntries((prev) => {
-        const src = prev[index]
-        if (!src) return prev
-        const copy = { ...src, entryKey: makeEntryKey(src.songId) }
+        const index = prev.findIndex((e) => e.entryKey === entryKey)
+        if (index < 0) return prev
+        const copy = { ...prev[index], entryKey: makeEntryKey(prev[index].songId) }
         const next = prev.slice()
         next.splice(index + 1, 0, copy)
         return next
@@ -214,14 +218,15 @@ export function useSetlistBuilder(setlistId: string) {
     [makeEntryKey, scheduleSave],
   )
 
-  const moveItem = useCallback(
-    (from: number, to: number) => {
+  const moveEntry = useCallback(
+    (fromKey: string, toKey: string) => {
       setEntries((prev) => {
-        if (from === to || from < 0 || from >= prev.length) return prev
-        const bounded = Math.max(0, Math.min(prev.length - 1, to))
+        const from = prev.findIndex((e) => e.entryKey === fromKey)
+        const to = prev.findIndex((e) => e.entryKey === toKey)
+        if (from < 0 || to < 0 || from === to) return prev
         const next = prev.slice()
         const [moved] = next.splice(from, 1)
-        next.splice(bounded, 0, moved)
+        next.splice(to, 0, moved)
         return next
       })
       scheduleSave()
@@ -229,9 +234,9 @@ export function useSetlistBuilder(setlistId: string) {
     [scheduleSave],
   )
 
-  const setKeyAt = useCallback(
-    (index: number, key: string | null) => {
-      setEntries((prev) => prev.map((e, i) => (i === index ? { ...e, toKey: key } : e)))
+  const setKeyFor = useCallback(
+    (entryKey: string, key: string | null) => {
+      setEntries((prev) => prev.map((e) => (e.entryKey === entryKey ? { ...e, toKey: key } : e)))
       scheduleSave()
     },
     [scheduleSave],
@@ -253,14 +258,13 @@ export function useSetlistBuilder(setlistId: string) {
     updatedAt,
     loading: loading || songsLoading,
     notFound,
-    saving,
     error: error ?? songsError,
     setName,
     toggleSong,
-    removeAt,
-    duplicateAt,
-    moveItem,
-    setKeyAt,
+    removeEntry,
+    duplicateEntry,
+    moveEntry,
+    setKeyFor,
     deleteSet,
   }
 }

--- a/apps/mobile/src/lib/useSetlistBuilder.ts
+++ b/apps/mobile/src/lib/useSetlistBuilder.ts
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AppState } from 'react-native'
+import {
+  deleteSetlist as repoDeleteSetlist,
+  fetchSetlist,
+  updateSetlist,
+} from '@gracechords/core'
+import { supabase } from './supabase'
+import { errMessage } from './errors'
+import { useSongList, type Song } from './useSongList'
+
+// One working entry in the builder. `entryKey` is a local list key that stays
+// stable across reorders (the DB row ids are wiped on every save, so they
+// can't key the list). `toKey` is the setlist-scoped key override
+// (setlist_songs.key_override); null means "play in the song's native key".
+export type SetlistItem = {
+  entryKey: string
+  songId: string
+  toKey: string | null
+  song: Song
+}
+
+const SAVE_DEBOUNCE_MS = 800
+
+type RawEntry = { song_id: string; toKey: string | null }
+
+// Working state + persistence for one setlist. Every mutation updates local
+// state immediately and schedules a debounced wipe-and-replace save (the web
+// updateSetlist semantics — position is the array index, so one write path
+// covers reorder / remove / duplicate / key change / rename). Saves are
+// serialized: while one is in flight at most one trailing save is queued, and
+// pending work is flushed when the app backgrounds or the screen unmounts.
+export function useSetlistBuilder(setlistId: string) {
+  const { songs, loading: songsLoading, error: songsError } = useSongList()
+  const [name, setNameState] = useState('')
+  const [entries, setEntries] = useState<Array<{ entryKey: string; songId: string; toKey: string | null }>>([])
+  const [serviceDate, setServiceDate] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notFound, setNotFound] = useState(false)
+
+  const songsById = useMemo(() => new Map(songs.map((s) => [s.id, s])), [songs])
+
+  const nextKey = useRef(0)
+  const makeEntryKey = useCallback((songId: string) => `${songId}:${nextKey.current++}`, [])
+
+  // Latest state for the save path (avoids stale closures in timers).
+  const latest = useRef({ name: '', serviceDate: null as string | null, entries: [] as Array<{ songId: string; toKey: string | null }> })
+  latest.current = { name, serviceDate, entries }
+
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const inFlight = useRef(false)
+  const trailing = useRef(false)
+  const deleted = useRef(false)
+  const hydrated = useRef(false)
+
+  const runSave = useCallback(async () => {
+    if (deleted.current || !hydrated.current) return
+    if (inFlight.current) {
+      trailing.current = true
+      return
+    }
+    inFlight.current = true
+    setSaving(true)
+    try {
+      const { name: n, serviceDate: d, entries: e } = latest.current
+      await updateSetlist(supabase, setlistId, {
+        name: n,
+        serviceDate: d,
+        songs: e.map((item) => ({ id: item.songId, toKey: item.toKey })),
+      })
+      setError(null)
+    } catch (err: unknown) {
+      setError(errMessage(err))
+    } finally {
+      inFlight.current = false
+      setSaving(false)
+      if (trailing.current) {
+        trailing.current = false
+        runSave()
+      }
+    }
+  }, [setlistId])
+
+  const scheduleSave = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => {
+      timer.current = null
+      runSave()
+    }, SAVE_DEBOUNCE_MS)
+  }, [runSave])
+
+  const flushSave = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current)
+      timer.current = null
+      runSave()
+    }
+  }, [runSave])
+
+  // Load the setlist once.
+  useEffect(() => {
+    let alive = true
+    fetchSetlist(supabase, setlistId)
+      .then((data: Awaited<ReturnType<typeof fetchSetlist>>) => {
+        if (!alive) return
+        if (!data) {
+          setNotFound(true)
+          return
+        }
+        setNameState(data.name)
+        setServiceDate(data.service_date)
+        setEntries(
+          data.entries.map((entry: RawEntry) => ({
+            entryKey: makeEntryKey(entry.song_id),
+            songId: entry.song_id,
+            toKey: entry.toKey,
+          })),
+        )
+      })
+      .catch((err: unknown) => {
+        if (alive) setError(errMessage(err))
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [setlistId, makeEntryKey])
+
+  // Only allow saves once the initial load has landed, so an early rename
+  // can't wipe entries that haven't been fetched yet.
+  useEffect(() => {
+    if (!loading && !notFound && !hydrated.current) hydrated.current = true
+  }, [loading, notFound])
+
+  // Flush pending edits when the app backgrounds or the screen unmounts.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state !== 'active') flushSave()
+    })
+    return () => {
+      sub.remove()
+      flushSave()
+    }
+  }, [flushSave])
+
+  // Entries hydrated against the song catalog. Entries whose song no longer
+  // exists (deleted since) are dropped from the working state once, at
+  // hydration, so list indexes always match what's rendered.
+  useEffect(() => {
+    if (songsLoading || songs.length === 0) return
+    setEntries((prev) => {
+      const kept = prev.filter((e) => songsById.has(e.songId))
+      return kept.length === prev.length ? prev : kept
+    })
+  }, [songsLoading, songs.length, songsById])
+
+  const items: SetlistItem[] = useMemo(
+    () =>
+      entries
+        .map((entry) => {
+          const song = songsById.get(entry.songId)
+          return song ? { ...entry, song } : null
+        })
+        .filter((item): item is SetlistItem => item != null),
+    [entries, songsById],
+  )
+
+  const setName = useCallback(
+    (next: string) => {
+      setNameState(next)
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
+
+  const toggleSong = useCallback(
+    (song: Song) => {
+      setEntries((prev) => {
+        const has = prev.some((e) => e.songId === song.id)
+        if (has) return prev.filter((e) => e.songId !== song.id)
+        return [...prev, { entryKey: makeEntryKey(song.id), songId: song.id, toKey: null }]
+      })
+      scheduleSave()
+    },
+    [makeEntryKey, scheduleSave],
+  )
+
+  const removeAt = useCallback(
+    (index: number) => {
+      setEntries((prev) => prev.filter((_, i) => i !== index))
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
+
+  const duplicateAt = useCallback(
+    (index: number) => {
+      setEntries((prev) => {
+        const src = prev[index]
+        if (!src) return prev
+        const copy = { ...src, entryKey: makeEntryKey(src.songId) }
+        const next = prev.slice()
+        next.splice(index + 1, 0, copy)
+        return next
+      })
+      scheduleSave()
+    },
+    [makeEntryKey, scheduleSave],
+  )
+
+  const moveItem = useCallback(
+    (from: number, to: number) => {
+      setEntries((prev) => {
+        if (from === to || from < 0 || from >= prev.length) return prev
+        const bounded = Math.max(0, Math.min(prev.length - 1, to))
+        const next = prev.slice()
+        const [moved] = next.splice(from, 1)
+        next.splice(bounded, 0, moved)
+        return next
+      })
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
+
+  const setKeyAt = useCallback(
+    (index: number, key: string | null) => {
+      setEntries((prev) => prev.map((e, i) => (i === index ? { ...e, toKey: key } : e)))
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
+
+  const deleteSet = useCallback(async () => {
+    deleted.current = true
+    if (timer.current) {
+      clearTimeout(timer.current)
+      timer.current = null
+    }
+    await repoDeleteSetlist(supabase, setlistId)
+  }, [setlistId])
+
+  return {
+    name,
+    items,
+    songs,
+    loading: loading || songsLoading,
+    notFound,
+    saving,
+    error: error ?? songsError,
+    setName,
+    toggleSong,
+    removeAt,
+    duplicateAt,
+    moveItem,
+    setKeyAt,
+    deleteSet,
+  }
+}

--- a/apps/mobile/src/lib/useSetlistBuilder.ts
+++ b/apps/mobile/src/lib/useSetlistBuilder.ts
@@ -35,6 +35,7 @@ export function useSetlistBuilder(setlistId: string) {
   const [name, setNameState] = useState('')
   const [entries, setEntries] = useState<Array<{ entryKey: string; songId: string; toKey: string | null }>>([])
   const [serviceDate, setServiceDate] = useState<string | null>(null)
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -111,6 +112,7 @@ export function useSetlistBuilder(setlistId: string) {
         }
         setNameState(data.name)
         setServiceDate(data.service_date)
+        setUpdatedAt(data.updated_at)
         setEntries(
           data.entries.map((entry: RawEntry) => ({
             entryKey: makeEntryKey(entry.song_id),
@@ -248,6 +250,7 @@ export function useSetlistBuilder(setlistId: string) {
     name,
     items,
     songs,
+    updatedAt,
     loading: loading || songsLoading,
     notFound,
     saving,

--- a/apps/mobile/src/lib/useSetlists.ts
+++ b/apps/mobile/src/lib/useSetlists.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createSetlist, deleteSetlist, fetchPersonalSetlists } from '@gracechords/core'
+import { supabase } from './supabase'
+import { errMessage } from './errors'
+
+// A setlist row as the Setlists tab needs it: metadata plus a song count
+// (flattened from the PostgREST `setlist_songs(count)` relationship embed).
+export type SetlistRow = {
+  id: string
+  name: string
+  service_date: string | null
+  updated_at: string
+  songCount: number
+}
+
+type RawRow = {
+  id: string
+  name: string
+  service_date: string | null
+  updated_at: string
+  setlist_songs: Array<{ count: number }>
+}
+
+// The user's personal setlists (newest-edited first), with create/remove.
+// Same plain loading/error/data pattern as useSongList — no React Query.
+export function useSetlists() {
+  const [setlists, setSetlists] = useState<SetlistRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const rows = (await fetchPersonalSetlists(supabase)) as RawRow[]
+      setSetlists(
+        rows.map((row) => ({
+          id: row.id,
+          name: row.name,
+          service_date: row.service_date,
+          updated_at: row.updated_at,
+          songCount: row.setlist_songs?.[0]?.count ?? 0,
+        })),
+      )
+      setError(null)
+    } catch (err: unknown) {
+      setError(errMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const create = useCallback(async (name?: string) => {
+    const row = (await createSetlist(supabase, { name })) as {
+      id: string
+      name: string
+    }
+    return row
+  }, [])
+
+  const remove = useCallback(
+    async (id: string) => {
+      await deleteSetlist(supabase, id)
+      setSetlists((prev) => prev.filter((s) => s.id !== id))
+    },
+    [],
+  )
+
+  return { setlists, loading, error, refresh, create, remove }
+}

--- a/apps/mobile/src/lib/useSetlists.ts
+++ b/apps/mobile/src/lib/useSetlists.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { createSetlist, deleteSetlist, fetchPersonalSetlists } from '@gracechords/core'
 import { supabase } from './supabase'
 import { errMessage } from './errors'
@@ -48,9 +48,8 @@ export function useSetlists() {
     }
   }, [])
 
-  useEffect(() => {
-    refresh()
-  }, [refresh])
+  // No mount fetch here: the owning screen's useFocusEffect fires on initial
+  // focus too, so fetching here would double the first load.
 
   const create = useCallback(async (name?: string) => {
     const row = (await createSetlist(supabase, { name })) as {

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -22,7 +22,8 @@ import {
   timeGreeting,
   useCurrentUser,
 } from '../lib/greetings'
-import { getLastSet, getRecentlyOpened } from '../lib/recents'
+import { getRecentlyOpened } from '../lib/recents'
+import { useLastSet } from '../lib/useLastSet'
 import { useStarredSongs, type StarredSong } from '../lib/useStarredSongs'
 import type { Song } from '../lib/useSongList'
 
@@ -64,10 +65,10 @@ export default function HomeScreen() {
   const greeting = `${timeGreeting()}, ${getDisplayName(user)}`
   const subGreeting = pickSubGreeting()
 
-  // Stubs today (empty). See src/lib/recents.ts — these fill in with the local
-  // history / setlist layer, no screen changes needed.
+  // Recently-opened is still a stub (the Viewer's local history ships later);
+  // the Last set card reads the real most-recently-edited setlist.
   const continueSong = getRecentlyOpened()[0] ?? null
-  const lastSet = getLastSet()
+  const { lastSet } = useLastSet()
 
   function onAvatar() {
     // The avatar opens Profile/Settings in a later stage; for now it exposes the
@@ -262,7 +263,7 @@ export default function HomeScreen() {
                     {lastSet.name}
                   </Text>
                   <Text style={{ fontSize: 13, color: t.colors.sec, marginTop: 4 }}>
-                    {lastSet.songCount} songs · {lastSet.durationMin} min
+                    {lastSet.songCount} {lastSet.songCount === 1 ? 'song' : 'songs'} · ~{lastSet.durationMin} min
                   </Text>
                 </View>
                 {lastSet.keys ? (
@@ -284,7 +285,7 @@ export default function HomeScreen() {
               </View>
               <View style={{ flexDirection: 'row', gap: 10, marginTop: 16 }}>
                 <Pressable
-                  onPress={() => router.push('/setlists')}
+                  onPress={() => router.push(`/setlist/${lastSet.id}`)}
                   accessibilityRole="button"
                   style={{
                     flex: 1,
@@ -303,7 +304,7 @@ export default function HomeScreen() {
                   <SymbolIcon name="chevron.right" size={14} color={t.colors.onAccent} weight="semibold" />
                 </Pressable>
                 <Pressable
-                  onPress={() => router.push('/setlists')}
+                  onPress={() => router.push(`/setlist/${lastSet.id}`)}
                   accessibilityRole="button"
                   accessibilityLabel="Edit set"
                   style={{

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -31,13 +31,12 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { useSong } from '../lib/useSong'
 import { exportSetlist, exportSong } from '../lib/exportSong'
-import { apiBase } from '../lib/api'
+import { buildSetlistShareUrl } from '../lib/setlistShare'
 import {
   pushSetToTelegram,
   pushSongToTelegram,
   TELEGRAM_BOT_URL,
 } from '../lib/telegramPush'
-import { errMessage } from '../lib/errors'
 
 const TRANSPOSE_BAR_CLEARANCE = 120
 const SWIPE_THRESHOLD = 50
@@ -59,25 +58,31 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   const entry = items[index]
   const { song, loading: songLoading, error: songError } = useSong(entry?.song.slug)
 
+  // useSong keeps the previous song while the next slug loads, so guard every
+  // render on the loaded song actually being this entry's song. Until it
+  // matches, treat the chart as still loading (no stale flash / mistranspose).
+  const songReady = !!(song && entry && song.slug === entry.song.slug)
+
   const { doc, parseError } = useMemo<{ doc: SongDoc | null; parseError: boolean }>(() => {
-    if (!song?.chordpro_content) return { doc: null, parseError: false }
+    if (!songReady || !song?.chordpro_content) return { doc: null, parseError: false }
     try {
       return { doc: parseChordProOrLegacy(song.chordpro_content), parseError: false }
     } catch {
       return { doc: null, parseError: true }
     }
-  }, [song])
+  }, [songReady, song])
 
   // Each entry's setlist key (override ?? native). Used to seed transpose and
-  // to key the export/share payloads.
+  // to key the whole-set export/share payloads.
   const entryKeys = useMemo(
     () => items.map((it) => computeEffectiveKey(it, it.song)),
     [items],
   )
 
-  // Transpose — ephemeral, reset on song change.
+  // Transpose — ephemeral, reset on song change. nativeKey comes from the
+  // entry's own catalog metadata (always current, unlike the loading `song`).
   const [delta, setDelta] = useState(0)
-  const nativeKey = doc?.meta?.key || song?.default_key || entry?.song.default_key || ''
+  const nativeKey = doc?.meta?.key || entry?.song.default_key || ''
   const targetKey = entryKeys[index] || nativeKey
   const seedSteps = targetKey ? stepsBetween(nativeKey, targetKey) : 0
   const steps = (((seedSteps + delta) % 12) + 12) % 12
@@ -136,10 +141,15 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
       }
     })
 
-  const displayTitle = song?.title || entry?.song.title || ''
-  const displayArtist = song?.artist ?? entry?.song.artist ?? ''
+  // Use the entry's catalog metadata for the header so it tracks the current
+  // song immediately, not the still-loading `song`.
+  const displayTitle = entry?.song.title || ''
+  const displayArtist = entry?.song.artist ?? ''
   const keyLabel = effectiveKey ? formatKeyDisplay(effectiveKey, chordStyle) : ''
-  const exportKey = steps ? effectiveKey : entryKeys[index] || ''
+  // The song-scope export key is whatever the performer is currently viewing:
+  // '' (native) when not transposed away from native, else the displayed key.
+  // This matches the on-screen chart even after transposing back to native.
+  const exportKey = effectiveKey && effectiveKey !== nativeKey ? effectiveKey : ''
 
   // --- Export / share handlers (screen owns errors) ------------------------
   function reportError(title: string, err: unknown) {
@@ -151,8 +161,8 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   }
 
   const shareSongFile = async (format: 'pdf' | 'jpg') => {
-    if (!song) return
-    const uri = await exportSong({ songId: song.id, key: exportKey, format })
+    if (!entry) return
+    const uri = await exportSong({ songId: entry.songId, key: exportKey, format })
     await Sharing.shareAsync(uri)
   }
 
@@ -185,9 +195,9 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
       }
     },
     onTelegramSong: async () => {
-      if (!song) return
+      if (!entry) return
       try {
-        const result = await pushSongToTelegram({ songId: song.id, key: exportKey })
+        const result = await pushSongToTelegram({ songId: entry.songId, key: exportKey })
         if (result === 'not_linked') return notLinkedAlert()
         setSheet(null)
         Alert.alert('Sent', 'The chart is on its way to your Telegram chat.')
@@ -207,11 +217,8 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
       }
     },
     onCopyLink: async () => {
-      // Same slug-based web URL the Builder copies.
-      const ids = items.map((it) => encodeURIComponent(it.song.slug)).join(',')
-      const keys = items.map((it) => encodeURIComponent(it.toKey || '')).join(',')
       try {
-        await Clipboard.setStringAsync(`${apiBase()}/setlist/${ids}?toKeys=${keys}`)
+        await Clipboard.setStringAsync(buildSetlistShareUrl(items))
         setSheet(null)
         Alert.alert('Copied', 'Set link copied to the clipboard.')
       } catch (err) {
@@ -377,7 +384,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
       </View>
 
       {/* Chart area */}
-      {setLoading || songLoading ? (
+      {setLoading || songLoading || (entry && !songReady && !songError) ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <ActivityIndicator color={t.colors.accent} />
         </View>

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -1,0 +1,499 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
+import * as Haptics from 'expo-haptics'
+import * as Clipboard from 'expo-clipboard'
+import * as Sharing from 'expo-sharing'
+import type { SongDoc } from '@gracechords/core'
+import {
+  effectiveKey as computeEffectiveKey,
+  formatKeyDisplay,
+  parseChordProOrLegacy,
+  stepsBetween,
+  transposeSymPrefer,
+} from '@gracechords/core'
+import ChordChart, { type ChordStyle } from '../components/ChordChart'
+import Screen from '../components/Screen'
+import SymbolIcon from '../components/SymbolIcon'
+import TransposeBar from '../components/TransposeBar'
+import ViewOptionsSheet from '../components/ViewOptionsSheet'
+import PerformerShareSheet, {
+  type PerformerShareHandlers,
+} from '../components/setlist/PerformerShareSheet'
+import { useTheme } from '../theme/ThemeProvider'
+import { useSetlistBuilder } from '../lib/useSetlistBuilder'
+import { useSong } from '../lib/useSong'
+import { exportSetlist, exportSong } from '../lib/exportSong'
+import { apiBase } from '../lib/api'
+import {
+  pushSetToTelegram,
+  pushSongToTelegram,
+  TELEGRAM_BOT_URL,
+} from '../lib/telegramPush'
+import { errMessage } from '../lib/errors'
+
+const TRANSPOSE_BAR_CLEARANCE = 120
+const SWIPE_THRESHOLD = 50
+
+// Setlist Viewer / Performer Mode: runs the set one song at a time. Reuses the
+// Song Viewer's chart + transpose + view-options pieces (transpose is
+// session-ephemeral here too — it seeds from each entry's setlist key but is
+// never written back). Navigation is Prev/Next, horizontal swipe, and a
+// tappable progress rail, all sliding between songs.
+export default function PerformerScreen({ setlistId }: { setlistId: string }) {
+  const t = useTheme()
+  const router = useRouter()
+
+  // Read-only reuse of the builder hook for the ordered entries + song
+  // metadata. We never mutate here, so its autosave stays idle.
+  const { name, items, loading: setLoading, notFound, error: setError } = useSetlistBuilder(setlistId)
+
+  const [index, setIndex] = useState(0)
+  const entry = items[index]
+  const { song, loading: songLoading, error: songError } = useSong(entry?.song.slug)
+
+  const { doc, parseError } = useMemo<{ doc: SongDoc | null; parseError: boolean }>(() => {
+    if (!song?.chordpro_content) return { doc: null, parseError: false }
+    try {
+      return { doc: parseChordProOrLegacy(song.chordpro_content), parseError: false }
+    } catch {
+      return { doc: null, parseError: true }
+    }
+  }, [song])
+
+  // Each entry's setlist key (override ?? native). Used to seed transpose and
+  // to key the export/share payloads.
+  const entryKeys = useMemo(
+    () => items.map((it) => computeEffectiveKey(it, it.song)),
+    [items],
+  )
+
+  // Transpose — ephemeral, reset on song change.
+  const [delta, setDelta] = useState(0)
+  const nativeKey = doc?.meta?.key || song?.default_key || entry?.song.default_key || ''
+  const targetKey = entryKeys[index] || nativeKey
+  const seedSteps = targetKey ? stepsBetween(nativeKey, targetKey) : 0
+  const steps = (((seedSteps + delta) % 12) + 12) % 12
+  const preferFlat = /^[A-G]b/.test(nativeKey)
+  const effectiveKey = steps ? transposeSymPrefer(nativeKey, steps, preferFlat) : nativeKey
+
+  // View options — session-ephemeral.
+  const [showChords, setShowChords] = useState(true)
+  const [showSections, setShowSections] = useState(true)
+  const [fontScale, setFontScale] = useState(1)
+  const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
+  const [sheet, setSheet] = useState<null | 'options' | 'share'>(null)
+
+  // Slide transition between songs (reanimated).
+  const slideX = useSharedValue(0)
+  const slideOpacity = useSharedValue(1)
+  const chartAnim = useAnimatedStyle(() => ({
+    transform: [{ translateX: slideX.value }],
+    opacity: slideOpacity.value,
+  }))
+
+  const count = items.length
+
+  function goTo(next: number, dir: 'next' | 'prev') {
+    if (next < 0 || next >= count || next === index) return
+    setSheet(null)
+    setDelta(0)
+    slideX.value = dir === 'next' ? 26 : -26
+    slideOpacity.value = 0.15
+    setIndex(next)
+    slideX.value = withTiming(0, { duration: 260 })
+    slideOpacity.value = withTiming(1, { duration: 240 })
+    Haptics.selectionAsync().catch(() => {})
+  }
+
+  const goNext = () => goTo(index + 1, 'next')
+  const goPrev = () => goTo(index - 1, 'prev')
+
+  const transposeBy = (dir: 1 | -1) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {})
+    setDelta((d) => d + dir)
+  }
+
+  // Horizontal swipe to change songs. activeOffsetX/failOffsetY keep it from
+  // fighting vertical scroll; the ~50px threshold + horizontal-dominance check
+  // mirror the reference.
+  const swipe = Gesture.Pan()
+    .activeOffsetX([-30, 30])
+    .failOffsetY([-24, 24])
+    .onEnd((e) => {
+      const dx = e.translationX
+      const dy = e.translationY
+      if (Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy) + 8) {
+        if (dx < 0) runOnJS(goNext)()
+        else runOnJS(goPrev)()
+      }
+    })
+
+  const displayTitle = song?.title || entry?.song.title || ''
+  const displayArtist = song?.artist ?? entry?.song.artist ?? ''
+  const keyLabel = effectiveKey ? formatKeyDisplay(effectiveKey, chordStyle) : ''
+  const exportKey = steps ? effectiveKey : entryKeys[index] || ''
+
+  // --- Export / share handlers (screen owns errors) ------------------------
+  function reportError(title: string, err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg === 'not_signed_in') Alert.alert('Sign in required', 'Sign in to export.')
+    else if (msg === 'image_unavailable') {
+      Alert.alert('Image unavailable', 'The server could not render an image. Try PDF instead.')
+    } else Alert.alert(title, msg)
+  }
+
+  const shareSongFile = async (format: 'pdf' | 'jpg') => {
+    if (!song) return
+    const uri = await exportSong({ songId: song.id, key: exportKey, format })
+    await Sharing.shareAsync(uri)
+  }
+
+  async function notLinkedAlert() {
+    Alert.alert(
+      'Link your Telegram',
+      'Send /link to the GraceChords bot on Telegram, then connect it from your profile on the website.',
+      [
+        { text: 'Open Telegram', onPress: () => Linking.openURL(TELEGRAM_BOT_URL) },
+        { text: 'Not now', style: 'cancel' },
+      ],
+    )
+  }
+
+  const shareHandlers: PerformerShareHandlers = {
+    onShareSong: async () => {
+      try {
+        await shareSongFile('pdf')
+        setSheet(null)
+      } catch (err) {
+        reportError('Share failed', err)
+      }
+    },
+    onExportSong: async (format) => {
+      try {
+        await shareSongFile(format)
+        setSheet(null)
+      } catch (err) {
+        reportError('Export failed', err)
+      }
+    },
+    onTelegramSong: async () => {
+      if (!song) return
+      try {
+        const result = await pushSongToTelegram({ songId: song.id, key: exportKey })
+        if (result === 'not_linked') return notLinkedAlert()
+        setSheet(null)
+        Alert.alert('Sent', 'The chart is on its way to your Telegram chat.')
+      } catch (err) {
+        reportError('Telegram failed', err)
+      }
+    },
+    onExportSet: async () => {
+      try {
+        const uri = await exportSetlist(
+          items.map((it, i) => ({ songId: it.songId, key: entryKeys[i] })),
+        )
+        await Sharing.shareAsync(uri)
+        setSheet(null)
+      } catch (err) {
+        reportError('Export failed', err)
+      }
+    },
+    onCopyLink: async () => {
+      // Same slug-based web URL the Builder copies.
+      const ids = items.map((it) => encodeURIComponent(it.song.slug)).join(',')
+      const keys = items.map((it) => encodeURIComponent(it.toKey || '')).join(',')
+      try {
+        await Clipboard.setStringAsync(`${apiBase()}/setlist/${ids}?toKeys=${keys}`)
+        setSheet(null)
+        Alert.alert('Copied', 'Set link copied to the clipboard.')
+      } catch (err) {
+        reportError('Could not copy link', err)
+      }
+    },
+    onTelegramSet: async () => {
+      try {
+        const result = await pushSetToTelegram(
+          items.map((it, i) => ({ songId: it.songId, key: entryKeys[i] })),
+        )
+        if (result === 'not_linked') return notLinkedAlert()
+        setSheet(null)
+        Alert.alert('Sent', 'The set is on its way to your Telegram chat.')
+      } catch (err) {
+        reportError('Telegram failed', err)
+      }
+    },
+  }
+
+  const headerButtonStyle = {
+    width: 40,
+    height: 40,
+    borderRadius: t.radii.pill,
+    backgroundColor: t.colors.surfaceAlt,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  }
+
+  const navButtonStyle = (disabled: boolean) => ({
+    width: 50,
+    height: 50,
+    borderRadius: t.radii.pill,
+    backgroundColor: t.colors.surface,
+    borderWidth: 1,
+    borderColor: t.colors.border,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    opacity: disabled ? 0.4 : 1,
+  })
+
+  if (notFound) {
+    return (
+      <Screen edges={['top', 'left', 'right', 'bottom']}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+            This setlist no longer exists.
+          </Text>
+        </View>
+      </Screen>
+    )
+  }
+
+  return (
+    <Screen edges={['top', 'left', 'right', 'bottom']}>
+      {/* Header */}
+      <View style={{ paddingHorizontal: t.spacing.lg, paddingTop: t.spacing.sm }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Pressable
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel="Back to setlist"
+            hitSlop={8}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+          >
+            <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+            <Text numberOfLines={1} style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent, maxWidth: 160 }}>
+              {name || 'Setlist'}
+            </Text>
+          </Pressable>
+          <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+            <Pressable
+              onPress={() => setSheet('options')}
+              accessibilityRole="button"
+              accessibilityLabel="View options"
+              style={headerButtonStyle}
+            >
+              <SymbolIcon name="ellipsis" size={17} color={t.colors.ink} />
+            </Pressable>
+            <Pressable
+              onPress={() => setSheet('share')}
+              accessibilityRole="button"
+              accessibilityLabel="Export and share"
+              style={headerButtonStyle}
+            >
+              <SymbolIcon name="square.and.arrow.up" size={17} color={t.colors.ink} />
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Progress rail (multi-song only) */}
+        {count > 1 ? (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: t.spacing.md }}>
+            {items.map((it, i) => {
+              const isCurrent = i === index
+              const isPast = i < index
+              return (
+                <Pressable
+                  key={it.entryKey}
+                  onPress={() => goTo(i, i > index ? 'next' : 'prev')}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Go to song ${i + 1}`}
+                  hitSlop={{ top: 10, bottom: 10 }}
+                  style={{ flex: isCurrent ? 1.6 : 1 }}
+                >
+                  <View
+                    style={{
+                      height: 4,
+                      borderRadius: 2,
+                      backgroundColor: isCurrent
+                        ? t.colors.accent
+                        : isPast
+                          ? t.colors.textAccent
+                          : t.colors.surfaceAlt,
+                    }}
+                  />
+                </Pressable>
+              )
+            })}
+          </View>
+        ) : null}
+
+        {/* Title + artist + key */}
+        <Text
+          numberOfLines={1}
+          style={{
+            marginTop: t.spacing.md,
+            fontSize: t.typography.largeTitle.fontSize,
+            fontWeight: t.typography.largeTitle.fontWeight,
+            letterSpacing: t.typography.largeTitle.letterSpacing,
+            color: t.colors.ink,
+          }}
+        >
+          {displayTitle}
+        </Text>
+        <View style={{ marginTop: 6, flexDirection: 'row', alignItems: 'center', gap: t.spacing.sm }}>
+          {displayArtist ? (
+            <Text style={{ fontSize: 13.5, color: t.colors.sec }}>{displayArtist}</Text>
+          ) : null}
+          {displayArtist && keyLabel ? (
+            <View style={{ width: 3, height: 3, borderRadius: 1.5, backgroundColor: t.colors.muted }} />
+          ) : null}
+          {keyLabel ? (
+            <View
+              style={{
+                backgroundColor: t.colors.accentSoft,
+                borderRadius: t.radii.pill,
+                paddingHorizontal: 10,
+                paddingVertical: 4,
+              }}
+            >
+              <Text style={{ fontSize: 13, fontWeight: '700', color: t.colors.textAccent }}>
+                Key of {keyLabel}
+              </Text>
+            </View>
+          ) : null}
+          {count > 1 ? (
+            <Text style={{ fontSize: 12.5, color: t.colors.muted }}>
+              {index + 1} / {count}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+
+      {/* Chart area */}
+      {setLoading || songLoading ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={t.colors.accent} />
+        </View>
+      ) : setError || songError || !entry ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.ink }}>
+            {!entry ? 'This set has no songs' : "Couldn't load song"}
+          </Text>
+          {setError || songError ? (
+            <Text style={{ marginTop: t.spacing.sm, fontSize: 13.5, color: t.colors.muted, textAlign: 'center' }}>
+              {setError || songError}
+            </Text>
+          ) : null}
+        </View>
+      ) : (
+        <GestureDetector gesture={swipe}>
+          <Animated.View style={[{ flex: 1 }, chartAnim]}>
+            {doc ? (
+              <ScrollView
+                style={{ flex: 1 }}
+                contentContainerStyle={{ padding: t.spacing.lg, paddingBottom: t.spacing.xxl * 2 + TRANSPOSE_BAR_CLEARANCE }}
+              >
+                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                  <ChordChart
+                    doc={doc}
+                    steps={steps}
+                    preferFlat={preferFlat}
+                    showChords={showChords}
+                    showSections={showSections}
+                    fontScale={fontScale}
+                    chordStyle={chordStyle}
+                  />
+                </ScrollView>
+              </ScrollView>
+            ) : (
+              <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
+                <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.ink }}>
+                  {parseError ? 'Chords unavailable' : 'No chart available'}
+                </Text>
+                <Text style={{ marginTop: t.spacing.sm, fontSize: 13.5, color: t.colors.muted }}>
+                  This song has no ChordPro content yet.
+                </Text>
+              </View>
+            )}
+          </Animated.View>
+        </GestureDetector>
+      )}
+
+      {/* Bottom controls: Prev · transpose island · Next */}
+      <View
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          bottom: 26,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: t.spacing.lg,
+        }}
+      >
+        {count > 1 ? (
+          <Pressable
+            onPress={goPrev}
+            disabled={index === 0}
+            accessibilityRole="button"
+            accessibilityLabel="Previous song"
+            style={navButtonStyle(index === 0)}
+          >
+            <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} weight="semibold" />
+          </Pressable>
+        ) : (
+          <View style={{ width: 50 }} />
+        )}
+
+        {keyLabel ? (
+          <TransposeBar keyLabel={keyLabel} onDown={() => transposeBy(-1)} onUp={() => transposeBy(1)} />
+        ) : (
+          <View />
+        )}
+
+        {count > 1 ? (
+          <Pressable
+            onPress={goNext}
+            disabled={index === count - 1}
+            accessibilityRole="button"
+            accessibilityLabel="Next song"
+            style={navButtonStyle(index === count - 1)}
+          >
+            <SymbolIcon name="chevron.right" size={22} color={t.colors.accent} weight="semibold" />
+          </Pressable>
+        ) : (
+          <View style={{ width: 50 }} />
+        )}
+      </View>
+
+      <ViewOptionsSheet
+        visible={sheet === 'options'}
+        onClose={() => setSheet(null)}
+        showChords={showChords}
+        onShowChords={setShowChords}
+        showSections={showSections}
+        onShowSections={setShowSections}
+        fontScale={fontScale}
+        onFontScale={setFontScale}
+        chordStyle={chordStyle}
+        onChordStyle={setChordStyle}
+      />
+      <PerformerShareSheet
+        visible={sheet === 'share'}
+        onClose={() => setSheet(null)}
+        songCount={count}
+        initialScope={count > 1 ? 'set' : 'song'}
+        handlers={shareHandlers}
+      />
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -1,5 +1,14 @@
-import { useEffect, useMemo, useState } from 'react'
-import { ActivityIndicator, Alert, Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import { useMemo, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  Animated as RNAnimated,
+  Linking,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native'
 import { useRouter } from 'expo-router'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import Animated, {
@@ -30,6 +39,7 @@ import PerformerShareSheet, {
 import { useTheme } from '../theme/ThemeProvider'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { useSong } from '../lib/useSong'
+import { useAutoHideChrome, useAutoHidePref } from '../lib/autoHideChrome'
 import { exportSetlist, exportSong } from '../lib/exportSong'
 import { buildSetlistShareUrl } from '../lib/setlistShare'
 import {
@@ -96,6 +106,15 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
   const [sheet, setSheet] = useState<null | 'options' | 'share'>(null)
 
+  // Chrome auto-hide (persisted). Pinned visible while a sheet is open; tap the
+  // chart, change songs, or use the transpose bar to bring it back.
+  const [autoHide, setAutoHide] = useAutoHidePref()
+  // Arm only when a chart is on screen (tap-to-reveal lives on the chart) and
+  // no sheet is open, so chrome can't hide behind a spinner or a sheet.
+  const { visible: chromeVisible, opacity: chromeOpacity, reveal } = useAutoHideChrome(
+    autoHide && sheet === null && songReady,
+  )
+
   // Slide transition between songs (reanimated).
   const slideX = useSharedValue(0)
   const slideOpacity = useSharedValue(1)
@@ -110,6 +129,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
     if (next < 0 || next >= count || next === index) return
     setSheet(null)
     setDelta(0)
+    reveal()
     slideX.value = dir === 'next' ? 26 : -26
     slideOpacity.value = 0.15
     setIndex(next)
@@ -123,6 +143,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
 
   const transposeBy = (dir: 1 | -1) => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {})
+    reveal()
     setDelta((d) => d + dir)
   }
 
@@ -140,6 +161,11 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         else runOnJS(goPrev)()
       }
     })
+
+  // A quick tap on the chart reveals hidden chrome (and resets the idle
+  // timer); it races the swipe so a drag still changes songs.
+  const tapReveal = Gesture.Tap().onEnd(() => runOnJS(reveal)())
+  const chartGesture = Gesture.Race(swipe, tapReveal)
 
   // Use the entry's catalog metadata for the header so it tracks the current
   // song immediately, not the still-loading `song`.
@@ -274,8 +300,11 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
 
   return (
     <Screen edges={['top', 'left', 'right', 'bottom']}>
-      {/* Header */}
-      <View style={{ paddingHorizontal: t.spacing.lg, paddingTop: t.spacing.sm }}>
+      {/* Header (auto-hides with the rest of the chrome) */}
+      <RNAnimated.View
+        pointerEvents={chromeVisible ? 'auto' : 'none'}
+        style={{ opacity: chromeOpacity, paddingHorizontal: t.spacing.lg, paddingTop: t.spacing.sm }}
+      >
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
           <Pressable
             onPress={() => router.back()}
@@ -381,7 +410,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
             </Text>
           ) : null}
         </View>
-      </View>
+      </RNAnimated.View>
 
       {/* Chart area */}
       {setLoading || songLoading || (entry && !songReady && !songError) ? (
@@ -400,7 +429,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
           ) : null}
         </View>
       ) : (
-        <GestureDetector gesture={swipe}>
+        <GestureDetector gesture={chartGesture}>
           <Animated.View style={[{ flex: 1 }, chartAnim]}>
             {doc ? (
               <ScrollView
@@ -433,10 +462,11 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         </GestureDetector>
       )}
 
-      {/* Bottom controls: Prev · transpose island · Next */}
-      <View
-        pointerEvents="box-none"
+      {/* Bottom controls: Prev · transpose island · Next (auto-hides too) */}
+      <RNAnimated.View
+        pointerEvents={chromeVisible ? 'box-none' : 'none'}
         style={{
+          opacity: chromeOpacity,
           position: 'absolute',
           left: 0,
           right: 0,
@@ -480,7 +510,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         ) : (
           <View style={{ width: 50 }} />
         )}
-      </View>
+      </RNAnimated.View>
 
       <ViewOptionsSheet
         visible={sheet === 'options'}
@@ -493,6 +523,8 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         onFontScale={setFontScale}
         chordStyle={chordStyle}
         onChordStyle={setChordStyle}
+        autoHide={autoHide}
+        onAutoHide={setAutoHide}
       />
       <PerformerShareSheet
         visible={sheet === 'share'}

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
@@ -54,10 +54,10 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
     error,
     setName,
     toggleSong,
-    removeAt,
-    duplicateAt,
-    moveItem,
-    setKeyAt,
+    removeEntry,
+    duplicateEntry,
+    moveEntry,
+    setKeyFor,
     deleteSet,
     updatedAt,
   } = useSetlistBuilder(setlistId)
@@ -73,23 +73,30 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
   const [optionsOpen, setOptionsOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
   const [addOpen, setAddOpen] = useState(false)
+  // "Change key" from the row sheet opens the key sheet only after the row
+  // sheet has fully dismissed (iOS refuses to present a modal while another
+  // is dismissing) — BottomSheet's onDismissed reports that moment.
+  const pendingKeyIndex = useRef<number | null>(null)
 
   // Toast pill (bottom-center, auto-dismiss).
   const [toast, setToast] = useState<string | null>(null)
   const toastOpacity = useRef(new Animated.Value(0)).current
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  function showToast(message: string) {
-    if (toastTimer.current) clearTimeout(toastTimer.current)
-    setToast(message)
-    Animated.timing(toastOpacity, { toValue: 1, duration: 160, useNativeDriver: true }).start()
-    toastTimer.current = setTimeout(() => {
-      Animated.timing(toastOpacity, { toValue: 0, duration: 220, useNativeDriver: true }).start(
-        ({ finished }) => {
-          if (finished) setToast(null)
-        },
-      )
-    }, TOAST_MS)
-  }
+  const showToast = useCallback(
+    (message: string) => {
+      if (toastTimer.current) clearTimeout(toastTimer.current)
+      setToast(message)
+      Animated.timing(toastOpacity, { toValue: 1, duration: 160, useNativeDriver: true }).start()
+      toastTimer.current = setTimeout(() => {
+        Animated.timing(toastOpacity, { toValue: 0, duration: 220, useNativeDriver: true }).start(
+          ({ finished }) => {
+            if (finished) setToast(null)
+          },
+        )
+      }, TOAST_MS)
+    },
+    [toastOpacity],
+  )
   useEffect(
     () => () => {
       if (toastTimer.current) clearTimeout(toastTimer.current)
@@ -125,21 +132,24 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
     setEditing(false)
   }
 
-  function openSong(index: number) {
-    const item = items[index]
-    if (!item) return
-    const key = effectiveKeys[index]
-    router.push({
-      pathname: '/viewer/[slug]',
-      params: {
-        slug: item.song.slug,
-        title: item.song.title,
-        artist: item.song.artist ?? '',
-        songKey: item.song.default_key ?? '',
-        ...(key ? { initialKey: key } : {}),
-      },
-    })
-  }
+  const openSong = useCallback(
+    (index: number) => {
+      const item = items[index]
+      if (!item) return
+      const key = effectiveKeys[index]
+      router.push({
+        pathname: '/viewer/[slug]',
+        params: {
+          slug: item.song.slug,
+          title: item.song.title,
+          artist: item.song.artist ?? '',
+          songKey: item.song.default_key ?? '',
+          ...(key ? { initialKey: key } : {}),
+        },
+      })
+    },
+    [items, effectiveKeys, router],
+  )
 
   function confirmDelete() {
     Alert.alert('Delete set?', `“${name}” and its songs will be removed.`, [
@@ -173,8 +183,10 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
       showToast('Add songs first')
       return
     }
-    // Same param-style share URL the web builder copies.
-    const ids = items.map((item) => encodeURIComponent(item.songId)).join(',')
+    // Same param-style share URL the web builder copies. The web catalog is
+    // keyed by SLUG (its normaliseSong maps id -> slug), so the link must
+    // carry slugs, not the Supabase uuids.
+    const ids = items.map((item) => encodeURIComponent(item.song.slug)).join(',')
     const keys = items.map((item) => encodeURIComponent(item.toKey || '')).join(',')
     try {
       await Clipboard.setStringAsync(`${apiBase()}/setlist/${ids}?toKeys=${keys}`)
@@ -203,16 +215,30 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
     }
   }
 
-  const callbacks: TimelineCallbacks = {
-    onPressRow: openSong,
-    onKeyTap: setKeyIndex,
-    onRowMenu: setMenuIndex,
-    onMove: moveItem,
-    onRemove: (index) => {
-      removeAt(index)
-      showToast('Removed from set')
-    },
-  }
+  // Stable identity so the memoized timeline rows don't re-render (and
+  // rebuild their gesture chains) on unrelated screen state changes. Actions
+  // resolve the rendered index to the entry's stable key before mutating —
+  // entries the catalog can't resolve stay in state but aren't rendered, so
+  // rendered indexes are not entry indexes.
+  const callbacks: TimelineCallbacks = useMemo(
+    () => ({
+      onPressRow: openSong,
+      onKeyTap: setKeyIndex,
+      onRowMenu: setMenuIndex,
+      onMove: (from, to) => {
+        const fromKey = items[from]?.entryKey
+        const toKey = items[to]?.entryKey
+        if (fromKey && toKey) moveEntry(fromKey, toKey)
+      },
+      onRemove: (index) => {
+        const entryKey = items[index]?.entryKey
+        if (!entryKey) return
+        removeEntry(entryKey)
+        showToast('Removed from set')
+      },
+    }),
+    [openSong, items, moveEntry, removeEntry, showToast],
+  )
 
   const iconButton = (label: string, icon: SymbolIconProps['name'], onPress: () => void) => (
     <Pressable
@@ -452,26 +478,34 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
         onClose={() => setKeyIndex(null)}
         songTitle={keyIndex != null ? items[keyIndex]?.song.title ?? null : null}
         currentKey={keyIndex != null ? effectiveKeys[keyIndex] ?? null : null}
+        nativeKey={keyIndex != null ? items[keyIndex]?.song.default_key ?? null : null}
+        hasOverride={keyIndex != null ? items[keyIndex]?.toKey != null : false}
         onPick={(key) => {
-          if (keyIndex != null) setKeyAt(keyIndex, key)
+          const entryKey = keyIndex != null ? items[keyIndex]?.entryKey : undefined
+          if (entryKey) setKeyFor(entryKey, key)
         }}
       />
       <RowActionsSheet
         visible={menuIndex != null}
         onClose={() => setMenuIndex(null)}
+        onDismissed={() => {
+          if (pendingKeyIndex.current != null) {
+            setKeyIndex(pendingKeyIndex.current)
+            pendingKeyIndex.current = null
+          }
+        }}
         songTitle={menuIndex != null ? items[menuIndex]?.song.title ?? '' : ''}
         onChangeKey={() => {
-          // Wait out the row sheet's exit animation — iOS won't present a new
-          // modal while another is still dismissing.
-          const index = menuIndex
-          if (index != null) setTimeout(() => setKeyIndex(index), 260)
+          pendingKeyIndex.current = menuIndex
         }}
         onDuplicate={() => {
-          if (menuIndex != null) duplicateAt(menuIndex)
+          const entryKey = menuIndex != null ? items[menuIndex]?.entryKey : undefined
+          if (entryKey) duplicateEntry(entryKey)
         }}
         onRemove={() => {
-          if (menuIndex != null) {
-            removeAt(menuIndex)
+          const entryKey = menuIndex != null ? items[menuIndex]?.entryKey : undefined
+          if (entryKey) {
+            removeEntry(entryKey)
             showToast('Removed from set')
           }
         }}
@@ -480,7 +514,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
         visible={optionsOpen}
         onClose={() => setOptionsOpen(false)}
         onRename={startRename}
-        onSavedSets={() => router.back()}
+        onSavedSets={() => router.navigate('/setlists')}
         onNewSet={newSet}
         onDeleteSet={confirmDelete}
       />

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -30,7 +30,7 @@ import AddSongsModal from '../components/setlist/AddSongsModal'
 import { useTheme } from '../theme/ThemeProvider'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { supabase } from '../lib/supabase'
-import { apiBase } from '../lib/api'
+import { buildSetlistShareUrl } from '../lib/setlistShare'
 import { pushSetToTelegram, TELEGRAM_BOT_URL } from '../lib/telegramPush'
 import { timeAgo } from '../lib/relativeTime'
 import { errMessage } from '../lib/errors'
@@ -183,13 +183,8 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
       showToast('Add songs first')
       return
     }
-    // Same param-style share URL the web builder copies. The web catalog is
-    // keyed by SLUG (its normaliseSong maps id -> slug), so the link must
-    // carry slugs, not the Supabase uuids.
-    const ids = items.map((item) => encodeURIComponent(item.song.slug)).join(',')
-    const keys = items.map((item) => encodeURIComponent(item.toKey || '')).join(',')
     try {
-      await Clipboard.setStringAsync(`${apiBase()}/setlist/${ids}?toKeys=${keys}`)
+      await Clipboard.setStringAsync(buildSetlistShareUrl(items))
       showToast('Set link copied')
     } catch (err: unknown) {
       Alert.alert('Could not copy link', errMessage(err))

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -1,0 +1,492 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  Animated,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import * as Clipboard from 'expo-clipboard'
+import {
+  createSetlist,
+  effectiveKey,
+  formatSetSummary,
+  summarizeSet,
+} from '@gracechords/core'
+import Screen from '../components/Screen'
+import Card from '../components/Card'
+import Button from '../components/Button'
+import SymbolIcon, { type SymbolIconProps } from '../components/SymbolIcon'
+import SetlistTimeline, { type TimelineCallbacks } from '../components/setlist/SetlistTimeline'
+import KeyPickerSheet from '../components/setlist/KeyPickerSheet'
+import RowActionsSheet from '../components/setlist/RowActionsSheet'
+import SetOptionsSheet from '../components/setlist/SetOptionsSheet'
+import ShareSetSheet from '../components/setlist/ShareSetSheet'
+import AddSongsModal from '../components/setlist/AddSongsModal'
+import { useTheme } from '../theme/ThemeProvider'
+import { useSetlistBuilder } from '../lib/useSetlistBuilder'
+import { supabase } from '../lib/supabase'
+import { apiBase } from '../lib/api'
+import { pushSetToTelegram, TELEGRAM_BOT_URL } from '../lib/telegramPush'
+import { timeAgo } from '../lib/relativeTime'
+import { errMessage } from '../lib/errors'
+
+const TOAST_MS = 1900
+
+// The Setlist Builder (build mode): hero set card with inline rename, the
+// numbered drag-to-reorder timeline, summary footer, Add + Start set bar,
+// and the share / options / key / row sheets. All edits autosave through
+// useSetlistBuilder; opening a song pushes the Viewer seeded at the entry's
+// setlist key via the existing initialKey param.
+export default function SetlistBuilderScreen({ setlistId }: { setlistId: string }) {
+  const t = useTheme()
+  const router = useRouter()
+  const {
+    name,
+    items,
+    songs,
+    loading,
+    notFound,
+    error,
+    setName,
+    toggleSong,
+    removeAt,
+    duplicateAt,
+    moveItem,
+    setKeyAt,
+    deleteSet,
+    updatedAt,
+  } = useSetlistBuilder(setlistId)
+
+  // Inline rename (in the hero card, no modal): select-all on focus, × clears
+  // and refocuses, Done/return commits, an empty draft reverts.
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const nameInput = useRef<TextInput>(null)
+
+  const [keyIndex, setKeyIndex] = useState<number | null>(null)
+  const [menuIndex, setMenuIndex] = useState<number | null>(null)
+  const [optionsOpen, setOptionsOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
+  const [addOpen, setAddOpen] = useState(false)
+
+  // Toast pill (bottom-center, auto-dismiss).
+  const [toast, setToast] = useState<string | null>(null)
+  const toastOpacity = useRef(new Animated.Value(0)).current
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  function showToast(message: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current)
+    setToast(message)
+    Animated.timing(toastOpacity, { toValue: 1, duration: 160, useNativeDriver: true }).start()
+    toastTimer.current = setTimeout(() => {
+      Animated.timing(toastOpacity, { toValue: 0, duration: 220, useNativeDriver: true }).start(
+        ({ finished }) => {
+          if (finished) setToast(null)
+        },
+      )
+    }, TOAST_MS)
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current)
+    },
+    [],
+  )
+
+  const effectiveKeys = useMemo(
+    () => items.map((item) => effectiveKey(item, item.song)),
+    [items],
+  )
+  const summary = useMemo(
+    () =>
+      summarizeSet(
+        items.map((item) => ({
+          toKey: item.toKey,
+          default_key: item.song.default_key,
+          tempo: item.song.tempo,
+        })),
+      ),
+    [items],
+  )
+  const addedSongIds = useMemo(() => new Set(items.map((item) => item.songId)), [items])
+
+  function startRename() {
+    setDraft(name)
+    setEditing(true)
+  }
+
+  function commitRename() {
+    const next = draft.trim()
+    if (next && next !== name) setName(next)
+    setEditing(false)
+  }
+
+  function openSong(index: number) {
+    const item = items[index]
+    if (!item) return
+    const key = effectiveKeys[index]
+    router.push({
+      pathname: '/viewer/[slug]',
+      params: {
+        slug: item.song.slug,
+        title: item.song.title,
+        artist: item.song.artist ?? '',
+        songKey: item.song.default_key ?? '',
+        ...(key ? { initialKey: key } : {}),
+      },
+    })
+  }
+
+  function confirmDelete() {
+    Alert.alert('Delete set?', `“${name}” and its songs will be removed.`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await deleteSet()
+            router.back()
+          } catch (err: unknown) {
+            Alert.alert('Could not delete set', errMessage(err))
+          }
+        },
+      },
+    ])
+  }
+
+  async function newSet() {
+    try {
+      const row = (await createSetlist(supabase)) as { id: string }
+      router.replace(`/setlist/${row.id}`)
+    } catch (err: unknown) {
+      Alert.alert('Could not create set', errMessage(err))
+    }
+  }
+
+  async function copyLink() {
+    // Same param-style share URL the web builder copies.
+    const ids = items.map((item) => encodeURIComponent(item.songId)).join(',')
+    const keys = items.map((item) => encodeURIComponent(item.toKey || '')).join(',')
+    try {
+      await Clipboard.setStringAsync(`${apiBase()}/setlist/${ids}?toKeys=${keys}`)
+      showToast('Set link copied')
+    } catch (err: unknown) {
+      Alert.alert('Could not copy link', errMessage(err))
+    }
+  }
+
+  async function sendTelegram() {
+    try {
+      const result = await pushSetToTelegram(
+        items.map((item, i) => ({ songId: item.songId, key: effectiveKeys[i] })),
+      )
+      if (result === 'not_linked') {
+        Alert.alert('Telegram not linked', `Link your account with the bot first: ${TELEGRAM_BOT_URL}`)
+        return
+      }
+      showToast('Sent to Telegram')
+    } catch (err: unknown) {
+      Alert.alert('Could not send set', errMessage(err))
+    }
+  }
+
+  const callbacks: TimelineCallbacks = {
+    onPressRow: openSong,
+    onKeyTap: setKeyIndex,
+    onRowMenu: setMenuIndex,
+    onMove: moveItem,
+    onRemove: (index) => {
+      removeAt(index)
+      showToast('Removed from set')
+    },
+  }
+
+  const iconButton = (label: string, icon: SymbolIconProps['name'], onPress: () => void) => (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={8}
+      onPress={onPress}
+      style={{
+        width: 38,
+        height: 38,
+        borderRadius: t.radii.pill,
+        backgroundColor: t.colors.surfaceAlt,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <SymbolIcon name={icon} size={17} color={t.colors.accent} />
+    </Pressable>
+  )
+
+  const metaLine = formatSetSummary(summary)
+  const edited = timeAgo(updatedAt)
+
+  if (notFound) {
+    return (
+      <Screen edges={['top', 'left', 'right', 'bottom']}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+            This setlist no longer exists.
+          </Text>
+        </View>
+      </Screen>
+    )
+  }
+
+  return (
+    <Screen edges={['top', 'left', 'right', 'bottom']}>
+      {/* Header: back + share + more */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: t.spacing.lg,
+          paddingVertical: t.spacing.sm,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back to setlists"
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 3 }}
+        >
+          <SymbolIcon name="chevron.left" size={17} color={t.colors.textAccent} weight="semibold" />
+          <Text style={{ fontSize: 16, color: t.colors.textAccent }}>Setlists</Text>
+        </Pressable>
+        <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+          {iconButton('Export and share', 'square.and.arrow.up', () => setShareOpen(true))}
+          {iconButton('Setlist options', 'ellipsis', () => setOptionsOpen(true))}
+        </View>
+      </View>
+
+      {loading ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={t.colors.accent} />
+        </View>
+      ) : (
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingHorizontal: t.spacing.lg, paddingBottom: t.spacing.xl }}
+        >
+          {/* Hero set card */}
+          <Card style={{ padding: t.spacing.lg, marginBottom: t.spacing.lg }}>
+            {editing ? (
+              <View style={{ gap: t.spacing.sm }}>
+                <Text
+                  style={{
+                    fontSize: t.typography.overline.fontSize,
+                    fontWeight: t.typography.overline.fontWeight,
+                    letterSpacing: t.typography.overline.letterSpacing,
+                    textTransform: 'uppercase',
+                    color: t.colors.muted,
+                  }}
+                >
+                  Set name
+                </Text>
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 8,
+                    borderWidth: 1.5,
+                    borderColor: t.colors.accent,
+                    borderRadius: t.radii.md,
+                    paddingHorizontal: 12,
+                    height: 46,
+                  }}
+                >
+                  <TextInput
+                    ref={nameInput}
+                    value={draft}
+                    onChangeText={setDraft}
+                    autoFocus
+                    selectTextOnFocus
+                    returnKeyType="done"
+                    onSubmitEditing={commitRename}
+                    accessibilityLabel="Set name"
+                    style={{ flex: 1, fontSize: 17, fontWeight: '600', color: t.colors.ink, padding: 0 }}
+                  />
+                  <Pressable
+                    onPress={() => {
+                      setDraft('')
+                      nameInput.current?.focus()
+                    }}
+                    accessibilityRole="button"
+                    accessibilityLabel="Clear set name"
+                    hitSlop={8}
+                  >
+                    <SymbolIcon name="xmark.circle.fill" size={18} color={t.colors.muted} />
+                  </Pressable>
+                </View>
+                <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Text style={{ fontSize: t.typography.rowMeta.fontSize, color: t.colors.sec }}>
+                    {metaLine}
+                  </Text>
+                  <Button title="Done" onPress={commitRename} fullWidth={false} style={{ height: 40 }} />
+                </View>
+              </View>
+            ) : (
+              <Pressable onPress={startRename} accessibilityRole="button" accessibilityLabel="Rename set">
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: t.spacing.sm }}>
+                  <Text
+                    numberOfLines={1}
+                    style={{ flexShrink: 1, fontSize: 22, fontWeight: '700', letterSpacing: -0.4, color: t.colors.ink }}
+                  >
+                    {name}
+                  </Text>
+                  <SymbolIcon name="pencil" size={15} color={t.colors.muted} />
+                </View>
+                <Text style={{ marginTop: 6, fontSize: t.typography.rowMeta.fontSize, color: t.colors.sec }}>
+                  {metaLine}
+                </Text>
+                {edited ? (
+                  <Text style={{ marginTop: 2, fontSize: t.typography.rowMeta.fontSize, color: t.colors.muted }}>
+                    Last edited {edited}
+                  </Text>
+                ) : null}
+              </Pressable>
+            )}
+          </Card>
+
+          {/* Timeline */}
+          {error ? (
+            <Text
+              style={{
+                marginBottom: t.spacing.sm,
+                fontSize: t.typography.rowMeta.fontSize,
+                color: t.colors.danger,
+              }}
+            >
+              {error}
+            </Text>
+          ) : null}
+          {items.length === 0 ? (
+            <View style={{ alignItems: 'center', paddingVertical: t.spacing.xxl, gap: 4 }}>
+              <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.ink }}>
+                No songs yet
+              </Text>
+              <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+                Tap Add to search your library.
+              </Text>
+            </View>
+          ) : (
+            <SetlistTimeline items={items} effectiveKeys={effectiveKeys} callbacks={callbacks} />
+          )}
+        </ScrollView>
+      )}
+
+      {/* Bottom action bar */}
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: t.spacing.sm,
+          paddingHorizontal: t.spacing.lg,
+          paddingTop: t.spacing.sm,
+          borderTopWidth: 0.5,
+          borderTopColor: t.colors.border,
+        }}
+      >
+        <Pressable
+          onPress={() => setAddOpen(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Add songs"
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 6,
+            height: 48,
+            paddingHorizontal: t.spacing.lg,
+            borderRadius: t.radii.md,
+            backgroundColor: t.colors.surfaceAlt,
+          }}
+        >
+          <SymbolIcon name="plus" size={16} color={t.colors.ink} weight="semibold" />
+          <Text style={{ fontSize: 16, fontWeight: '600', letterSpacing: -0.2, color: t.colors.ink }}>
+            Add
+          </Text>
+        </Pressable>
+        {/* Performer mode ships in a later stage. */}
+        <Button title="Start set" disabled style={{ flex: 1 }} fullWidth={false} />
+      </View>
+
+      {/* Toast */}
+      {toast ? (
+        <Animated.View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            bottom: 84,
+            alignSelf: 'center',
+            opacity: toastOpacity,
+            backgroundColor: t.colors.ink,
+            borderRadius: t.radii.pill,
+            paddingHorizontal: t.spacing.lg,
+            paddingVertical: 10,
+          }}
+        >
+          <Text style={{ fontSize: 13.5, fontWeight: '600', color: t.colors.bg }}>{toast}</Text>
+        </Animated.View>
+      ) : null}
+
+      {/* Sheets */}
+      <KeyPickerSheet
+        visible={keyIndex != null}
+        onClose={() => setKeyIndex(null)}
+        songTitle={keyIndex != null ? items[keyIndex]?.song.title ?? null : null}
+        currentKey={keyIndex != null ? effectiveKeys[keyIndex] ?? null : null}
+        onPick={(key) => {
+          if (keyIndex != null) setKeyAt(keyIndex, key)
+        }}
+      />
+      <RowActionsSheet
+        visible={menuIndex != null}
+        onClose={() => setMenuIndex(null)}
+        songTitle={menuIndex != null ? items[menuIndex]?.song.title ?? '' : ''}
+        onChangeKey={() => {
+          if (menuIndex != null) setKeyIndex(menuIndex)
+        }}
+        onDuplicate={() => {
+          if (menuIndex != null) duplicateAt(menuIndex)
+        }}
+        onRemove={() => {
+          if (menuIndex != null) {
+            removeAt(menuIndex)
+            showToast('Removed from set')
+          }
+        }}
+      />
+      <SetOptionsSheet
+        visible={optionsOpen}
+        onClose={() => setOptionsOpen(false)}
+        onRename={startRename}
+        onSavedSets={() => router.back()}
+        onNewSet={newSet}
+        onDeleteSet={confirmDelete}
+      />
+      <ShareSetSheet
+        visible={shareOpen}
+        onClose={() => setShareOpen(false)}
+        songCount={items.length}
+        onCopyLink={copyLink}
+        onTelegram={sendTelegram}
+      />
+      <AddSongsModal
+        visible={addOpen}
+        onClose={() => setAddOpen(false)}
+        songs={songs}
+        addedSongIds={addedSongIds}
+        onToggle={toggleSong}
+      />
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -169,6 +169,10 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
   }
 
   async function copyLink() {
+    if (items.length === 0) {
+      showToast('Add songs first')
+      return
+    }
     // Same param-style share URL the web builder copies.
     const ids = items.map((item) => encodeURIComponent(item.songId)).join(',')
     const keys = items.map((item) => encodeURIComponent(item.toKey || '')).join(',')
@@ -181,6 +185,10 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
   }
 
   async function sendTelegram() {
+    if (items.length === 0) {
+      showToast('Add songs first')
+      return
+    }
     try {
       const result = await pushSetToTelegram(
         items.map((item, i) => ({ songId: item.songId, key: effectiveKeys[i] })),
@@ -453,7 +461,10 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
         onClose={() => setMenuIndex(null)}
         songTitle={menuIndex != null ? items[menuIndex]?.song.title ?? '' : ''}
         onChangeKey={() => {
-          if (menuIndex != null) setKeyIndex(menuIndex)
+          // Wait out the row sheet's exit animation — iOS won't present a new
+          // modal while another is still dismissing.
+          const index = menuIndex
+          if (index != null) setTimeout(() => setKeyIndex(index), 260)
         }}
         onDuplicate={() => {
           if (menuIndex != null) duplicateAt(menuIndex)

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -449,8 +449,13 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
             Add
           </Text>
         </Pressable>
-        {/* Performer mode ships in a later stage. */}
-        <Button title="Start set" disabled style={{ flex: 1 }} fullWidth={false} />
+        <Button
+          title="Start set"
+          onPress={() => router.push(`/perform/${setlistId}`)}
+          disabled={items.length === 0}
+          style={{ flex: 1 }}
+          fullWidth={false}
+        />
       </View>
 
       {/* Toast */}

--- a/apps/mobile/src/screens/SetlistsScreen.tsx
+++ b/apps/mobile/src/screens/SetlistsScreen.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useState } from 'react'
+import { ActivityIndicator, Alert, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
+import { useFocusEffect, useRouter } from 'expo-router'
+import Screen from '../components/Screen'
+import ListRow from '../components/ListRow'
+import Button from '../components/Button'
+import SymbolIcon from '../components/SymbolIcon'
+import { useTheme } from '../theme/ThemeProvider'
+import { useSetlists, type SetlistRow } from '../lib/useSetlists'
+import { timeAgo } from '../lib/relativeTime'
+import { errMessage } from '../lib/errors'
+
+// The Setlists tab: every personal setlist (newest-edited first), a New set
+// action, and tap-to-open into the builder.
+export default function SetlistsScreen() {
+  const t = useTheme()
+  const router = useRouter()
+  const { setlists, loading, error, refresh, create } = useSetlists()
+  const [refreshing, setRefreshing] = useState(false)
+  const [creating, setCreating] = useState(false)
+
+  // Refresh whenever the tab regains focus so edits made in the builder
+  // (name, songs, deletes) are reflected without a manual pull.
+  useFocusEffect(
+    useCallback(() => {
+      refresh()
+    }, [refresh]),
+  )
+
+  async function onRefresh() {
+    setRefreshing(true)
+    await refresh()
+    setRefreshing(false)
+  }
+
+  async function onCreate() {
+    if (creating) return
+    setCreating(true)
+    try {
+      const row = await create()
+      router.push(`/setlist/${row.id}`)
+    } catch (err: unknown) {
+      Alert.alert('Could not create set', errMessage(err))
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  function subtitle(item: SetlistRow) {
+    const n = item.songCount
+    const edited = timeAgo(item.updated_at)
+    return [`${n} ${n === 1 ? 'song' : 'songs'}`, edited ? `edited ${edited}` : null]
+      .filter(Boolean)
+      .join(' · ')
+  }
+
+  function renderBody() {
+    if (loading) {
+      return (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={t.colors.accent} />
+        </View>
+      )
+    }
+    if (error) {
+      return (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted, textAlign: 'center' }}>
+            {error}
+          </Text>
+        </View>
+      )
+    }
+    if (setlists.length === 0) {
+      return (
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: t.spacing.xl,
+            gap: t.spacing.lg,
+          }}
+        >
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted, textAlign: 'center' }}>
+            No setlists yet.{'\n'}Create one to start planning a service.
+          </Text>
+          <Button title="New set" onPress={onCreate} disabled={creating} fullWidth={false} />
+        </View>
+      )
+    }
+    return (
+      <FlatList
+        data={setlists}
+        keyExtractor={(item) => item.id}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={t.colors.muted} />
+        }
+        renderItem={({ item }) => (
+          <ListRow
+            title={item.name}
+            subtitle={subtitle(item)}
+            onPress={() => router.push(`/setlist/${item.id}`)}
+          />
+        )}
+        contentContainerStyle={{ paddingBottom: t.spacing.sm }}
+      />
+    )
+  }
+
+  return (
+    <Screen edges={['top', 'left', 'right']}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: t.spacing.lg,
+          paddingTop: t.spacing.sm,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: t.typography.largeTitle.fontSize,
+            fontWeight: t.typography.largeTitle.fontWeight,
+            letterSpacing: t.typography.largeTitle.letterSpacing,
+            color: t.colors.ink,
+          }}
+        >
+          Setlists
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="New set"
+          hitSlop={8}
+          onPress={onCreate}
+          disabled={creating}
+          style={{
+            width: 38,
+            height: 38,
+            borderRadius: t.radii.pill,
+            backgroundColor: t.colors.accent,
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: creating ? 0.5 : 1,
+          }}
+        >
+          <SymbolIcon name="plus" size={20} color={t.colors.onAccent} weight="semibold" />
+        </Pressable>
+      </View>
+      {renderBody()}
+    </Screen>
+  )
+}

--- a/apps/web/functions/api/export/_shared.js
+++ b/apps/web/functions/api/export/_shared.js
@@ -1,0 +1,76 @@
+// Shared helpers for the /api/export/* Pages Functions (single song + whole
+// setlist). Files prefixed with `_` are not routed by Cloudflare Pages, so this
+// is a safe place for the common JSON helpers, Supabase JWT verification, and
+// the song-row fetch both endpoints use — keeping auth logic in ONE place so
+// the two routes can't drift.
+
+// jsPDF references `window` in a couple of optional code paths. Provide a
+// minimal shim before any pdf_mvp call. Safe in browsers (already exists).
+export function ensureWindowShim() {
+  if (typeof globalThis.window === 'undefined') {
+    globalThis.window = globalThis
+  }
+}
+
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function json(body, init = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(init.headers || {}) }
+  return new Response(JSON.stringify(body), { ...init, headers })
+}
+
+export function jsonError(msg, status, extra) {
+  return json({ error: msg, ...(extra || {}) }, { status })
+}
+
+export function corsPreflight(request) {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': new URL(request.url).origin,
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    },
+  })
+}
+
+export async function verifySupabaseJwt(request, env) {
+  const auth = request.headers.get('Authorization') || ''
+  if (!auth.startsWith('Bearer ')) {
+    return { error: 'Missing bearer token', status: 401 }
+  }
+  const token = auth.slice(7).trim()
+
+  const resp = await fetch(`${env.SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (resp.status === 401) return { error: 'Invalid or expired token', status: 401 }
+  if (!resp.ok) return { error: `Auth check failed: ${resp.status}`, status: 502 }
+  const user = await resp.json().catch(() => null)
+  if (!user?.id) return { error: 'Auth response missing user id', status: 502 }
+  return { userId: user.id }
+}
+
+const SONG_SELECT = 'id,slug,title,artist,default_key,chordpro_content'
+
+// Fetch songs by a service-role query (RLS bypassed; the caller is already
+// authenticated). `filter` is a PostgREST filter clause, e.g.
+// `id=eq.<uuid>` or `id=in.(<uuid>,<uuid>)`.
+export async function fetchSongsByFilter(env, filter) {
+  const resp = await fetch(
+    `${env.SUPABASE_URL}/rest/v1/songs?select=${SONG_SELECT}&${filter}&is_deleted=eq.false`,
+    {
+      headers: {
+        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+    },
+  )
+  if (!resp.ok) return { error: `Supabase query failed: ${resp.status}`, status: 502 }
+  const rows = await resp.json().catch(() => null)
+  if (!Array.isArray(rows)) return { error: 'Supabase returned no rows', status: 502 }
+  return { rows }
+}

--- a/apps/web/functions/api/export/setlist.js
+++ b/apps/web/functions/api/export/setlist.js
@@ -13,79 +13,24 @@
 import { renderMultiSongPdfBuffer } from '../../../src/utils/pdf_mvp/pure.js'
 import { toRenderableSong } from '../../../src/utils/pdf_mvp/serverSong.js'
 import { makeFontRegistrar } from '../../../src/utils/pdf_mvp/fontsR2.js'
+import {
+  UUID_RE,
+  corsPreflight,
+  ensureWindowShim,
+  fetchSongsByFilter,
+  jsonError,
+  verifySupabaseJwt,
+} from './_shared.js'
 
-// jsPDF references `window` in a couple of optional code paths. Provide a
-// minimal shim before any pdf_mvp call. Safe in browsers (already exists).
-if (typeof globalThis.window === 'undefined') {
-  globalThis.window = globalThis
-}
+ensureWindowShim()
 
 const MAX_ITEMS = 25
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-function json(body, init = {}) {
-  const headers = { 'Content-Type': 'application/json', ...(init.headers || {}) }
-  return new Response(JSON.stringify(body), { ...init, headers })
-}
-function jsonError(msg, status, extra) {
-  return json({ error: msg, ...(extra || {}) }, { status })
-}
-
-async function verifySupabaseJwt(request, env) {
-  const auth = request.headers.get('Authorization') || ''
-  if (!auth.startsWith('Bearer ')) {
-    return { error: 'Missing bearer token', status: 401 }
-  }
-  const token = auth.slice(7).trim()
-
-  const resp = await fetch(`${env.SUPABASE_URL}/auth/v1/user`, {
-    headers: {
-      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
-      Authorization: `Bearer ${token}`,
-    },
-  })
-  if (resp.status === 401) return { error: 'Invalid or expired token', status: 401 }
-  if (!resp.ok) return { error: `Auth check failed: ${resp.status}`, status: 502 }
-  const user = await resp.json().catch(() => null)
-  if (!user?.id) return { error: 'Auth response missing user id', status: 502 }
-  return { userId: user.id }
-}
-
-async function fetchSongRows(env, ids) {
-  const inList = ids.map((id) => encodeURIComponent(id)).join(',')
-  const select = 'id,slug,title,artist,default_key,chordpro_content'
-  const resp = await fetch(
-    `${env.SUPABASE_URL}/rest/v1/songs?select=${select}&id=in.(${inList})&is_deleted=eq.false`,
-    {
-      headers: {
-        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
-        Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
-      },
-    },
-  )
-  if (!resp.ok) return { error: `Supabase query failed: ${resp.status}`, status: 502 }
-  const rows = await resp.json().catch(() => null)
-  if (!Array.isArray(rows)) return { error: 'Supabase returned no rows', status: 502 }
-  return { rows }
-}
 
 export async function onRequest(context) {
   const { request, env } = context
 
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        'Access-Control-Allow-Origin': new URL(request.url).origin,
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Authorization, Content-Type',
-      },
-    })
-  }
-
-  if (request.method !== 'POST') {
-    return jsonError('Method not allowed', 405)
-  }
+  if (request.method === 'OPTIONS') return corsPreflight(request)
+  if (request.method !== 'POST') return jsonError('Method not allowed', 405)
 
   const auth = await verifySupabaseJwt(request, env)
   if (auth.error) return jsonError(auth.error, auth.status)
@@ -112,7 +57,8 @@ export async function onRequest(context) {
   // One query for all unique ids, then reorder to match the request (dropping
   // any id the query didn't return, e.g. soft-deleted since).
   const uniqueIds = [...new Set(normalized.map((n) => n.song_id))]
-  const found = await fetchSongRows(env, uniqueIds)
+  const inList = uniqueIds.map((id) => encodeURIComponent(id)).join(',')
+  const found = await fetchSongsByFilter(env, `id=in.(${inList})`)
   if (found.error) return jsonError(found.error, found.status)
   const rowById = new Map(found.rows.map((r) => [r.id, r]))
 

--- a/apps/web/functions/api/export/setlist.js
+++ b/apps/web/functions/api/export/setlist.js
@@ -1,0 +1,139 @@
+// POST /api/export/setlist
+//   Body: { items: [{ song_id: uuid, key?: string }] }  (max 25)
+//   Headers: Authorization: Bearer <supabase access token>
+//
+// Renders a whole setlist to a single combined PDF, one song per page, using
+// the same DOM-free pdf_mvp engine the single-song endpoint and the Telegram
+// bot use. Returns application/pdf bytes. This is the multi-song counterpart
+// to /api/export/song; there is intentionally no image scope for sets.
+//
+// Fonts: registers Noto from R2 (makeFontRegistrar) so output matches the
+// browser + Telegram bot, falling back to Helvetica/Courier if R2 is absent.
+
+import { renderMultiSongPdfBuffer } from '../../../src/utils/pdf_mvp/pure.js'
+import { toRenderableSong } from '../../../src/utils/pdf_mvp/serverSong.js'
+import { makeFontRegistrar } from '../../../src/utils/pdf_mvp/fontsR2.js'
+
+// jsPDF references `window` in a couple of optional code paths. Provide a
+// minimal shim before any pdf_mvp call. Safe in browsers (already exists).
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = globalThis
+}
+
+const MAX_ITEMS = 25
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function json(body, init = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(init.headers || {}) }
+  return new Response(JSON.stringify(body), { ...init, headers })
+}
+function jsonError(msg, status, extra) {
+  return json({ error: msg, ...(extra || {}) }, { status })
+}
+
+async function verifySupabaseJwt(request, env) {
+  const auth = request.headers.get('Authorization') || ''
+  if (!auth.startsWith('Bearer ')) {
+    return { error: 'Missing bearer token', status: 401 }
+  }
+  const token = auth.slice(7).trim()
+
+  const resp = await fetch(`${env.SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (resp.status === 401) return { error: 'Invalid or expired token', status: 401 }
+  if (!resp.ok) return { error: `Auth check failed: ${resp.status}`, status: 502 }
+  const user = await resp.json().catch(() => null)
+  if (!user?.id) return { error: 'Auth response missing user id', status: 502 }
+  return { userId: user.id }
+}
+
+async function fetchSongRows(env, ids) {
+  const inList = ids.map((id) => encodeURIComponent(id)).join(',')
+  const select = 'id,slug,title,artist,default_key,chordpro_content'
+  const resp = await fetch(
+    `${env.SUPABASE_URL}/rest/v1/songs?select=${select}&id=in.(${inList})&is_deleted=eq.false`,
+    {
+      headers: {
+        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+    },
+  )
+  if (!resp.ok) return { error: `Supabase query failed: ${resp.status}`, status: 502 }
+  const rows = await resp.json().catch(() => null)
+  if (!Array.isArray(rows)) return { error: 'Supabase returned no rows', status: 502 }
+  return { rows }
+}
+
+export async function onRequest(context) {
+  const { request, env } = context
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': new URL(request.url).origin,
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      },
+    })
+  }
+
+  if (request.method !== 'POST') {
+    return jsonError('Method not allowed', 405)
+  }
+
+  const auth = await verifySupabaseJwt(request, env)
+  if (auth.error) return jsonError(auth.error, auth.status)
+
+  let body
+  try {
+    body = await request.json()
+  } catch {
+    return jsonError('Invalid JSON', 400)
+  }
+
+  const items = Array.isArray(body?.items) ? body.items : null
+  if (!items || items.length === 0) return jsonError('items required', 400)
+  if (items.length > MAX_ITEMS) return jsonError(`Too many items (max ${MAX_ITEMS})`, 400)
+
+  const normalized = []
+  for (const it of items) {
+    const songId = typeof it?.song_id === 'string' ? it.song_id.trim() : ''
+    if (!UUID_RE.test(songId)) return jsonError('each item.song_id must be a UUID', 400)
+    const key = typeof it?.key === 'string' ? it.key.trim() : ''
+    normalized.push({ song_id: songId, key })
+  }
+
+  // One query for all unique ids, then reorder to match the request (dropping
+  // any id the query didn't return, e.g. soft-deleted since).
+  const uniqueIds = [...new Set(normalized.map((n) => n.song_id))]
+  const found = await fetchSongRows(env, uniqueIds)
+  if (found.error) return jsonError(found.error, found.status)
+  const rowById = new Map(found.rows.map((r) => [r.id, r]))
+
+  const renderables = []
+  for (const n of normalized) {
+    const row = rowById.get(n.song_id)
+    if (row) renderables.push(toRenderableSong(row, n.key))
+  }
+  if (renderables.length === 0) return jsonError('No songs found', 404)
+
+  let pdf
+  try {
+    pdf = await renderMultiSongPdfBuffer(renderables, { registerFonts: makeFontRegistrar(env) })
+  } catch (err) {
+    return jsonError(`Render failed: ${err?.message || err}`, 500)
+  }
+
+  return new Response(pdf, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': 'attachment; filename="setlist.pdf"',
+    },
+  })
+}

--- a/apps/web/functions/api/export/song.js
+++ b/apps/web/functions/api/export/song.js
@@ -17,80 +17,35 @@ import { renderSingleSongPdfBuffer } from '../../../src/utils/pdf_mvp/pure.js'
 import { toRenderableSong } from '../../../src/utils/pdf_mvp/serverSong.js'
 import { rasterizePdfToPng } from '../../../src/utils/pdf_mvp/pngRaster.js'
 import { makeFontRegistrar } from '../../../src/utils/pdf_mvp/fontsR2.js'
+import {
+  UUID_RE,
+  corsPreflight,
+  ensureWindowShim,
+  fetchSongsByFilter,
+  jsonError,
+  verifySupabaseJwt,
+} from './_shared.js'
 // Bundle the pdfium WASM at deploy time. Workers/Pages only allow
 // pre-compiled WebAssembly.Module instances, which is what wrangler's
 // bundler produces from a .wasm import.
 import pdfiumWasmModule from '@hyzyla/pdfium/pdfium.wasm'
 
-// jsPDF references `window` in a couple of optional code paths. Provide a
-// minimal shim before any pdf_mvp call. Safe in browsers (already exists).
-if (typeof globalThis.window === 'undefined') {
-  globalThis.window = globalThis
-}
-
-function json(body, init = {}) {
-  const headers = { 'Content-Type': 'application/json', ...(init.headers || {}) }
-  return new Response(JSON.stringify(body), { ...init, headers })
-}
-function jsonError(msg, status, extra) {
-  return json({ error: msg, ...(extra || {}) }, { status })
-}
-
-async function verifySupabaseJwt(request, env) {
-  const auth = request.headers.get('Authorization') || ''
-  if (!auth.startsWith('Bearer ')) {
-    return { error: 'Missing bearer token', status: 401 }
-  }
-  const token = auth.slice(7).trim()
-
-  const resp = await fetch(`${env.SUPABASE_URL}/auth/v1/user`, {
-    headers: {
-      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
-      Authorization: `Bearer ${token}`,
-    },
-  })
-  if (resp.status === 401) return { error: 'Invalid or expired token', status: 401 }
-  if (!resp.ok) return { error: `Auth check failed: ${resp.status}`, status: 502 }
-  const user = await resp.json().catch(() => null)
-  if (!user?.id) return { error: 'Auth response missing user id', status: 502 }
-  return { userId: user.id }
-}
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+ensureWindowShim()
 
 async function fetchSongRow(env, { song_id, slug }) {
   const filter = song_id
-    ? `id=eq.${encodeURIComponent(song_id)}`
-    : `slug=eq.${encodeURIComponent(slug)}`
-  const select = 'id,slug,title,artist,default_key,chordpro_content'
-  const resp = await fetch(
-    `${env.SUPABASE_URL}/rest/v1/songs?select=${select}&${filter}&is_deleted=eq.false&limit=1`,
-    {
-      headers: {
-        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
-        Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
-      },
-    },
-  )
-  if (!resp.ok) return { error: `Supabase query failed: ${resp.status}`, status: 502 }
-  const rows = await resp.json().catch(() => null)
-  if (!Array.isArray(rows) || rows.length === 0) return { error: 'Song not found', status: 404 }
-  return { song: rows[0] }
+    ? `id=eq.${encodeURIComponent(song_id)}&limit=1`
+    : `slug=eq.${encodeURIComponent(slug)}&limit=1`
+  const found = await fetchSongsByFilter(env, filter)
+  if (found.error) return found
+  if (found.rows.length === 0) return { error: 'Song not found', status: 404 }
+  return { song: found.rows[0] }
 }
 
 export async function onRequest(context) {
   const { request, env } = context
 
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        'Access-Control-Allow-Origin': new URL(request.url).origin,
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Authorization, Content-Type',
-      },
-    })
-  }
+  if (request.method === 'OPTIONS') return corsPreflight(request)
 
   if (request.method !== 'POST') {
     return jsonError('Method not allowed', 405)

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@supabase/supabase-js": "^2.98.0",
         "expo": "~55.0.27",
+        "expo-clipboard": "~55.0.14",
         "expo-constants": "~55.0.16",
         "expo-file-system": "~55.0.23",
         "expo-haptics": "~55.0.15",
@@ -33,14 +34,149 @@
         "expo-symbols": "~55.0.9",
         "react": "19.2.0",
         "react-native": "0.83.6",
+        "react-native-gesture-handler": "~2.30.0",
+        "react-native-reanimated": "^4.2.1",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
-        "react-native-url-polyfill": "^2.0.0"
+        "react-native-url-polyfill": "^2.0.0",
+        "react-native-worklets": "^0.7.4"
       },
       "devDependencies": {
         "@types/react": "~19.2.0",
         "babel-preset-expo": "~55.0.23",
         "typescript": "~5.9.2"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+      "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-classes": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
+      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/traverse": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "apps/mobile/node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "apps/mobile/node_modules/@expo/devtools": {
@@ -510,6 +646,17 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "apps/mobile/node_modules/expo-clipboard": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-55.0.14.tgz",
+      "integrity": "sha512-PU0jIOV31nH1gr7yXWTP3PxAaTRraFYAglTGc+LAD54Kxtq/F6NDeNdrND6djqjsePXjnAaIV378b/O2LPTOXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "apps/mobile/node_modules/expo-constants": {
@@ -1361,6 +1508,21 @@
         }
       }
     },
+    "apps/mobile/node_modules/react-native-gesture-handler": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.1.tgz",
+      "integrity": "sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "apps/mobile/node_modules/react-native-is-edge-to-edge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
@@ -1369,6 +1531,43 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/react-native-reanimated": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.2.1.tgz",
+      "integrity": "sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "1.2.1",
+        "semver": "7.7.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": ">=0.7.0"
+      }
+    },
+    "apps/mobile/node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
+      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "apps/mobile/node_modules/react-native-safe-area-context": {
@@ -1405,6 +1604,42 @@
       },
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/react-native-worklets": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.7.4.tgz",
+      "integrity": "sha512-NYOdM1MwBb3n+AtMqy1tFy3Mn8DliQtd8sbzAVRf9Gc+uvQ0zRfxN7dS8ZzoyX7t6cyQL5THuGhlnX+iFlQTag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "7.27.1",
+        "@babel/plugin-transform-class-properties": "7.27.1",
+        "@babel/plugin-transform-classes": "7.28.4",
+        "@babel/plugin-transform-nullish-coalescing-operator": "7.27.1",
+        "@babel/plugin-transform-optional-chaining": "7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "7.27.1",
+        "@babel/plugin-transform-template-literals": "7.27.1",
+        "@babel/plugin-transform-unicode-regex": "7.27.1",
+        "@babel/preset-typescript": "7.27.1",
+        "convert-source-map": "2.0.0",
+        "semver": "7.7.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "apps/mobile/node_modules/react-native/node_modules/@react-native/virtualized-lists": {
@@ -2919,6 +3154,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
@@ -2966,25 +3216,6 @@
         "@babel/plugin-transform-react-jsx": "^7.29.7",
         "@babel/plugin-transform-react-jsx-development": "^7.29.7",
         "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
-      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
-        "@babel/plugin-syntax-jsx": "^7.29.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
-        "@babel/plugin-transform-typescript": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3514,6 +3745,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -8505,6 +8748,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -11780,6 +12029,21 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",

--- a/packages/core/src/chordpro/index.js
+++ b/packages/core/src/chordpro/index.js
@@ -21,6 +21,9 @@ export function parseChordPro(text){
 export function extractChords(line){ let plain=''; const chords=[]; let i=0; while(i<line.length){ if(line[i]==='['){ const j=line.indexOf(']', i+1); if(j!==-1){ const sym=line.slice(i+1,j).trim(); chords.push({ sym, index: plain.length }); i=j+1; continue } } plain+=line[i]; i++ } return { plain, chords } }
 export function makeMonospaceChordLine(plain, chordPositions){ if(!chordPositions?.length) return ''; let out=''; let cursor=0; for(const c of chordPositions){ const pad=Math.max(0, c.index - cursor); out += ' '.repeat(pad) + c.sym; cursor = c.index + c.sym.length } return out }
 export const KEYS=['C','C#','D','D#','E','F','F#','G','G#','A','A#','B']; const FLAT={'Db':'C#','Eb':'D#','Gb':'F#','Ab':'G#','Bb':'A#'}; function norm(n){ return FLAT[n] || n }
+// Normalize a key name to its sharp spelling in KEYS ('Bb' -> 'A#'); unknown
+// input passes through. Shared so key comparisons agree across modules.
+export function normKey(k){ return norm(k) }
 
 // Extract normalized root (sharp-preference) from a key/chord string.
 // Examples: 'Em' -> 'E', 'C#m' -> 'C#', 'Bb' -> 'A#'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,8 +22,10 @@ export * from './songs/songMetadata'
 export * from './songs/sort'
 export * from './songs/songsRepo'
 
-// Setlist codec
+// Setlist codec + queries + summary math
 export * from './setlists/setcode'
+export * from './setlists/setlistsRepo'
+export * from './setlists/setlistSummary'
 
 // Role hierarchy
 export * from './rbac/roles'

--- a/packages/core/src/setlists/setlistSummary.js
+++ b/packages/core/src/setlists/setlistSummary.js
@@ -1,0 +1,94 @@
+// Pure setlist summary math shared by the mobile builder footer and Home's
+// "Last set" card. No song duration exists in the schema, so total time is an
+// estimate at a flat minutes-per-song rate (the design demo's default), and
+// callers should render it with a tilde ("~25 min").
+
+import { KEYS } from '../chordpro'
+
+/** Flat minutes-per-song used for the estimated set duration. */
+export const EST_MINUTES_PER_SONG = 5
+
+const FLATS = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' }
+
+function keyIndex(k) {
+  if (!k) return -1
+  const i = KEYS.indexOf(k)
+  if (i >= 0) return i
+  return KEYS.indexOf(FLATS[k] ?? '')
+}
+
+/**
+ * The key an entry is actually played in: its setlist-scoped override when
+ * set, otherwise the song's native key.
+ *
+ * @param {{ toKey?: string|null }} entry
+ * @param {{ default_key?: string|null }|null|undefined} song
+ * @returns {string|null}
+ */
+export function effectiveKey(entry, song) {
+  return (entry && entry.toKey) || (song && song.default_key) || null
+}
+
+/**
+ * Summarize a set's entries: count, estimated minutes, key range and BPM
+ * range. Entries carry `{ toKey, default_key, tempo }` (already joined —
+ * see fetchLastSetSummary), or pass `songsById` to resolve default_key/tempo
+ * from `{ toKey, song_id }` entries.
+ *
+ * @param {Array<{ toKey?: string|null, song_id?: string, default_key?: string|null, tempo?: number|null }>} entries
+ * @param {Map<string, { default_key?: string|null, tempo?: number|null }>} [songsById]
+ * @returns {{ songCount: number, durationMin: number, keyRange: string|null, bpmRange: string|null }}
+ */
+export function summarizeSet(entries, songsById) {
+  const list = entries || []
+  const keys = []
+  const bpms = []
+  for (const entry of list) {
+    const song = songsById ? songsById.get(String(entry.song_id)) : entry
+    const key = effectiveKey(entry, song)
+    const idx = keyIndex(key)
+    if (idx >= 0) keys.push(idx)
+    const tempo = song && song.tempo
+    if (typeof tempo === 'number' && tempo > 0) bpms.push(tempo)
+  }
+
+  let keyRange = null
+  if (keys.length > 0) {
+    const lo = KEYS[Math.min(...keys)]
+    const hi = KEYS[Math.max(...keys)]
+    keyRange = lo === hi ? `Key ${lo}` : `Keys ${lo}–${hi}`
+  }
+
+  let bpmRange = null
+  if (bpms.length > 0) {
+    const lo = Math.min(...bpms)
+    const hi = Math.max(...bpms)
+    bpmRange = lo === hi ? `${lo} BPM` : `${lo}–${hi} BPM`
+  }
+
+  return {
+    songCount: list.length,
+    durationMin: list.length * EST_MINUTES_PER_SONG,
+    keyRange,
+    bpmRange,
+  }
+}
+
+/**
+ * Render a summary as the footer line, omitting empty segments:
+ * "5 songs · ~25 min · Keys G–D · 72–128 BPM".
+ *
+ * @param {{ songCount: number, durationMin: number, keyRange: string|null, bpmRange: string|null }} summary
+ * @returns {string}
+ */
+export function formatSetSummary(summary) {
+  const n = summary.songCount
+  return [
+    `${n} ${n === 1 ? 'song' : 'songs'}`,
+    n > 0 ? `~${summary.durationMin} min` : null,
+    summary.keyRange,
+    summary.bpmRange,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}

--- a/packages/core/src/setlists/setlistSummary.js
+++ b/packages/core/src/setlists/setlistSummary.js
@@ -3,18 +3,14 @@
 // estimate at a flat minutes-per-song rate (the design demo's default), and
 // callers should render it with a tilde ("~25 min").
 
-import { KEYS } from '../chordpro'
+import { KEYS, normKey } from '../chordpro'
 
 /** Flat minutes-per-song used for the estimated set duration. */
 export const EST_MINUTES_PER_SONG = 5
 
-const FLATS = { Db: 'C#', Eb: 'D#', Gb: 'F#', Ab: 'G#', Bb: 'A#' }
-
 function keyIndex(k) {
   if (!k) return -1
-  const i = KEYS.indexOf(k)
-  if (i >= 0) return i
-  return KEYS.indexOf(FLATS[k] ?? '')
+  return KEYS.indexOf(normKey(k))
 }
 
 /**
@@ -37,7 +33,7 @@ export function effectiveKey(entry, song) {
  *
  * @param {Array<{ toKey?: string|null, song_id?: string, default_key?: string|null, tempo?: number|null }>} entries
  * @param {Map<string, { default_key?: string|null, tempo?: number|null }>} [songsById]
- * @returns {{ songCount: number, durationMin: number, keyRange: string|null, bpmRange: string|null }}
+ * @returns {{ songCount: number, durationMin: number, keys: string|null, keyRange: string|null, bpmRange: string|null }}
  */
 export function summarizeSet(entries, songsById) {
   const list = entries || []
@@ -52,10 +48,14 @@ export function summarizeSet(entries, songsById) {
     if (typeof tempo === 'number' && tempo > 0) bpms.push(tempo)
   }
 
+  // `keys` is the raw range ("G–D" / "G") for badges; `keyRange` the labeled
+  // footer segment ("Keys G–D" / "Key G").
+  let keysRaw = null
   let keyRange = null
   if (keys.length > 0) {
     const lo = KEYS[Math.min(...keys)]
     const hi = KEYS[Math.max(...keys)]
+    keysRaw = lo === hi ? lo : `${lo}–${hi}`
     keyRange = lo === hi ? `Key ${lo}` : `Keys ${lo}–${hi}`
   }
 
@@ -69,6 +69,7 @@ export function summarizeSet(entries, songsById) {
   return {
     songCount: list.length,
     durationMin: list.length * EST_MINUTES_PER_SONG,
+    keys: keysRaw,
     keyRange,
     bpmRange,
   }

--- a/packages/core/src/setlists/setlistsRepo.js
+++ b/packages/core/src/setlists/setlistsRepo.js
@@ -1,0 +1,162 @@
+// Platform-agnostic setlist queries (new setlists + setlist_songs schema).
+//
+// This is the canonical, client-injected counterpart to the web-side module at
+// apps/web/src/hooks/useSetlists.js — same semantics (personal sets only,
+// wipe-and-replace updates where position = array index), but callers inject
+// the Supabase client created via createGcSupabase(), like songsRepo. Errors
+// throw (songsRepo convention); callers catch. The per-entry setlist-scoped
+// key lives in setlist_songs.key_override and is exposed app-side as `toKey`.
+
+/**
+ * Fetch all personal (team_id IS NULL) setlists for the current user,
+ * sorted by updated_at DESC, with a song count via the relationship.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} client
+ * @returns {Promise<Array<{ id: string, name: string, service_date: string|null, created_at: string, updated_at: string, setlist_songs: Array<{ count: number }> }>>}
+ */
+export async function fetchPersonalSetlists(client) {
+  const { data, error } = await client
+    .from('setlists')
+    .select('id, name, service_date, created_at, updated_at, setlist_songs(count)')
+    .is('team_id', null)
+    .order('updated_at', { ascending: false })
+  if (error) throw error
+  return data || []
+}
+
+/**
+ * Fetch one setlist's metadata plus its ordered entries.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} client
+ * @param {string} setlistId
+ * @returns {Promise<{ id: string, name: string, service_date: string|null, updated_at: string, entries: Array<{ id: string, song_id: string, position: number, toKey: string|null, notes: string|null }> }|null>}
+ */
+export async function fetchSetlist(client, setlistId) {
+  const { data, error } = await client
+    .from('setlists')
+    .select('id, name, service_date, updated_at, setlist_songs(id, song_id, position, key_override, notes)')
+    .eq('id', setlistId)
+    .maybeSingle()
+  if (error) throw error
+  if (!data) return null
+  const entries = (data.setlist_songs || [])
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map((row) => ({
+      id: row.id,
+      song_id: row.song_id,
+      position: row.position,
+      toKey: row.key_override || null,
+      notes: row.notes || null,
+    }))
+  return {
+    id: data.id,
+    name: data.name,
+    service_date: data.service_date,
+    updated_at: data.updated_at,
+    entries,
+  }
+}
+
+/**
+ * Create a new personal setlist (no songs yet) owned by the current user.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} client
+ * @param {{ name?: string, serviceDate?: string|null }} [opts]
+ * @returns {Promise<{ id: string, name: string, service_date: string|null, created_at: string, updated_at: string }>}
+ */
+export async function createSetlist(client, opts = {}) {
+  const { data: userData, error: authError } = await client.auth.getUser()
+  const user = userData && userData.user
+  if (authError || !user) throw authError || new Error('Not authenticated')
+
+  const { data, error } = await client
+    .from('setlists')
+    .insert({
+      owner_id: user.id,
+      name: (opts.name || '').trim() || 'New Setlist',
+      service_date: opts.serviceDate || null,
+      team_id: null,
+      edit_mode: 'suggest',
+    })
+    .select('id, name, service_date, created_at, updated_at')
+    .single()
+  if (error) throw error
+  return data
+}
+
+/**
+ * Overwrite an existing setlist: update metadata, wipe entries, re-insert.
+ * Position is the array index, so this one write path covers reorder,
+ * remove, duplicate and key changes alike (web semantics).
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} client
+ * @param {string} setlistId
+ * @param {{ name?: string, serviceDate?: string|null, songs?: Array<{ id: string, toKey?: string|null }> }} input
+ */
+export async function updateSetlist(client, setlistId, input = {}) {
+  const { error: updateError } = await client
+    .from('setlists')
+    .update({
+      name: (input.name || '').trim() || 'Untitled Set',
+      service_date: input.serviceDate || null,
+    })
+    .eq('id', setlistId)
+  if (updateError) throw updateError
+
+  const { error: deleteError } = await client
+    .from('setlist_songs')
+    .delete()
+    .eq('setlist_id', setlistId)
+  if (deleteError) throw deleteError
+
+  const songs = input.songs || []
+  if (songs.length > 0) {
+    const rows = songs.map((song, i) => ({
+      setlist_id: setlistId,
+      song_id: song.id,
+      position: i,
+      key_override: song.toKey || null,
+      notes: null,
+    }))
+    const { error: songsError } = await client.from('setlist_songs').insert(rows)
+    if (songsError) throw songsError
+  }
+}
+
+/**
+ * Delete a setlist by id. Cascade handles setlist_songs.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} client
+ * @param {string} setlistId
+ */
+export async function deleteSetlist(client, setlistId) {
+  const { error } = await client.from('setlists').delete().eq('id', setlistId)
+  if (error) throw error
+}
+
+/**
+ * Fetch the most recently updated personal setlist with just enough entry
+ * data to summarize it (Home's "Last set" card): per-entry key override plus
+ * each song's default key. Returns null when the user has no setlists.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} client
+ * @returns {Promise<{ id: string, name: string, updated_at: string, entries: Array<{ toKey: string|null, default_key: string|null, tempo: number|null }> }|null>}
+ */
+export async function fetchLastSetSummary(client) {
+  const { data, error } = await client
+    .from('setlists')
+    .select('id, name, updated_at, setlist_songs(key_override, songs(default_key, tempo))')
+    .is('team_id', null)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (error) throw error
+  if (!data) return null
+  const entries = (data.setlist_songs || []).map((row) => ({
+    toKey: row.key_override || null,
+    default_key: (row.songs && row.songs.default_key) || null,
+    tempo: (row.songs && row.songs.tempo) ?? null,
+  }))
+  return { id: data.id, name: data.name, updated_at: data.updated_at, entries }
+}

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -44,6 +44,10 @@ export type ThemeColors = {
   border: string
   /** Text/icon color on top of the accent. */
   onAccent: string
+  /** Destructive actions (delete/remove) — text on surfaces and fills. */
+  danger: string
+  /** Text/icon color on top of the danger fill. */
+  onDanger: string
   /** Dimmed color for inactive scrubber letters. */
   off: string
   /**
@@ -67,6 +71,8 @@ export const lightColors: ThemeColors = {
   textAccent: '#15619A',
   border: '#E3E8EC',
   onAccent: '#FFFFFF',
+  danger: '#C43D38',
+  onDanger: '#FFFFFF',
   off: 'rgba(138,146,155,0.45)',
   heroGradient: {
     colors: ['#BFD3E3', '#CFE0EA', '#E3EDF2', '#F5F7F9'],
@@ -87,6 +93,8 @@ export const darkColors: ThemeColors = {
   textAccent: '#6FB6EA',
   border: '#2A3036',
   onAccent: '#14171A',
+  danger: '#F0736A',
+  onDanger: '#14171A',
   off: 'rgba(124,133,142,0.5)',
   heroGradient: {
     colors: ['#1C2A36', '#18222A', '#15191D', '#14171A'],


### PR DESCRIPTION
## Summary

Ships the full setlist experience in `apps/mobile` (Expo SDK 55 / Expo Router v7), plus a new whole-set PDF export endpoint. Three stages on this branch:

### 1. Setlist Builder (build mode)
- **Setlists tab** — lists the user's personal setlists (Supabase), create/open.
- **Builder** — hero card with inline rename, a numbered drag-to-reorder timeline (hand-rolled `Gesture.Pan` + Reanimated, since `react-native-draggable-flatlist` isn't maintained against Reanimated v4 / New Arch), swipe-to-remove (`ReanimatedSwipeable`), per-entry key chip, and a summary footer (count · estimated minutes · key range · BPM range).
- **Sheets** — key picker, row actions (change key / duplicate / remove), set options (rename / saved sets / new / delete), add-songs search modal, and a share sheet (Telegram + Copy link live).
- Wires directly to `setlist_songs.key_override` (no schema change needed) via a new client-injected core repo `packages/core/src/setlists/setlistsRepo.js`; persistence is debounced, serialized, wipe-and-replace autosave.
- **Home** "Last set" card now reads real data (`useLastSet`); `getRecentlyOpened()` stays stubbed.

### 2. Setlist Viewer / Performer Mode
- Launched by the Builder's now-enabled **Start set** button. Runs the set one song at a time, reusing the Song Viewer's `ChordChart`, `TransposeBar`, and `ViewOptionsSheet` (transpose is session-ephemeral, seeded from each entry's `key_override`).
- Navigation: **Prev/Next**, **horizontal swipe** (~50px threshold), and a **tappable progress rail**, all sliding between songs.
- Share sheet with a **This song / Whole set** scope toggle — this-song reuses the working single-song export (PDF/JPG/system share/Telegram); whole-set offers the new combined-PDF endpoint, Copy link, and Telegram.

### 3. Chrome auto-hide (shared)
- Opt-in **"Hide controls when idle"** toggle in the shared `ViewOptionsSheet`, used by both the Song Viewer and the Performer. After ~6.5s idle the header + floating controls (and the performer's Prev/Next + rail) fade out for a full-page view; tap/transpose/song-change reveals them. Off by default, **persisted** across launches via AsyncStorage.

### New backend endpoint
- `apps/web/functions/api/export/setlist.js` — Supabase-authed, `{ items: [{ song_id, key? }] }` (max 25), renders the ordered set to one combined PDF via the DOM-free `renderMultiSongPdfBuffer` already used by `export/song.js` and the Telegram bot. Auth/JSON/CORS/song-fetch helpers were factored into `functions/api/export/_shared.js` and shared with `song.js`.

## Reuse
`ChordChart`, `TransposeBar`, `ViewOptionsSheet`, `BottomSheet`, `ListRow`, `SymbolIcon`, theme tokens; `useSetlistBuilder`, `useSong`/`fetchSongBySlug`, `exportSong`/`api`/`telegramPush`; core `stepsBetween`/`transposeSymPrefer`/`effectiveKey`/`normKey`/`renderMultiSongPdfBuffer`/`toRenderableSong`.

## Verification
- `npm run typecheck` (apps/mobile) — clean.
- `npm run export:ios` (apps/mobile) — bundles clean. *Run headless (Linux), so this is a Metro bundle-check, not a simulator run.*
- `npm test --workspace=apps/web` — 160/160 pass (covers the shared pure PDF engine touched by the new endpoint).
- A high-effort code review ran per stage; findings were applied (slug-based share links, `entryKey`-keyed mutations, Telegram 25-item chunking, stale-song guard in the performer, shared export helper, etc.).

## Known limitations (intentional, deferred)
- Whole-set **Charts ZIP / ChordPro / Set list** render disabled ("coming soon") — no backend exists yet.
- Chrome auto-hide fades the header **in place** (keeps its layout slot); it doesn't yet reclaim the header strip edge-to-edge.
- No hardware iOS simulator run in CI — device QA still recommended for gestures/sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPsdsXeZYTwdXGzo2VcNkB)_