### PR TITLE
fix(mobile): auth hero gradient full-bleed + declare expo-build-properties dep

### DIFF
--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -8,7 +8,7 @@ import AuthScreen from '../src/screens/AuthScreen'
 
 export default function Login() {
   return (
-    <Screen>
+    <Screen edges={['bottom', 'left', 'right']}>
       <Stack.Screen options={{ headerShown: false }} />
       <AuthScreen />
     </Screen>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "@supabase/supabase-js": "^2.98.0",
     "expo": "~55.0.27",
     "expo-apple-authentication": "~55.0.14",
+    "expo-build-properties": "~55.0.15",
     "expo-clipboard": "~55.0.14",
     "expo-constants": "~55.0.16",
     "expo-crypto": "~55.0.16",

--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native'
 import { LinearGradient } from 'expo-linear-gradient'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import * as AppleAuthentication from 'expo-apple-authentication'
 import { useRouter } from 'expo-router'
 import { useTheme } from '../theme/ThemeProvider'
@@ -30,6 +31,7 @@ type Mode = 'signin' | 'signup'
 
 export default function AuthScreen() {
   const t = useTheme()
+  const insets = useSafeAreaInsets()
   const router = useRouter()
   const [mode, setMode] = useState<Mode>('signin')
   const [fullName, setFullName] = useState('')
@@ -99,7 +101,7 @@ export default function AuthScreen() {
           locations={t.colors.heroGradient.locations}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}
-          style={{ alignItems: 'center', paddingTop: t.spacing.xxl, paddingBottom: t.spacing.xl }}
+          style={{ alignItems: 'center', paddingTop: insets.top + t.spacing.xxl, paddingBottom: t.spacing.xl }}
         >
           <View
             style={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@supabase/supabase-js": "^2.98.0",
         "expo": "~55.0.27",
         "expo-apple-authentication": "~55.0.14",
+        "expo-build-properties": "~55.0.15",
         "expo-clipboard": "~55.0.14",
         "expo-constants": "~55.0.16",
         "expo-crypto": "~55.0.16",
@@ -782,6 +783,20 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-build-properties": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.15.tgz",
+      "integrity": "sha512-mLCtpn/nBEg4lm7tQUhh/yT5l+8gqwHU/ONqs/zbeeqnNbvryjTuGE0krluueB7Tol4/epfgjiKL4hVEW2VAvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.4",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "apps/mobile/node_modules/expo-clipboard": {


### PR DESCRIPTION
Follow-up to #364 (now merged). Two small fixes.

## Auth hero gradient full-bleed
On device, the login screen's hero gradient stopped at the top safe-area inset, leaving a seam of base background behind the Dynamic Island (other screens render correctly).

- `app/login.tsx`: drop `'top'` from the `Screen` edges so it no longer pads/paints the top strip, letting the gradient reach the true top edge.
- `src/screens/AuthScreen.tsx`: add `useSafeAreaInsets()` and pad the hero's `paddingTop` by `insets.top`, so the GC tile still clears the notch.

JS-only; no native rebuild required.

## Declare `expo-build-properties`
`app.json` already references the `expo-build-properties` config plugin (`ios.useFrameworks: "static"`, required so the Google Sign-In SDK's Swift pods — `AppCheckCore`/`GoogleUtilities`/`RecaptchaInterop` — build as static frameworks and `pod install` succeeds). The dependency itself was missing from `package.json`, so a clean install couldn't resolve the plugin. Adds it at the SDK-pinned `~55.0.15` and updates the lockfile.

## Verification
- `npm run typecheck -w @gracechords/mobile` — clean
- `npm run test -w @gracechords/mobile` — 37/37 pass
- Gradient fix verified on-device (iPhone, dark mode): gradient now fills under the Dynamic Island.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwX4qqeh8QhRDQzwEKNhdp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwX4qqeh8QhRDQzwEKNhdp)_