### PR TITLE
feat(mobile): grouped Settings screen + app-wide defaults

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,6 +9,7 @@
     "newArchEnabled": true,
     "ios": {
       "bundleIdentifier": "com.gracechords.app",
+      "buildNumber": "1",
       "supportsTablet": true,
       "usesAppleSignIn": true
     },

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -9,6 +9,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { ThemeProvider } from '../src/theme/ThemeProvider'
 import { registerAuthAutoRefresh, supabase } from '../src/lib/supabase'
 import { flushPendingSprite } from '../src/lib/profile'
+import { hydrateDefaults } from '../src/lib/defaults'
 import { prefetchToday } from '../src/lib/bibleSource'
 
 // Keep the native splash up past first render so we can resolve the persisted
@@ -67,7 +68,10 @@ export default function RootLayout() {
   useEffect(() => registerAuthAutoRefresh(), [])
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => {
+    // Load app-wide defaults (theme/chord style) before the splash lifts so the
+    // resolved theme is applied on first paint — no light→dark flash. Runs in
+    // parallel with the session read; both must resolve before `ready`.
+    Promise.all([supabase.auth.getSession(), hydrateDefaults(AsyncStorage)]).then(([{ data }]) => {
       setSession(data.session)
       setReady(true)
     })
@@ -104,6 +108,9 @@ export default function RootLayout() {
             <Stack.Screen name="viewer/[slug]" />
             <Stack.Screen name="setlist/[id]" />
             <Stack.Screen name="perform/[id]" />
+            <Stack.Screen name="settings" />
+            <Stack.Screen name="about" />
+            <Stack.Screen name="offline" />
           </Stack>
         </SafeAreaProvider>
       </ThemeProvider>

--- a/apps/mobile/app/about.tsx
+++ b/apps/mobile/app/about.tsx
@@ -1,0 +1,6 @@
+import AboutScreen from '../src/screens/AboutScreen'
+
+// About GraceChords — pushed from Settings → Support.
+export default function About() {
+  return <AboutScreen />
+}

--- a/apps/mobile/app/offline.tsx
+++ b/apps/mobile/app/offline.tsx
@@ -1,0 +1,6 @@
+import OfflineDownloadsScreen from '../src/screens/OfflineDownloadsScreen'
+
+// Offline & downloads — pushed from Settings (stubbed until Stage 3).
+export default function Offline() {
+  return <OfflineDownloadsScreen />
+}

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -1,0 +1,6 @@
+import SettingsScreen from '../src/screens/SettingsScreen'
+
+// Profile & Settings — pushed over the tab shell from the Home header avatar.
+export default function Settings() {
+  return <SettingsScreen />
+}

--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -33,6 +33,7 @@ import { exportSong } from '../../src/lib/exportSong'
 import { pushSongToTelegram, TELEGRAM_BOT_URL } from '../../src/lib/telegramPush'
 import { useSong } from '../../src/lib/useSong'
 import { useAutoHideChrome, useAutoHidePref } from '../../src/lib/autoHideChrome'
+import { getDefaultsSnapshot } from '../../src/lib/defaults'
 import { useTheme } from '../../src/theme/ThemeProvider'
 
 // Song Viewer. Pass 1 built the static monospaced chart; pass 2 adds the live
@@ -77,7 +78,9 @@ export default function ViewerScreen() {
   const [showChords, setShowChords] = useState(true)
   const [showSections, setShowSections] = useState(true)
   const [fontScale, setFontScale] = useState(1)
-  const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
+  // Chord style initializes from the app-wide default (read-on-open); in-viewer
+  // changes stay session-local — no write-back to the global default.
+  const [chordStyle, setChordStyle] = useState<ChordStyle>(() => getDefaultsSnapshot().chordStyle)
   const [accidental, setAccidental] = useState<Accidental>('sharp')
   // Seed the accidental from the key until the user flips it themselves.
   const accidentalTouched = useRef(false)

--- a/apps/mobile/src/components/ListRow.tsx
+++ b/apps/mobile/src/components/ListRow.tsx
@@ -1,11 +1,16 @@
 import type { ReactNode } from 'react'
 import { Pressable, Text, View } from 'react-native'
 import { useTheme } from '../theme/ThemeProvider'
+import SymbolIcon from './SymbolIcon'
 
 // The dense, text-only list row from the design: a title + optional subtitle on
 // the left, and an optional two-line trailing block on the right (used for
 // key / time signature). `trailing` renders a custom accessory after that
 // block (e.g. the add-songs +/✓ badge). Density and scan-speed over decoration.
+//
+// The grouped Settings screen reuses this row with `leading` (an SF Symbol
+// slot), a muted `value` string, a disclosure `chevron`, and `isLast` to drop
+// the hairline on the final row inside a rounded Card group.
 
 export type ListRowProps = {
   title: string
@@ -14,6 +19,14 @@ export type ListRowProps = {
   trailingBottom?: string | null
   /** Custom accessory rendered at the far right. */
   trailing?: ReactNode
+  /** Leading accessory (e.g. an SF Symbol) rendered before the title. */
+  leading?: ReactNode
+  /** Muted trailing value text (settings rows: "English", "Letters"). */
+  value?: string | null
+  /** Show a disclosure chevron at the far right (navigation rows). */
+  chevron?: boolean
+  /** Drop the bottom hairline — use on the last row inside a grouped Card. */
+  isLast?: boolean
   accessibilityLabel?: string
   onPress?: () => void
 }
@@ -24,6 +37,10 @@ export default function ListRow({
   trailingTop,
   trailingBottom,
   trailing,
+  leading,
+  value,
+  chevron,
+  isLast,
   accessibilityLabel,
   onPress,
 }: ListRowProps) {
@@ -39,11 +56,12 @@ export default function ListRow({
         gap: t.spacing.md,
         paddingVertical: 11,
         paddingHorizontal: t.spacing.xl,
-        borderBottomWidth: 0.5,
+        borderBottomWidth: isLast ? 0 : 0.5,
         borderBottomColor: t.colors.border,
         backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
       })}
     >
+      {leading}
       <View style={{ flex: 1, minWidth: 0 }}>
         <Text
           numberOfLines={1}
@@ -97,7 +115,22 @@ export default function ListRow({
         </View>
       ) : null}
 
+      {value ? (
+        <Text
+          numberOfLines={1}
+          style={{
+            fontSize: t.typography.body.fontSize,
+            color: t.colors.sec,
+            maxWidth: '45%',
+          }}
+        >
+          {value}
+        </Text>
+      ) : null}
+
       {trailing}
+
+      {chevron ? <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} /> : null}
     </Pressable>
   )
 }

--- a/apps/mobile/src/lib/__tests__/defaults.test.ts
+++ b/apps/mobile/src/lib/__tests__/defaults.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_APP_DEFAULTS,
+  getDefaultsSnapshot,
+  hydrateDefaults,
+  initialChordStyle,
+  resolveThemeMode,
+  setDefaultChordStyle,
+  setDefaultTheme,
+  type KVStorage,
+} from '../defaults'
+
+function memoryStorage(initial: Record<string, string> = {}): KVStorage & { store: Map<string, string> } {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    getItem: async (k) => store.get(k) ?? null,
+    setItem: async (k, v) => void store.set(k, v),
+    removeItem: async (k) => void store.delete(k),
+  }
+}
+
+describe('defaults store', () => {
+  it('falls back to DEFAULT_APP_DEFAULTS when nothing is stored', async () => {
+    await hydrateDefaults(memoryStorage())
+    expect(getDefaultsSnapshot()).toEqual(DEFAULT_APP_DEFAULTS)
+    expect(getDefaultsSnapshot()).toEqual({ theme: 'system', chordStyle: 'letters' })
+  })
+
+  it('ignores invalid stored values and uses fallbacks', async () => {
+    await hydrateDefaults(memoryStorage({ 'gc.defaults.theme': 'neon', 'gc.defaults.chordStyle': 'tab' }))
+    expect(getDefaultsSnapshot()).toEqual(DEFAULT_APP_DEFAULTS)
+  })
+
+  it('writes each setting through to storage and reflects it in the snapshot', async () => {
+    const s = memoryStorage()
+    await hydrateDefaults(s)
+
+    setDefaultTheme('dark')
+    setDefaultChordStyle('solfege')
+
+    expect(getDefaultsSnapshot()).toEqual({ theme: 'dark', chordStyle: 'solfege' })
+    expect(s.store.get('gc.defaults.theme')).toBe('dark')
+    expect(s.store.get('gc.defaults.chordStyle')).toBe('solfege')
+  })
+
+  it('survives a simulated reload (re-hydrate from the same storage)', async () => {
+    const s = memoryStorage()
+    await hydrateDefaults(s)
+    setDefaultTheme('light')
+    setDefaultChordStyle('solfege')
+
+    // Reset the cache to defaults via a fresh empty hydrate, then reload from `s`.
+    await hydrateDefaults(memoryStorage())
+    expect(getDefaultsSnapshot()).toEqual(DEFAULT_APP_DEFAULTS)
+
+    await hydrateDefaults(s)
+    expect(getDefaultsSnapshot()).toEqual({ theme: 'light', chordStyle: 'solfege' })
+  })
+
+  it('returns a stable snapshot reference between changes', async () => {
+    await hydrateDefaults(memoryStorage())
+    const a = getDefaultsSnapshot()
+    expect(getDefaultsSnapshot()).toBe(a)
+    setDefaultTheme(a.theme) // no-op (same value) → reference unchanged
+    expect(getDefaultsSnapshot()).toBe(a)
+    setDefaultTheme('dark') // real change → new reference
+    expect(getDefaultsSnapshot()).not.toBe(a)
+  })
+})
+
+describe('resolveThemeMode', () => {
+  it("'system' follows the OS scheme", () => {
+    expect(resolveThemeMode('system', 'dark')).toBe('dark')
+    expect(resolveThemeMode('system', 'light')).toBe('light')
+    expect(resolveThemeMode('system', null)).toBe('light')
+    expect(resolveThemeMode('system', undefined)).toBe('light')
+  })
+
+  it("'light'/'dark' force the mode regardless of scheme", () => {
+    expect(resolveThemeMode('light', 'dark')).toBe('light')
+    expect(resolveThemeMode('dark', 'light')).toBe('dark')
+  })
+})
+
+describe('initialChordStyle', () => {
+  it('seeds the viewer from the stored default', () => {
+    expect(initialChordStyle({ theme: 'system', chordStyle: 'solfege' })).toBe('solfege')
+    expect(initialChordStyle({ theme: 'system', chordStyle: 'letters' })).toBe('letters')
+  })
+})

--- a/apps/mobile/src/lib/defaults.ts
+++ b/apps/mobile/src/lib/defaults.ts
@@ -1,0 +1,124 @@
+import { useSyncExternalStore } from 'react'
+import type { ThemeMode } from '@gracechords/tokens/native'
+
+// App-wide defaults — the theme and chord-style preferences the Settings screen
+// writes and the Song Viewer / Performer / Daily Word read. Device-local
+// (AsyncStorage), NOT Supabase-synced and NOT the Stage-3 asset layer.
+//
+// Storage is INJECTED (a KVStorage, same shape as profile.ts) so this module is
+// DOM/RN-free and unit-testable headless. The app root calls hydrateDefaults()
+// once with AsyncStorage during the splash hold; after that getDefaultsSnapshot()
+// is synchronous, so screens seed their initial state on open with no flash.
+
+export type KVStorage = {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+/** 'system' follows the OS scheme (today's behavior); light/dark force a mode. */
+export type ThemePref = 'system' | 'light' | 'dark'
+/** Chord token spelling. Structurally identical to ChordChart's ChordStyle. */
+export type ChordStyle = 'letters' | 'solfege'
+
+export type AppDefaults = {
+  theme: ThemePref
+  chordStyle: ChordStyle
+}
+
+export const DEFAULT_APP_DEFAULTS: AppDefaults = {
+  theme: 'system',
+  chordStyle: 'letters',
+}
+
+const THEME_KEY = 'gc.defaults.theme'
+const CHORD_STYLE_KEY = 'gc.defaults.chordStyle'
+
+const THEME_PREFS: readonly ThemePref[] = ['system', 'light', 'dark']
+const CHORD_STYLES: readonly ChordStyle[] = ['letters', 'solfege']
+
+// Module-level cache + write-through storage. `cache` is replaced with a NEW
+// object on every change so useSyncExternalStore sees a stable reference between
+// changes (required — getSnapshot must not return a fresh object each call).
+let cache: AppDefaults = DEFAULT_APP_DEFAULTS
+let storage: KVStorage | null = null
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function isThemePref(v: unknown): v is ThemePref {
+  return typeof v === 'string' && (THEME_PREFS as readonly string[]).includes(v)
+}
+function isChordStyle(v: unknown): v is ChordStyle {
+  return typeof v === 'string' && (CHORD_STYLES as readonly string[]).includes(v)
+}
+
+/**
+ * Load stored defaults into the cache and remember `store` for write-through.
+ * Missing/invalid values fall back to DEFAULT_APP_DEFAULTS. Safe to call again
+ * to re-read from the same storage (used to simulate a reload in tests).
+ */
+export async function hydrateDefaults(store: KVStorage): Promise<AppDefaults> {
+  storage = store
+  let theme: ThemePref = DEFAULT_APP_DEFAULTS.theme
+  let chordStyle: ChordStyle = DEFAULT_APP_DEFAULTS.chordStyle
+  try {
+    const [rawTheme, rawChord] = await Promise.all([
+      store.getItem(THEME_KEY),
+      store.getItem(CHORD_STYLE_KEY),
+    ])
+    if (isThemePref(rawTheme)) theme = rawTheme
+    if (isChordStyle(rawChord)) chordStyle = rawChord
+  } catch {
+    // Best-effort — a bad read must never crash the app; fall back to defaults.
+  }
+  cache = { theme, chordStyle }
+  emit()
+  return cache
+}
+
+/** Synchronous read of the current defaults (safe before hydrate — returns fallbacks). */
+export function getDefaultsSnapshot(): AppDefaults {
+  return cache
+}
+
+export function setDefaultTheme(v: ThemePref): void {
+  if (cache.theme === v) return
+  cache = { ...cache, theme: v }
+  emit()
+  storage?.setItem(THEME_KEY, v).catch(() => {})
+}
+
+export function setDefaultChordStyle(v: ChordStyle): void {
+  if (cache.chordStyle === v) return
+  cache = { ...cache, chordStyle: v }
+  emit()
+  storage?.setItem(CHORD_STYLE_KEY, v).catch(() => {})
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Subscribing hook — re-renders on any defaults change (Settings + ThemeProvider). */
+export function useAppDefaults(): AppDefaults {
+  return useSyncExternalStore(subscribe, getDefaultsSnapshot, getDefaultsSnapshot)
+}
+
+/**
+ * Resolve a theme preference against the OS scheme to a concrete token mode.
+ * `systemScheme` is loosely typed to accept RN's ColorSchemeName
+ * ('light' | 'dark' | 'unspecified' | null | undefined).
+ */
+export function resolveThemeMode(pref: ThemePref, systemScheme: string | null | undefined): ThemeMode {
+  if (pref === 'light' || pref === 'dark') return pref
+  return systemScheme === 'dark' ? 'dark' : 'light'
+}
+
+/** Viewer/Performer initial chord style on open (read-on-open, session-local). */
+export function initialChordStyle(defaults: AppDefaults): ChordStyle {
+  return defaults.chordStyle
+}

--- a/apps/mobile/src/lib/profile.ts
+++ b/apps/mobile/src/lib/profile.ts
@@ -41,6 +41,23 @@ export async function saveSpritePreference(
   return { error: null }
 }
 
+// Read the saved sprite id back from public.users.preferences.sprite. Returns
+// null when unset, on error, or if RLS/absent row denies the read — callers
+// fall back to a default avatar.
+export async function fetchSpritePreference(
+  client: SupabaseClient,
+  userId: string,
+): Promise<string | null> {
+  const { data, error } = await client
+    .from('users')
+    .select('preferences')
+    .eq('id', userId)
+    .maybeSingle()
+  if (error || !data) return null
+  const sprite = (data.preferences as Record<string, unknown> | null)?.sprite
+  return typeof sprite === 'string' ? sprite : null
+}
+
 export async function stashPendingSprite(storage: KVStorage, sprite: string): Promise<void> {
   await storage.setItem(PENDING_SPRITE_KEY, sprite)
 }

--- a/apps/mobile/src/lib/useProfileSprite.ts
+++ b/apps/mobile/src/lib/useProfileSprite.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import type { ImageSourcePropType } from 'react-native'
+import { supabase } from './supabase'
+import { useCurrentUser } from './greetings'
+import { fetchSpritePreference } from './profile'
+import { SPRITE_SOURCES, type SpriteId } from './sprites'
+
+// Reads the current user's chosen sprite (public.users.preferences.sprite) and
+// resolves it to a static image source. Returns null until it loads / when the
+// user hasn't picked one, so callers fall back to the default `person` symbol.
+
+export function useProfileSprite(): { spriteId: SpriteId | null; source: ImageSourcePropType | null } {
+  const user = useCurrentUser()
+  const [spriteId, setSpriteId] = useState<SpriteId | null>(null)
+
+  useEffect(() => {
+    if (!user?.id) {
+      setSpriteId(null)
+      return
+    }
+    let alive = true
+    fetchSpritePreference(supabase, user.id)
+      .then((id) => {
+        if (alive && id && id in SPRITE_SOURCES) setSpriteId(id as SpriteId)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [user?.id])
+
+  return { spriteId, source: spriteId ? SPRITE_SOURCES[spriteId] : null }
+}

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -1,0 +1,114 @@
+import { Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import Constants from 'expo-constants'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Screen from '../components/Screen'
+import Card from '../components/Card'
+import ListRow from '../components/ListRow'
+import SectionHeader from '../components/SectionHeader'
+import SymbolIcon from '../components/SymbolIcon'
+import { useTheme } from '../theme/ThemeProvider'
+
+// About GraceChords — reached from Settings → Support. Shows the app version +
+// build (via expo-constants) and links out to the privacy policy and licenses.
+
+const PRIVACY_URL = 'https://gracechords.com/privacy'
+const LICENSES_URL = 'https://gracechords.com/licenses'
+
+export default function AboutScreen() {
+  const t = useTheme()
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+
+  const version = Constants.expoConfig?.version ?? '—'
+  const build =
+    Constants.expoConfig?.ios?.buildNumber ??
+    (Constants.expoConfig?.android?.versionCode != null
+      ? String(Constants.expoConfig.android.versionCode)
+      : null)
+  const versionLabel = build ? `${version} (${build})` : version
+
+  return (
+    <Screen edges={['top', 'left', 'right']}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+        >
+          <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>Settings</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: t.spacing.lg,
+          paddingBottom: insets.bottom + t.spacing.xxl,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: t.typography.largeTitle.fontSize,
+            fontWeight: t.typography.largeTitle.fontWeight,
+            letterSpacing: t.typography.largeTitle.letterSpacing,
+            color: t.colors.ink,
+            paddingHorizontal: t.spacing.xs,
+            paddingBottom: t.spacing.md,
+          }}
+        >
+          About
+        </Text>
+
+        {/* App identity */}
+        <Card>
+          <View style={{ alignItems: 'center', paddingVertical: t.spacing.xl, gap: t.spacing.sm }}>
+            <View
+              style={{
+                width: 64,
+                height: 64,
+                borderRadius: 16,
+                backgroundColor: t.colors.accent,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Text style={{ fontSize: 24, fontWeight: '700', letterSpacing: 0.5, color: t.colors.onAccent }}>
+                GC
+              </Text>
+            </View>
+            <Text style={{ fontSize: 19, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
+              GraceChords
+            </Text>
+            <Text style={{ fontSize: 13.5, color: t.colors.sec }}>Version {versionLabel}</Text>
+          </View>
+        </Card>
+
+        <SectionHeader label="LEGAL" />
+        <Card>
+          <ListRow
+            title="Privacy Policy"
+            chevron
+            onPress={() => void Linking.openURL(PRIVACY_URL)}
+          />
+          <ListRow
+            title="Acknowledgements &amp; Licenses"
+            chevron
+            isLast
+            onPress={() => void Linking.openURL(LICENSES_URL)}
+          />
+        </Card>
+      </ScrollView>
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import {
   ActivityIndicator,
-  Alert,
+  Image,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -15,13 +15,13 @@ import ListRow from '../components/ListRow'
 import SymbolIcon from '../components/SymbolIcon'
 import { useTheme } from '../theme/ThemeProvider'
 import type { Tokens } from '@gracechords/tokens/native'
-import { supabase } from '../lib/supabase'
 import {
   getDisplayName,
   pickSubGreeting,
   timeGreeting,
   useCurrentUser,
 } from '../lib/greetings'
+import { useProfileSprite } from '../lib/useProfileSprite'
 import { getRecentlyOpened } from '../lib/recents'
 import { useLastSet } from '../lib/useLastSet'
 import { useStarredSongs, type StarredSong } from '../lib/useStarredSongs'
@@ -60,6 +60,7 @@ export default function HomeScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const user = useCurrentUser()
+  const { source: spriteSource } = useProfileSprite()
   const { songs: starred, loading: starredLoading, error: starredError } = useStarredSongs()
 
   const greeting = `${timeGreeting()}, ${getDisplayName(user)}`
@@ -71,12 +72,7 @@ export default function HomeScreen() {
   const { lastSet } = useLastSet()
 
   function onAvatar() {
-    // The avatar opens Profile/Settings in a later stage; for now it exposes the
-    // existing sign-out affordance.
-    Alert.alert('Account', undefined, [
-      { text: 'Sign out', style: 'destructive', onPress: () => supabase.auth.signOut() },
-      { text: 'Cancel', style: 'cancel' },
-    ])
+    router.push('/settings')
   }
 
   function openSong(s: { slug: string; title: string; artist: string | null; default_key: string | null }) {
@@ -162,9 +158,14 @@ export default function HomeScreen() {
                     borderColor: t.colors.border,
                     alignItems: 'center',
                     justifyContent: 'center',
+                    overflow: 'hidden',
                   }}
                 >
-                  <SymbolIcon name="person" size={20} color={t.colors.accent} />
+                  {spriteSource ? (
+                    <Image source={spriteSource} style={{ width: 36, height: 36 }} resizeMode="cover" />
+                  ) : (
+                    <SymbolIcon name="person" size={20} color={t.colors.accent} />
+                  )}
                 </View>
               </Pressable>
             </View>

--- a/apps/mobile/src/screens/OfflineDownloadsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineDownloadsScreen.tsx
@@ -1,0 +1,45 @@
+import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import Screen from '../components/Screen'
+import EmptyState from '../components/EmptyState'
+import SymbolIcon from '../components/SymbolIcon'
+import { useTheme } from '../theme/ThemeProvider'
+
+// Offline & downloads — reached from Settings. Stubbed for this stage: real
+// offline downloads / asset persistence ship in Stage 3. Scaffolded so the
+// Settings row has a destination, with no download logic wired.
+
+export default function OfflineDownloadsScreen() {
+  const t = useTheme()
+  const router = useRouter()
+
+  return (
+    <Screen edges={['top', 'left', 'right', 'bottom']}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+        >
+          <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>Settings</Text>
+        </Pressable>
+      </View>
+
+      <EmptyState
+        icon="arrow.down.circle"
+        title="Offline downloads"
+        subtitle="Save songs and readings to this device for offline use. Downloads arrive in a later update."
+      />
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -45,6 +45,7 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { prefetchSong, useSong } from '../lib/useSong'
 import { useAutoHideChrome, useAutoHidePref } from '../lib/autoHideChrome'
+import { getDefaultsSnapshot } from '../lib/defaults'
 import { exportSetlist, exportSong } from '../lib/exportSong'
 import { buildSetlistShareUrl } from '../lib/setlistShare'
 import {
@@ -107,7 +108,9 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   const [showChords, setShowChords] = useState(true)
   const [showSections, setShowSections] = useState(true)
   const [fontScale, setFontScale] = useState(1)
-  const [chordStyle, setChordStyle] = useState<ChordStyle>('letters')
+  // Chord style initializes from the app-wide default (read-on-open); in-session
+  // changes stay local — no write-back to the global default.
+  const [chordStyle, setChordStyle] = useState<ChordStyle>(() => getDefaultsSnapshot().chordStyle)
   const [accidental, setAccidental] = useState<Accidental>('sharp')
   // Seed from each song's key until the user flips it.
   const accidentalTouched = useRef(false)

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,372 @@
+import { useState } from 'react'
+import { Alert, Image, Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Screen from '../components/Screen'
+import Card from '../components/Card'
+import ListRow from '../components/ListRow'
+import SectionHeader from '../components/SectionHeader'
+import SymbolIcon from '../components/SymbolIcon'
+import BottomSheet from '../components/BottomSheet'
+import { useTheme } from '../theme/ThemeProvider'
+import type { Tokens } from '@gracechords/tokens/native'
+import { supabase } from '../lib/supabase'
+import { useCurrentUser } from '../lib/greetings'
+import { useProfileSprite } from '../lib/useProfileSprite'
+import {
+  setDefaultChordStyle,
+  setDefaultTheme,
+  useAppDefaults,
+  type ChordStyle,
+  type ThemePref,
+} from '../lib/defaults'
+
+// The grouped "Profile & Settings" screen (design: [CONTENT] Settings Content).
+// Built from Stage-0 primitives — a Profile card, three grouped Cards
+// (Settings / Library / Support), and destructive Log out + Delete account
+// cards. Theme + chord style are app-wide DEFAULTS written here and read by the
+// Song Viewer / Performer / Daily Word.
+
+const HELP_URL = 'https://gracechords.com/help'
+const FEEDBACK_MAILTO = 'mailto:support@gracechords.com?subject=GraceChords%20feedback'
+
+const THEME_OPTIONS: { value: ThemePref; label: string }[] = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+]
+const CHORD_OPTIONS: { value: ChordStyle; label: string }[] = [
+  { value: 'letters', label: 'Letters' },
+  { value: 'solfege', label: 'Solfège' },
+]
+
+function labelFor<T extends string>(options: { value: T; label: string }[], value: T): string {
+  return options.find((o) => o.value === value)?.label ?? ''
+}
+
+/** Rounded leading icon chip used on the grouped rows. */
+function RowIcon({ name, t }: { name: Parameters<typeof SymbolIcon>[0]['name']; t: Tokens }) {
+  return (
+    <View
+      style={{
+        width: 29,
+        height: 29,
+        borderRadius: 7,
+        backgroundColor: t.colors.accentSoft,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <SymbolIcon name={name} size={16} color={t.colors.accent} />
+    </View>
+  )
+}
+
+/** A standalone destructive action card (Log out / Delete account). */
+function DangerCard({
+  label,
+  onPress,
+  accessibilityLabel,
+}: {
+  label: string
+  onPress: () => void
+  accessibilityLabel?: string
+}) {
+  const t = useTheme()
+  return (
+    <Card style={{ marginTop: t.spacing.lg }}>
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? label}
+        style={({ pressed }) => ({
+          paddingVertical: 13,
+          alignItems: 'center',
+          backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
+        })}
+      >
+        <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.danger }}>
+          {label}
+        </Text>
+      </Pressable>
+    </Card>
+  )
+}
+
+/** BottomSheet radio list of options with a checkmark on the current value. */
+function OptionSheet<T extends string>({
+  visible,
+  title,
+  options,
+  value,
+  onSelect,
+  onClose,
+}: {
+  visible: boolean
+  title: string
+  options: { value: T; label: string }[]
+  value: T
+  onSelect: (v: T) => void
+  onClose: () => void
+}) {
+  const t = useTheme()
+  return (
+    <BottomSheet visible={visible} onClose={onClose} title={title}>
+      <View style={{ paddingBottom: t.spacing.lg }}>
+        {options.map((o, i) => (
+          <ListRow
+            key={o.value}
+            title={o.label}
+            isLast={i === options.length - 1}
+            accessibilityLabel={o.label}
+            onPress={() => {
+              onSelect(o.value)
+              onClose()
+            }}
+            trailing={
+              o.value === value ? (
+                <SymbolIcon name="checkmark" size={16} color={t.colors.accent} />
+              ) : null
+            }
+          />
+        ))}
+      </View>
+    </BottomSheet>
+  )
+}
+
+export default function SettingsScreen() {
+  const t = useTheme()
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const user = useCurrentUser()
+  const defaults = useAppDefaults()
+  const { source: spriteSource } = useProfileSprite()
+  const [sheet, setSheet] = useState<null | 'theme' | 'chordStyle'>(null)
+
+  const meta = (user?.user_metadata ?? {}) as Record<string, unknown>
+  const fullName = ((meta.full_name ?? meta.name) as string | undefined)?.trim()
+  const email = user?.email ?? ''
+  const displayName = fullName || (email ? email.split('@')[0] : 'Your account')
+
+  function onSignOut() {
+    Alert.alert('Sign out', 'Sign out of GraceChords on this device?', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Sign out', style: 'destructive', onPress: () => void supabase.auth.signOut() },
+    ])
+  }
+
+  function onDeleteAccount() {
+    Alert.alert(
+      'Delete account',
+      'This permanently deletes your account and all your data — starred songs, setlists, and preferences. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete account',
+          style: 'destructive',
+          onPress: async () => {
+            // Reuses the existing SECURITY DEFINER RPC (same path web uses):
+            // removes auth.users + cascades. Session then invalidates and the
+            // root auth listener redirects to /login.
+            const { error } = await supabase.rpc('delete_user')
+            if (error) {
+              Alert.alert('Delete failed', 'We could not delete your account. Please try again.')
+              return
+            }
+            await supabase.auth.signOut()
+          },
+        },
+      ],
+    )
+  }
+
+  return (
+    <Screen edges={['top', 'left', 'right']}>
+      {/* Nav header */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+        >
+          <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>Home</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: t.spacing.lg,
+          paddingBottom: insets.bottom + t.spacing.xxl,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: t.typography.largeTitle.fontSize,
+            fontWeight: t.typography.largeTitle.fontWeight,
+            letterSpacing: t.typography.largeTitle.letterSpacing,
+            color: t.colors.ink,
+            paddingHorizontal: t.spacing.xs,
+            paddingBottom: t.spacing.md,
+          }}
+        >
+          Profile &amp; Settings
+        </Text>
+
+        {/* Profile card */}
+        <Card>
+          <Pressable
+            onPress={() => router.push('/choose-icon')}
+            accessibilityRole="button"
+            accessibilityLabel="Edit profile"
+            style={({ pressed }) => ({
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: t.spacing.md,
+              padding: t.spacing.lg,
+              backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
+            })}
+          >
+            <View
+              style={{
+                width: 52,
+                height: 52,
+                borderRadius: t.radii.pill,
+                backgroundColor: t.colors.accentSoft,
+                borderWidth: 1,
+                borderColor: t.colors.border,
+                alignItems: 'center',
+                justifyContent: 'center',
+                overflow: 'hidden',
+              }}
+            >
+              {spriteSource ? (
+                <Image source={spriteSource} style={{ width: 52, height: 52 }} resizeMode="cover" />
+              ) : (
+                <SymbolIcon name="person" size={26} color={t.colors.accent} />
+              )}
+            </View>
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <Text
+                numberOfLines={1}
+                style={{ fontSize: 17, fontWeight: '600', letterSpacing: -0.3, color: t.colors.ink }}
+              >
+                {displayName}
+              </Text>
+              {email ? (
+                <Text numberOfLines={1} style={{ marginTop: 2, fontSize: 13.5, color: t.colors.sec }}>
+                  {email}
+                </Text>
+              ) : null}
+            </View>
+            <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+          </Pressable>
+        </Card>
+
+        {/* SETTINGS */}
+        <SectionHeader label="SETTINGS" />
+        <Card>
+          <ListRow
+            title="Appearance"
+            leading={<RowIcon name="circle.lefthalf.filled" t={t} />}
+            value={labelFor(THEME_OPTIONS, defaults.theme)}
+            chevron
+            onPress={() => setSheet('theme')}
+          />
+          <ListRow
+            title="Language"
+            leading={<RowIcon name="globe" t={t} />}
+            value="English"
+          />
+          <ListRow
+            title="Chord style"
+            leading={<RowIcon name="music.note" t={t} />}
+            value={labelFor(CHORD_OPTIONS, defaults.chordStyle)}
+            chevron
+            onPress={() => setSheet('chordStyle')}
+          />
+          <ListRow
+            title="Offline &amp; downloads"
+            leading={<RowIcon name="arrow.down.circle" t={t} />}
+            chevron
+            isLast
+            onPress={() => router.push('/offline')}
+          />
+        </Card>
+
+        {/* LIBRARY */}
+        <SectionHeader label="LIBRARY" />
+        <Card>
+          <ListRow
+            title="Starred"
+            leading={<RowIcon name="star" t={t} />}
+            chevron
+            onPress={() => router.push('/songs')}
+          />
+          <ListRow
+            title="My setlists"
+            leading={<RowIcon name="music.note.list" t={t} />}
+            chevron
+            isLast
+            onPress={() => router.push('/setlists')}
+          />
+        </Card>
+
+        {/* SUPPORT */}
+        <SectionHeader label="SUPPORT" />
+        <Card>
+          <ListRow
+            title="Help center"
+            leading={<RowIcon name="questionmark.circle" t={t} />}
+            chevron
+            onPress={() => void Linking.openURL(HELP_URL)}
+          />
+          <ListRow
+            title="Send feedback"
+            leading={<RowIcon name="envelope" t={t} />}
+            chevron
+            onPress={() => void Linking.openURL(FEEDBACK_MAILTO)}
+          />
+          <ListRow
+            title="About GraceChords"
+            leading={<RowIcon name="info.circle" t={t} />}
+            chevron
+            isLast
+            onPress={() => router.push('/about')}
+          />
+        </Card>
+
+        <DangerCard label="Log out" onPress={onSignOut} />
+        <DangerCard label="Delete account" onPress={onDeleteAccount} />
+      </ScrollView>
+
+      <OptionSheet
+        visible={sheet === 'theme'}
+        title="Appearance"
+        options={THEME_OPTIONS}
+        value={defaults.theme}
+        onSelect={setDefaultTheme}
+        onClose={() => setSheet(null)}
+      />
+      <OptionSheet
+        visible={sheet === 'chordStyle'}
+        title="Chord style"
+        options={CHORD_OPTIONS}
+        value={defaults.chordStyle}
+        onSelect={setDefaultChordStyle}
+        onClose={() => setSheet(null)}
+      />
+    </Screen>
+  )
+}

--- a/apps/mobile/src/theme/ThemeProvider.tsx
+++ b/apps/mobile/src/theme/ThemeProvider.tsx
@@ -1,17 +1,21 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { useColorScheme } from 'react-native'
 import { getTokens, lightTokens, type Tokens } from '@gracechords/tokens/native'
+import { resolveThemeMode, useAppDefaults } from '../lib/defaults'
 
-// The app follows the system appearance (app.json userInterfaceStyle:
-// "automatic"). ThemeProvider resolves the current scheme to the canonical
-// token set from @gracechords/tokens and hands it down; components read it with
-// useTheme(). Dark is the primary mode for stage use, but both are correct.
+// ThemeProvider is the single source of truth for the app's color scheme. It
+// resolves the user's theme preference (Settings → Appearance, stored in the
+// defaults store) against the OS scheme: 'system' follows the device (the
+// original app.json userInterfaceStyle: "automatic" behavior), while
+// 'light'/'dark' force a mode. Changing the setting re-renders the whole app
+// immediately. Components read the resolved tokens with useTheme().
 
 const ThemeContext = createContext<Tokens>(lightTokens)
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const scheme = useColorScheme()
-  const tokens = useMemo(() => getTokens(scheme === 'dark' ? 'dark' : 'light'), [scheme])
+  const { theme } = useAppDefaults()
+  const tokens = useMemo(() => getTokens(resolveThemeMode(theme, scheme)), [theme, scheme])
   return <ThemeContext.Provider value={tokens}>{children}</ThemeContext.Provider>
 }
 


### PR DESCRIPTION
## Summary

Stage 2 — builds the grouped iOS **Profile & Settings** screen (design: `[CONTENT] Settings Content`) and establishes the **app-wide defaults** (theme + chord style) that the Song Viewer, Setlist Performer, and Daily Word Reader read.

## What's included

**Defaults store** — `apps/mobile/src/lib/defaults.ts`
- Device-local, AsyncStorage-backed cache: `hydrateDefaults` / `getDefaultsSnapshot` / `setDefaultTheme` / `setDefaultChordStyle` / `useAppDefaults` + `resolveThemeMode`.
- Storage is injected (`KVStorage`), keeping the module RN-free and unit-testable — mirrors the `profile.ts` pattern. Not Supabase-synced; not the Stage-3 asset layer.

**Theme** — `ThemeProvider.tsx`
- Resolves the mode from the defaults store: **System / Light / Dark** (System preserves today's `userInterfaceStyle: automatic` behavior). Single source of truth — no second provider. Hydrated at the app root before the splash lifts to avoid a theme flash.

**Settings UI** — `SettingsScreen.tsx` + `app/settings.tsx`
- Profile card (with sprite-avatar read-back), grouped **Settings / Library / Support** cards, Appearance + Chord-style picker sheets, Log out, and **Delete account**.
- Delete account reuses the existing `public.delete_user()` RPC — the same path the web `ProfilePage` uses — so no new server function is required.
- `AboutScreen` (version/build via `expo-constants`, privacy/licenses links) and a **stubbed** Offline & downloads screen (real downloads are a later stage).

**Read-integration**
- Song Viewer and Setlist Performer seed chord style from the default on open; in-screen changes stay session-local (no write-back). Transpose / `key_override` behavior is untouched. Daily Word follows the theme default via the provider.

**Supporting changes**
- `ListRow` gains additive `leading` / `value` / `chevron` / `isLast` props for grouped rows (no new primitive).
- Home avatar navigates to Settings and displays the chosen sprite.
- `profile.ts` gains an additive `fetchSpritePreference` read.
- `app.json` sets `ios.buildNumber` to `1`.

## Decisions (surfaced at the plan gate)
- **Font-size default:** not built — no such row exists in the DEMO/UI (SPEC musing only). Font size stays a per-view session control.
- **Theme:** three-way (System/Light/Dark) rather than the DEMO's binary toggle, to preserve system-follow and match HIG.
- **Account deletion:** entry + confirmation built now, reusing the existing production RPC — no new edge function or migration.
- **Offline row:** visible, routes to a stub screen.

## Verification
- `npm run typecheck` — clean.
- `npm run test` — 45/45 pass (includes new `defaults.test.ts`: persistence, simulated reload, fallbacks, theme resolution, viewer seed selector).
- `npm run export:ios` — full Metro bundle succeeds.

## Follow-ups for the maintainer
- Confirm `public.delete_user()` is applied to the target Supabase project (already used by web in production).
- Replace placeholder URLs wired into Support/About: `https://gracechords.com/help`, `.../privacy`, `.../licenses`, `mailto:support@gracechords.com`.
- **Pre-existing (not from this PR):** `expo-build-properties` is listed in `app.json` plugins but is missing from `package.json`/lockfile, which breaks `expo export`/prebuild. Add it via `npx expo install expo-build-properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkBKkMNqT6goonER9s5bJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkBKkMNqT6goonER9s5bJ8)_