### PR TITLE
feat(viewer): 2-state sharp/flat accidental toggle; add to key sheet;…

### DIFF
--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ActivityIndicator, Alert, Animated, Linking, Pressable, ScrollView, Text, View } from 'react-native'
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
@@ -26,6 +26,7 @@ import SymbolIcon from '../../src/components/SymbolIcon'
 import TransposeBar from '../../src/components/TransposeBar'
 import ViewOptionsSheet, {
   type Accidental,
+  defaultAccidental,
   resolvePreferFlat,
 } from '../../src/components/ViewOptionsSheet'
 import { exportSong } from '../../src/lib/exportSong'
@@ -77,7 +78,13 @@ export default function ViewerScreen() {
   const [showSections, setShowSections] = useState(true)
   const [fontScale, setFontScale] = useState(1)
   const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
-  const [accidental, setAccidental] = useState<Accidental>('auto')
+  const [accidental, setAccidental] = useState<Accidental>('sharp')
+  // Seed the accidental from the key until the user flips it themselves.
+  const accidentalTouched = useRef(false)
+  const setAccidentalManual = (v: Accidental) => {
+    accidentalTouched.current = true
+    setAccidental(v)
+  }
   const [sheet, setSheet] = useState<null | 'options' | 'export'>(null)
   // Header is a floating overlay so the chart runs edge-to-edge; its measured
   // height seeds the chart's top inset, so the first line starts where the
@@ -87,8 +94,12 @@ export default function ViewerScreen() {
   const nativeKey = doc?.meta?.key || song?.default_key || songKey || ''
   const seedSteps = initialKey ? stepsBetween(nativeKey, initialKey) : 0
   const steps = (((seedSteps + delta) % 12) + 12) % 12
-  const preferFlat = resolvePreferFlat(accidental, nativeKey)
+  const preferFlat = resolvePreferFlat(accidental)
   const effectiveKey = steps ? transposeSymPrefer(nativeKey, steps, preferFlat) : nativeKey
+
+  useEffect(() => {
+    if (!accidentalTouched.current) setAccidental(defaultAccidental(nativeKey))
+  }, [nativeKey])
 
   // Chrome auto-hide (persisted preference). Pinned visible while a sheet is
   // open so it can't hide behind one. Tap the chart to bring it back.
@@ -344,7 +355,7 @@ export default function ViewerScreen() {
         chordStyle={chordStyle}
         onChordStyle={setChordStyle}
         accidental={accidental}
-        onAccidental={setAccidental}
+        onAccidental={setAccidentalManual}
         autoHide={autoHide}
         onAutoHide={setAutoHide}
       />

--- a/apps/mobile/src/components/AccidentalToggle.tsx
+++ b/apps/mobile/src/components/AccidentalToggle.tsx
@@ -1,0 +1,62 @@
+import { Pressable, Text, View } from 'react-native'
+import { useTheme } from '../theme/ThemeProvider'
+
+// Accidental spelling: a concrete ♯ or ♭ (no "auto" state — the default is
+// resolved from the key up-front, then the user can flip it). Session-scoped.
+export type Accidental = 'sharp' | 'flat'
+
+// Default spelling for a key: ♭ if the key is already spelled with a flat
+// (e.g. Bb, Eb), otherwise ♯. Callers seed the toggle with this and let the
+// user override.
+export function defaultAccidental(key: string | null | undefined): Accidental {
+  return key && key.includes('b') ? 'flat' : 'sharp'
+}
+
+// The boolean the chart/transpose helpers expect.
+export function resolvePreferFlat(accidental: Accidental): boolean {
+  return accidental === 'flat'
+}
+
+// Compact two-cell ♯/♭ control that sits inline (e.g. right-justified next to
+// "Play … in"). Glyph-forward with a tiny label; the selected side fills accent.
+export default function AccidentalToggle({
+  value,
+  onChange,
+}: {
+  value: Accidental
+  onChange: (v: Accidental) => void
+}) {
+  const t = useTheme()
+
+  const cell = (v: Accidental, glyph: string, label: string) => {
+    const selected = value === v
+    return (
+      <Pressable
+        onPress={() => onChange(v)}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityState={{ selected }}
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 3,
+          height: 30,
+          paddingHorizontal: 12,
+          borderRadius: 8,
+          backgroundColor: selected ? t.colors.accent : 'transparent',
+        }}
+      >
+        <Text style={{ fontSize: 15, fontWeight: '700', color: selected ? t.colors.onAccent : t.colors.sec }}>
+          {glyph}
+        </Text>
+      </Pressable>
+    )
+  }
+
+  return (
+    <View style={{ flexDirection: 'row', backgroundColor: t.colors.surfaceAlt, borderRadius: 10, padding: 3 }}>
+      {cell('sharp', '♯', 'Sharps')}
+      {cell('flat', '♭', 'Flats')}
+    </View>
+  )
+}

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -1,20 +1,12 @@
 import { Pressable, Switch, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import BottomSheet from './BottomSheet'
+import AccidentalToggle, { type Accidental } from './AccidentalToggle'
 import type { ChordStyle } from './ChordChart'
 import { useTheme } from '../theme/ThemeProvider'
 
-// Accidental spelling preference: Auto derives from the key; ♯/♭ force it.
-export type Accidental = 'auto' | 'sharp' | 'flat'
-
-// Resolve the boolean `preferFlat` the chart/transpose helpers expect from the
-// user's accidental choice; Auto keeps the prior behavior (flat if the key is
-// spelled with a flat, e.g. Bb/Eb).
-export function resolvePreferFlat(accidental: Accidental, nativeKey: string): boolean {
-  if (accidental === 'flat') return true
-  if (accidental === 'sharp') return false
-  return /^[A-G]b/.test(nativeKey)
-}
+// Re-export so existing screen imports (`from './ViewOptionsSheet'`) keep working.
+export { type Accidental, defaultAccidental, resolvePreferFlat } from './AccidentalToggle'
 
 // The viewer's "View options" bottom sheet (••• button). Everything is
 // controlled/ephemeral — the screen owns the state, nothing persists.
@@ -245,20 +237,15 @@ export default function ViewOptionsSheet({
           onChange={onChordStyle}
         />
 
-        {/* Accidentals — Auto derives from the key; ♯/♭ force the spelling
-            (session-scoped). Rendered only when the screen wires it. */}
-        {onAccidental ? (
+        {/* Accidentals — ♯/♭ spelling (session-scoped). Rendered only when the
+            screen wires it. */}
+        {onAccidental && accidental ? (
           <>
             <OverlineLabel>Accidentals</OverlineLabel>
-            <Segmented
-              options={[
-                { value: 'auto', label: 'Auto' },
-                { value: 'sharp', label: '♯ Sharps' },
-                { value: 'flat', label: '♭ Flats' },
-              ]}
-              value={accidental ?? 'auto'}
-              onChange={onAccidental}
-            />
+            <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Text style={{ fontSize: 16, color: t.colors.ink }}>Spelling</Text>
+              <AccidentalToggle value={accidental} onChange={onAccidental} />
+            </View>
           </>
         ) : null}
 

--- a/apps/mobile/src/components/setlist/KeyPickerSheet.tsx
+++ b/apps/mobile/src/components/setlist/KeyPickerSheet.tsx
@@ -1,13 +1,20 @@
+import { useEffect, useState } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { KEYS, normKey } from '@gracechords/core'
 import BottomSheet from '../BottomSheet'
+import AccidentalToggle, { type Accidental, defaultAccidental } from '../AccidentalToggle'
 import { useTheme } from '../../theme/ThemeProvider'
 
-// "Play this song in…" — a 4-column grid of the 12 keys, current highlighted
-// (flat spellings like "Bb" normalize to their sharp cell). Picking a key sets
-// the entry's setlist-scoped override and closes; "Use native key" clears the
-// override so the entry follows the song's default key again.
+// Flat spellings aligned to KEYS index (C, C#/Db, D, …). Used to relabel the
+// grid when the ♯/♭ toggle is set to flats.
+const FLAT_KEYS = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B']
+
+// "Play this song in…" — a 4-column grid of the 12 keys with a ♯/♭ toggle
+// (inline, right of the prompt) that relabels the grid between sharp and flat
+// spellings; the picked spelling is what's stored as the override. The current
+// key is highlighted by enharmonic equivalence. "Reset to {key}" clears the
+// override so the entry follows the song's own key again.
 export default function KeyPickerSheet({
   visible,
   onClose,
@@ -29,29 +36,44 @@ export default function KeyPickerSheet({
 }) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
-  const keys = KEYS as readonly string[]
   const current = currentKey ? (normKey(currentKey) as string) : null
+
+  // Default the spelling from the current/native key; re-seed each open.
+  const [accidental, setAccidental] = useState<Accidental>(() =>
+    defaultAccidental(currentKey ?? nativeKey),
+  )
+  useEffect(() => {
+    if (visible) setAccidental(defaultAccidental(currentKey ?? nativeKey))
+  }, [visible, currentKey, nativeKey])
+
+  const labels = accidental === 'flat' ? FLAT_KEYS : (KEYS as readonly string[])
 
   return (
     <BottomSheet visible={visible} onClose={onClose} title="Key" closeAccessibilityLabel="Close key picker">
       <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.md }}>
-        {songTitle ? (
-          <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
-            Play {songTitle} in…
-          </Text>
-        ) : null}
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          {songTitle ? (
+            <Text style={{ flexShrink: 1, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
+              Play {songTitle} in…
+            </Text>
+          ) : (
+            <View />
+          )}
+          <AccidentalToggle value={accidental} onChange={setAccidental} />
+        </View>
         <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: t.spacing.sm }}>
-          {keys.map((key) => {
-            const selected = key === current
+          {(KEYS as readonly string[]).map((sharpKey, i) => {
+            const label = labels[i]
+            const selected = sharpKey === current
             return (
               <Pressable
-                key={key}
+                key={sharpKey}
                 onPress={() => {
-                  onPick(key)
+                  onPick(label)
                   onClose()
                 }}
                 accessibilityRole="button"
-                accessibilityLabel={`Key of ${key}`}
+                accessibilityLabel={`Key of ${label}`}
                 accessibilityState={{ selected }}
                 style={{
                   // 4 columns with the wrap gap accounted for.
@@ -73,7 +95,7 @@ export default function KeyPickerSheet({
                     color: selected ? t.colors.onAccent : t.colors.ink,
                   }}
                 >
-                  {key}
+                  {label}
                 </Text>
               </Pressable>
             )
@@ -86,7 +108,7 @@ export default function KeyPickerSheet({
               onClose()
             }}
             accessibilityRole="button"
-            accessibilityLabel="Use the song's native key"
+            accessibilityLabel={nativeKey ? `Reset to ${nativeKey}` : 'Reset to the original key'}
             style={({ pressed }) => ({
               height: 44,
               borderRadius: t.radii.sm,
@@ -98,7 +120,7 @@ export default function KeyPickerSheet({
             })}
           >
             <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.textAccent }}>
-              Use native key{nativeKey ? ` (${nativeKey})` : ''}
+              Reset to {nativeKey || 'original key'}
             </Text>
           </Pressable>
         ) : null}

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
@@ -35,6 +35,7 @@ import SymbolIcon from '../components/SymbolIcon'
 import TransposeBar from '../components/TransposeBar'
 import ViewOptionsSheet, {
   type Accidental,
+  defaultAccidental,
   resolvePreferFlat,
 } from '../components/ViewOptionsSheet'
 import PerformerShareSheet, {
@@ -107,7 +108,13 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   const [showSections, setShowSections] = useState(true)
   const [fontScale, setFontScale] = useState(1)
   const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
-  const [accidental, setAccidental] = useState<Accidental>('auto')
+  const [accidental, setAccidental] = useState<Accidental>('sharp')
+  // Seed from each song's key until the user flips it.
+  const accidentalTouched = useRef(false)
+  const setAccidentalManual = (v: Accidental) => {
+    accidentalTouched.current = true
+    setAccidental(v)
+  }
   const [sheet, setSheet] = useState<null | 'options' | 'share'>(null)
   // Floating-overlay header height → chart top inset (edge-to-edge).
   const [headerH, setHeaderH] = useState(0)
@@ -116,8 +123,12 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   const targetKey = entryKeys[index] || nativeKey
   const seedSteps = targetKey ? stepsBetween(nativeKey, targetKey) : 0
   const steps = (((seedSteps + delta) % 12) + 12) % 12
-  const preferFlat = resolvePreferFlat(accidental, nativeKey)
+  const preferFlat = resolvePreferFlat(accidental)
   const effectiveKey = steps ? transposeSymPrefer(nativeKey, steps, preferFlat) : nativeKey
+
+  useEffect(() => {
+    if (!accidentalTouched.current) setAccidental(defaultAccidental(nativeKey))
+  }, [nativeKey])
 
   // Chrome auto-hide (persisted). Pinned visible while a sheet is open; tap the
   // chart, change songs, or use the transpose bar to bring it back.
@@ -551,7 +562,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         chordStyle={chordStyle}
         onChordStyle={setChordStyle}
         accidental={accidental}
-        onAccidental={setAccidental}
+        onAccidental={setAccidentalManual}
         autoHide={autoHide}
         onAutoHide={setAutoHide}
       />


### PR DESCRIPTION
… reword reset

- Replace the 3-segment Auto/♯/♭ control with a compact 2-state ♯/♭ toggle (AccidentalToggle). No visible Auto: the spelling defaults from the key (♭ if the key is spelled with a flat, else ♯) and the user can flip it; it stays put once touched.
- Key picker (builder) gains the toggle inline-right of "Play … in" and relabels the grid between sharp and flat spellings — the picked spelling is what's stored as the override.
- Reset row reworded "Use native key (X)" → "Reset to X".
- Viewer/Performer seed the toggle from each song's key (per song until the user overrides) and feed resolvePreferFlat into the chart + key label.


Claude-Session: https://claude.ai/code/session_01FPsdsXeZYTwdXGzo2VcNkB