### PR TITLE
fix(mobile): stable reader fade, day-cached passages, prefetch on open

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context'
 import type { Session } from '@supabase/supabase-js'
 import { ThemeProvider } from '../src/theme/ThemeProvider'
 import { registerAuthAutoRefresh, supabase } from '../src/lib/supabase'
+import { prefetchToday } from '../src/lib/bibleSource'
 
 // Keep the native splash up past first render so we can resolve the persisted
 // session and route to the right screen before anything is shown — the app is
@@ -68,6 +69,13 @@ export default function RootLayout() {
     })
     return () => sub.subscription.unsubscribe()
   }, [])
+
+  // Warm today's Daily Word passages on open so the reader is instant even if
+  // it isn't visited. Best-effort; clears + repulls on the first open of a new
+  // day. Other dates load on demand via the date picker.
+  useEffect(() => {
+    if (session) prefetchToday()
+  }, [session])
 
   useProtectedRoute(session, ready)
 

--- a/apps/mobile/src/lib/bibleSource.ts
+++ b/apps/mobile/src/lib/bibleSource.ts
@@ -3,6 +3,8 @@ import {
   fetchBibleTranslations,
   getPlanForDate,
   expandReadings,
+  mmddFromDate,
+  resolveBibleTranslationSelection,
   type BibleTranslation,
   type ChapterData,
   type Passage,
@@ -12,7 +14,7 @@ import {
 // Source seam for Daily Word passage content. Today it reads from the
 // Cloudflare R2 bucket that also serves the web app's Bible JSON; the accessor
 // is shaped so a LOCAL OFFLINE-DOWNLOAD source can slot in behind it later
-// without any caller changes (see the stubbed branch in getPassage).
+// without any caller changes (see the stubbed branch in fetchChapter).
 //
 // R2 layout (confirmed against apps/web + apps/web/scripts/bible-xml-to-json.mjs):
 //   <base>/bible/translations.json                       — manifest
@@ -33,31 +35,100 @@ export function r2Base(): string {
 export { getPlanForDate, expandReadings }
 export type { BibleTranslation, ChapterData, Passage }
 
-/** Load and normalize the translation manifest from the active source. */
+// ── Translation manifest (memoized for the app's lifetime) ──────────────────
+let translationsPromise: Promise<TranslationsResult> | null = null
+
+/** Load and normalize the translation manifest from the active source (once). */
 export function getTranslations(): Promise<TranslationsResult> {
-  return fetchBibleTranslations(r2Base())
+  if (!translationsPromise) translationsPromise = fetchBibleTranslations(r2Base())
+  return translationsPromise
+}
+
+// ── Chapter cache ───────────────────────────────────────────────────────────
+// Chapters are cached in memory keyed by translation+book+chapter. Bible text
+// is immutable, so within a day the reader never re-fetches. The cache is
+// scoped to a calendar day: the first open on a new day clears it (see
+// prefetchToday), so "today's" reading is naturally repulled.
+const chapterCache = new Map<string, ChapterData>()
+const inFlight = new Map<string, Promise<ChapterData>>()
+let cacheDay = ''
+
+function chapterKey(translationId: string, bookNumber: number, chapter: number) {
+  return `${translationId}:${bookNumber}:${chapter}`
+}
+
+/** Synchronous cache read — lets the reader render prefetched chapters with no spinner. */
+export function getCachedPassage(
+  translationId: string,
+  bookNumber: number,
+  chapter: number
+): ChapterData | undefined {
+  return chapterCache.get(chapterKey(translationId, bookNumber, chapter))
 }
 
 export type PassageQuery = {
   passage: Passage
   translation: BibleTranslation
-  signal?: AbortSignal
 }
 
 /**
- * Fetch the chapter backing a passage. The single seam every reader path goes
- * through: swap the body for a local-file read to add offline support later.
+ * Fetch the chapter backing a passage. Cache-first, with in-flight de-duping so
+ * a prefetch and the reader can't double-fetch the same chapter. This is the
+ * single seam every reader path goes through: swap the body for a local-file
+ * read to add offline support later.
  */
-export function getPassage({ passage, translation, signal }: PassageQuery): Promise<ChapterData> {
+export function getPassage({ passage, translation }: PassageQuery): Promise<ChapterData> {
+  const key = chapterKey(translation.id, passage.bookNumber, passage.chapter)
+  const cached = chapterCache.get(key)
+  if (cached) return Promise.resolve(cached)
+  const existing = inFlight.get(key)
+  if (existing) return existing
+
   // offline: a downloaded-translation source will branch here first, e.g.
   //   if (await hasLocalCopy(translation.id, passage.bookNumber, passage.chapter))
   //     return readLocalChapter(...)
   // Download + file management ships in a later stage; for now always fetch R2.
-  return fetchBibleChapter({
+  const request = fetchBibleChapter({
     baseUrl: r2Base(),
     dataRoot: translation.dataRoot,
     bookNumber: passage.bookNumber,
     chapter: passage.chapter,
-    signal,
   })
+    .then((data) => {
+      chapterCache.set(key, data)
+      inFlight.delete(key)
+      return data
+    })
+    .catch((err) => {
+      inFlight.delete(key)
+      throw err
+    })
+  inFlight.set(key, request)
+  return request
+}
+
+/**
+ * Warm the cache with today's passages so the reader opens instantly even if it
+ * hasn't been visited. Called once on app open. On the first open of a new
+ * calendar day it clears the previous day's cache and repulls. Best-effort:
+ * failures are swallowed and the reader falls back to on-demand fetching.
+ */
+export async function prefetchToday(): Promise<void> {
+  const today = new Date()
+  const day = mmddFromDate(today)
+  if (day !== cacheDay) {
+    cacheDay = day
+    chapterCache.clear()
+    inFlight.clear()
+  }
+  try {
+    const { translations, defaultTranslationId } = await getTranslations()
+    const id = resolveBibleTranslationSelection('', translations, defaultTranslationId)
+    const translation = translations.find((x) => x.id === id) || translations[0]
+    if (!translation) return
+    const passages = expandReadings(getPlanForDate(today).readings)
+    await Promise.all(passages.map((passage) => getPassage({ passage, translation }).catch(() => {})))
+  } catch {
+    // best-effort warm-up
+  }
 }

--- a/apps/mobile/src/lib/useBibleTranslations.ts
+++ b/apps/mobile/src/lib/useBibleTranslations.ts
@@ -20,13 +20,6 @@ type State = {
   loading: boolean
 }
 
-// Process-lifetime cache — the manifest is static within a session.
-let cached: Promise<{ translations: BibleTranslation[]; defaultTranslationId: string }> | null = null
-function loadOnce() {
-  if (!cached) cached = getTranslations()
-  return cached
-}
-
 export function useBibleTranslations(): State {
   const fallback = getFallbackBibleTranslations()
   const [state, setState] = useState<State>({
@@ -38,7 +31,9 @@ export function useBibleTranslations(): State {
 
   useEffect(() => {
     let alive = true
-    loadOnce().then((result) => {
+    // getTranslations is memoized in bibleSource, so this shares the manifest
+    // fetch with the app-open prefetch.
+    getTranslations().then((result) => {
       if (!alive) return
       setState({
         translations: result.translations,

--- a/apps/mobile/src/lib/useReader.ts
+++ b/apps/mobile/src/lib/useReader.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { getPassage, type BibleTranslation, type ChapterData, type Passage } from './bibleSource'
+import { getCachedPassage, getPassage, type BibleTranslation, type ChapterData, type Passage } from './bibleSource'
 import { errMessage } from './errors'
 
 // Session-ephemeral reader typography preferences. Per the Daily Word spec these
@@ -65,17 +65,27 @@ export function usePassageChapter(
       setState({ chapter: null, loading: false, error: null })
       return
     }
-    const controller = new AbortController()
+    // Prefetched / previously-read chapters render immediately, no spinner.
+    const cached = getCachedPassage(translation.id, passage.bookNumber, passage.chapter)
+    if (cached) {
+      setState({ chapter: cached, loading: false, error: null })
+      return
+    }
+
+    let alive = true
     setState({ chapter: null, loading: true, error: null })
 
-    getPassage({ passage, translation, signal: controller.signal })
-      .then((chapter) => setState({ chapter, loading: false, error: null }))
+    getPassage({ passage, translation })
+      .then((chapter) => {
+        if (alive) setState({ chapter, loading: false, error: null })
+      })
       .catch((err: unknown) => {
-        if (err instanceof Error && err.name === 'AbortError') return
-        setState({ chapter: null, loading: false, error: errMessage(err) })
+        if (alive) setState({ chapter: null, loading: false, error: errMessage(err) })
       })
 
-    return () => controller.abort()
+    return () => {
+      alive = false
+    }
   }, [passage, translation, reloadToken])
 
   return state

--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -97,16 +97,21 @@ export default function DailyWordScreen() {
   useEffect(() => {
     setPassageIndex(0)
     setSelection(new Set())
-    fade.setValue(1)
-  }, [date, fade])
+  }, [date])
+
+  // Fade the reading region in whenever new chapter content arrives (chapter
+  // switch, translation switch, or first load). The Animated.View is persistent
+  // (wraps every state), so the animation never targets an unmounted node.
+  useEffect(() => {
+    if (!chapter) return
+    fade.setValue(0)
+    Animated.timing(fade, { toValue: 1, duration: 200, useNativeDriver: true }).start()
+  }, [chapter, fade])
 
   function changePassage(next: number) {
     if (next < 0 || next >= passages.length || next === passageIndex) return
-    Animated.timing(fade, { toValue: 0, duration: 130, useNativeDriver: true }).start(() => {
-      setPassageIndex(next)
-      setSelection(new Set())
-      Animated.timing(fade, { toValue: 1, duration: 130, useNativeDriver: true }).start()
-    })
+    setPassageIndex(next)
+    setSelection(new Set())
   }
 
   const pan = useRef(
@@ -259,8 +264,9 @@ export default function DailyWordScreen() {
         </ScrollView>
       </View>
 
-      {/* Reading area */}
-      <View style={{ flex: 1 }} {...pan.panHandlers}>
+      {/* Reading area — one persistent Animated.View wraps every state so the
+          fade never targets an unmounted node. */}
+      <Animated.View style={{ flex: 1, opacity: fade }} {...pan.panHandlers}>
         {loading ? (
           <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             <ActivityIndicator color={t.colors.accent} />
@@ -268,22 +274,21 @@ export default function DailyWordScreen() {
         ) : error ? (
           <EmptyState
             icon="wifi.slash"
-            title="Can't load this passage"
-            subtitle="You're offline, or this translation isn't downloaded yet. Connect to read it."
-            actionLabel="Try again"
+            title="Can't load today's reading"
+            subtitle="Connect to the internet and try again. Downloaded translations will read offline in a later update."
+            actionLabel="Retry"
             onAction={() => setReloadToken((n) => n + 1)}
           />
         ) : versesInScope.length === 0 ? (
           <EmptyState icon="book.closed" title="No reading for this day" subtitle="Pick another date to keep reading." />
         ) : (
-          <Animated.View style={{ flex: 1, opacity: fade }}>
-            <ScrollView
-              contentContainerStyle={{
-                paddingHorizontal: t.spacing.xl,
-                paddingTop: t.spacing.xs,
-                paddingBottom: t.spacing.xxl,
-              }}
-            >
+          <ScrollView
+            contentContainerStyle={{
+              paddingHorizontal: t.spacing.xl,
+              paddingTop: t.spacing.xs,
+              paddingBottom: t.spacing.xxl,
+            }}
+          >
               {settings.layout === 'prose' ? (
                 <Text style={readingBase}>
                   {versesInScope.map(({ num, text }) => {
@@ -338,8 +343,7 @@ export default function DailyWordScreen() {
                   )
                 })
               )}
-            </ScrollView>
-          </Animated.View>
+          </ScrollView>
         )}
 
         {/* Copy FAB — appears while a selection exists (no count badge). */}
@@ -368,7 +372,7 @@ export default function DailyWordScreen() {
             <SymbolIcon name="doc.on.doc" size={23} color={t.colors.onAccent} />
           </Pressable>
         ) : null}
-      </View>
+      </Animated.View>
 
       <TranslationPickerSheet
         visible={sheet === 'translations'}


### PR DESCRIPTION
- Fix the stuck-white reader after a chapter switch: the fade Animated.View wrapped only the loaded branch, so switching passages animated opacity on a node that unmounted mid-animation (native driver) and never returned to 1. Wrap every reader state in one persistent Animated.View and fade in on new chapter data instead of gating the passage change on the animation.
- Cache chapters in the source seam (keyed by translation+book+chapter, with in-flight de-duping) and render cached/prefetched chapters with no spinner, so switching between today's chapters is instant. The cache is day-scoped: the first open of a new day clears and repulls.
- Prefetch today's passages on app open (best-effort) so the reader is ready even if it isn't visited; other dates load on demand.
- Offline/error placeholder uses the shared EmptyState (matching the Songs / Setlists empties): "Can't load today's reading" + Retry.


Claude-Session: https://claude.ai/code/session_01Q4t4vg1A5R8KPRPkCf4kJQ