### PR TITLE
Use system sans-serif for chord chart lyrics; remove RTL logic

### DIFF
--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -15,10 +15,10 @@ import {
 import ChordChart, {
   CHART_FONT_SIZE,
   CHART_LINE_HEIGHT,
-  CHART_SERIF,
+  CHART_LYRIC_FONT,
   type ChordStyle,
 } from '../../src/components/ChordChart'
-// CHART_LINE_HEIGHT / CHART_FONT_SIZE / CHART_SERIF drive the raw-text fallback.
+// CHART_LINE_HEIGHT / CHART_FONT_SIZE / CHART_LYRIC_FONT drive the raw-text fallback.
 import ExportSheet from '../../src/components/ExportSheet'
 import Screen from '../../src/components/Screen'
 import StarButton from '../../src/components/StarButton'
@@ -418,7 +418,7 @@ function RawFallback({ content, parseError }: { content: string; parseError: boo
         <Text
           key={i}
           style={{
-            fontFamily: CHART_SERIF,
+            fontFamily: CHART_LYRIC_FONT,
             fontSize: CHART_FONT_SIZE,
             lineHeight: CHART_LINE_HEIGHT,
             color: t.colors.ink,

--- a/apps/mobile/src/components/ChordChart.tsx
+++ b/apps/mobile/src/components/ChordChart.tsx
@@ -8,16 +8,19 @@ import {
 } from '@gracechords/core'
 import { useTheme } from '../theme/ThemeProvider'
 
-// Chord chart: lyrics render in a proportional SERIF face and wrap to the
-// screen width; chords stay MONOSPACE in the accent color, stacked above the
-// word they sit on (word-anchored, so no monospace-padding math and no
-// horizontal scroll). Chord positions come from the parser as character
-// indices into the lyric line; each is attached to the word it falls within.
-// Transposition + chord style are applied per symbol at render time.
+// Chord chart: lyrics render in the system SANS-SERIF face (SF Pro on iOS,
+// Roboto on Android) to match the rest of the app, and wrap to the screen
+// width; chords stay MONOSPACE in the accent color, stacked above the word
+// they sit on (word-anchored, so no monospace-padding math and no horizontal
+// scroll). Chord positions come from the parser as character indices into the
+// lyric line; each is attached to the word it falls within. Transposition +
+// chord style are applied per symbol at render time.
 
 export const CHART_MONO = Platform.select({ ios: 'Menlo', default: 'monospace' })
-// System serif on iOS (Georgia is always present); "serif" elsewhere.
-export const CHART_SERIF = Platform.select({ ios: 'Georgia', default: 'serif' })
+// System sans-serif: RN falls back to the platform system font when fontFamily
+// is unset, so `undefined` gives SF Pro on iOS / Roboto on Android — the same
+// face the app chrome uses.
+export const CHART_LYRIC_FONT = undefined
 export const CHART_FONT_SIZE = 17
 export const CHART_LINE_HEIGHT = 24
 
@@ -136,7 +139,7 @@ function ChartLine({ line, ...opts }: RenderOpts & { line: SongLine }) {
   const chordSize = 14 * fontScale
   const chordLineHeight = Math.round(20 * fontScale)
 
-  const serif = { fontFamily: CHART_SERIF, fontSize: lyricSize, lineHeight, color: t.colors.ink }
+  const lyric = { fontFamily: CHART_LYRIC_FONT, fontSize: lyricSize, lineHeight, color: t.colors.ink }
   const chordStyleObj = {
     fontFamily: CHART_MONO,
     fontSize: chordSize,
@@ -164,7 +167,7 @@ function ChartLine({ line, ...opts }: RenderOpts & { line: SongLine }) {
 
   if (line.comment) {
     return (
-      <Text style={{ fontFamily: CHART_SERIF, fontSize: 14.5 * fontScale, lineHeight, fontStyle: 'italic', color: t.colors.sec }}>
+      <Text style={{ fontFamily: CHART_LYRIC_FONT, fontSize: 14.5 * fontScale, lineHeight, fontStyle: 'italic', color: t.colors.sec }}>
         {line.comment}
       </Text>
     )
@@ -179,9 +182,9 @@ function ChartLine({ line, ...opts }: RenderOpts & { line: SongLine }) {
     return <View style={{ height: lineHeight }} />
   }
 
-  // Lyrics with no chords (or chords hidden): plain wrapping serif line.
+  // Lyrics with no chords (or chords hidden): plain wrapping line.
   if (!hasChords) {
-    return <Text style={serif}>{line.lyrics || ' '}</Text>
+    return <Text style={lyric}>{line.lyrics || ' '}</Text>
   }
 
   const cells = buildWordCells(
@@ -200,7 +203,7 @@ function ChartLine({ line, ...opts }: RenderOpts & { line: SongLine }) {
           <Text style={[chordStyleObj, { minHeight: chordLineHeight }]}>
             {cell.chords.join(' ') || ' '}
           </Text>
-          {cell.text ? <Text style={serif}>{cell.text}</Text> : <Text style={serif}> </Text>}
+          {cell.text ? <Text style={lyric}>{cell.text}</Text> : <Text style={lyric}> </Text>}
         </View>
       ))}
     </View>

--- a/apps/mobile/src/components/reader/TranslationPickerSheet.tsx
+++ b/apps/mobile/src/components/reader/TranslationPickerSheet.tsx
@@ -1,7 +1,6 @@
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import {
-  isRtlBibleLanguage,
   translationOptionLabel,
   type BibleTranslation,
   type BibleTranslationGroup,
@@ -11,8 +10,10 @@ import SymbolIcon from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
 
 // Translation picker (Daily Word). Grouped by language; the active translation
-// carries a checkmark and accent text. RTL languages (e.g. Arabic) right-align
-// their rows. Offline download state is out of scope this pass — selection only.
+// carries a checkmark and accent text. Rows always read left-to-right: the
+// option labels are English names/abbreviations (e.g. "Ketab El Hayat (KEH)")
+// even for RTL-script Bibles, so aligning them right would look wrong. Offline
+// download state is out of scope this pass — selection only.
 
 export default function TranslationPickerSheet({
   visible,
@@ -54,7 +55,6 @@ export default function TranslationPickerSheet({
             </Text>
             {group.translations.map((item) => {
               const selected = item.id === selectedId
-              const rtl = isRtlBibleLanguage(item.language)
               return (
                 <Pressable
                   key={item.id}
@@ -62,7 +62,7 @@ export default function TranslationPickerSheet({
                   accessibilityRole="button"
                   accessibilityState={{ selected }}
                   style={({ pressed }) => ({
-                    flexDirection: rtl ? 'row-reverse' : 'row',
+                    flexDirection: 'row',
                     alignItems: 'center',
                     gap: t.spacing.md,
                     paddingHorizontal: t.spacing.lg,
@@ -75,8 +75,8 @@ export default function TranslationPickerSheet({
                       flex: 1,
                       fontSize: 16,
                       letterSpacing: -0.2,
-                      textAlign: rtl ? 'right' : 'left',
-                      writingDirection: rtl ? 'rtl' : 'ltr',
+                      textAlign: 'left',
+                      writingDirection: 'ltr',
                       color: selected ? t.colors.textAccent : t.colors.ink,
                       fontWeight: selected ? '700' : '400',
                     }}


### PR DESCRIPTION
## Summary
Updates the chord chart component to use the system sans-serif font (SF Pro on iOS, Roboto on Android) for lyrics instead of serif, aligning with the rest of the app's typography. Also removes RTL-specific layout logic from the translation picker, since option labels are always English regardless of script direction.

## Changes

**ChordChart.tsx:**
- Replaced `CHART_SERIF` constant (Georgia on iOS, serif fallback elsewhere) with `CHART_LYRIC_FONT` set to `undefined`, which lets React Native use the platform system font
- Updated all lyric text styling to use the new `lyric` style object (renamed from `serif`)
- Updated comments to reflect the sans-serif choice and explain the font selection strategy

**TranslationPickerSheet.tsx:**
- Removed `isRtlBibleLanguage` import and RTL detection logic
- Removed conditional `flexDirection: rtl ? 'row-reverse' : 'row'` — now always `'row'`
- Removed conditional `textAlign` and `writingDirection` — now always `'left'` and `'ltr'`
- Updated comments to explain that option labels are English names/abbreviations, so left-to-right alignment is correct even for RTL-script Bibles

**viewer/[slug].tsx:**
- Updated import and comment references from `CHART_SERIF` to `CHART_LYRIC_FONT`

## Implementation Details
The system font approach (`undefined` fontFamily) is simpler and more maintainable than hardcoding platform-specific serif fonts, and ensures chord charts use the same typeface as the app chrome for visual consistency.

https://claude.ai/code/session_017pGaWqwniBar8xEkSgBmPD