### PR TITLE
docs: sync mobile app docs with shipped native features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ supabase/       SQL migrations
 ```
 
 - The web app lives in `apps/web/` (its `src/`, `public/`, `functions/`, `scripts/`, `index.html`, `vite.config.js`, `eslint.config.js`). Cloudflare Pages' root directory is `apps/web`. See [`MONOREPO_MIGRATION.md`](MONOREPO_MIGRATION.md) for the exact CF settings.
-- The Expo iOS app lives in `apps/mobile/` (`@gracechords/mobile`). It's a real native client (themed four-tab shell, Song Library + Home screens, an authenticated-only route gate), not just a scaffold.
+- The Expo iOS app lives in `apps/mobile/` (`@gracechords/mobile`). It's a real native client (themed four-tab shell, chord-chart Song Viewer, Performer mode, setlist builder, Daily Word reader, native Google/Apple auth, all behind an authenticated-only route gate), not just a scaffold.
 - Run web tasks from the repo root via the delegating scripts (`npm run dev`, `npm run build`, `npm run test`, `npm run lint` → `-w @gracechords/web`), or from inside `apps/web/`.
 - The repo root holds only the workspace `package.json` + lockfile, `packages/`, `apps/`, `workers/`, `supabase/`, and docs.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ GraceChords/
 | Workspace | Package | What it is |
 |-----------|---------|------------|
 | `apps/web` | `@gracechords/web` | The production single-page app: full song catalog, setlists, worship mode, admin/editor portals, Daily Word, resources. Deployed to Cloudflare Pages. |
-| `apps/mobile` | `@gracechords/mobile` | Native iOS client (Expo SDK 55, Expo Router v7). A themed four-tab shell with the Song Library and Home screens live; more screens in progress. |
+| `apps/mobile` | `@gracechords/mobile` | Native iOS client (Expo SDK 55, Expo Router v7). A themed four-tab shell (Home · Songs · Setlists · Daily Word) with a real chord-chart Song Viewer, Performer mode, the setlist builder, the Daily Word reader, and native Google/Apple auth. |
 | `packages/core` | `@gracechords/core` | Pure TypeScript/JS shared by both apps — ChordPro **parser** (not the renderer), transposition, chord placement, song metadata/sort, the setlist codec, the role hierarchy, and the Supabase client **factory**. Consumed as source, no build step. |
 | `packages/tokens` | `@gracechords/tokens` | The single home for design tokens. Web imports `tokens.css`; native imports the typed map from `@gracechords/tokens/native`. |
 | `workers/*` | — | Cloudflare Workers deployed independently: authenticated PPTX upload/delete, weekly sitemap rebuild, and the `@gracechords_bot` Telegram bot. |
@@ -90,8 +90,8 @@ permission matrix and the admin/editor portals.
 Current focus and planned work:
 
 - **Tablet-responsive web layout** — a proper master-detail experience on larger screens.
-- **Mobile app build-out** — flesh out the iOS client (Song Viewer with chord charts, Setlists, Daily Word/Reader, on-device history), then EAS Build / TestFlight.
-- **Android** — extend the Expo app to Android once the iOS surface stabilizes.
+- **Mobile app polish** — the iOS client's core flows ship (Song Viewer, Performer, Setlists, Daily Word, auth); next up are offline downloads, on-device history, and EAS Build / TestFlight.
+- **Android** — extend the Expo app to Android once the iOS surface stabilizes (Android OAuth config still to set up).
 - **GraceTracks integration** — surface practice stem tracks (`has_stems` / `stem_slug` / `gracetracks_url`) across web and mobile.
 - **Shared-core growth** — migrate more query/util logic into `@gracechords/core` as the mobile app needs it, keeping web and native in lockstep.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ permission matrix and the admin/editor portals.
 Current focus and planned work:
 
 - **Tablet-responsive web layout** — a proper master-detail experience on larger screens.
-- **Mobile app polish** — the iOS client's core flows ship (Song Viewer, Performer, Setlists, Daily Word, auth); next up are offline downloads, on-device history, and EAS Build / TestFlight.
+- **Mobile app polish** — the iOS client's core flows ship (Song Viewer, Performer, Setlists, Daily Word with offline Bible downloads, recent-song history, auth); next up are password reset, offline song persistence, and EAS Build / TestFlight.
 - **Android** — extend the Expo app to Android once the iOS surface stabilizes (Android OAuth config still to set up).
 - **GraceTracks integration** — surface practice stem tracks (`has_stems` / `stem_slug` / `gracetracks_url`) across web and mobile.
 - **Shared-core growth** — migrate more query/util logic into `@gracechords/core` as the mobile app needs it, keeping web and native in lockstep.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -37,8 +37,9 @@ the visual rather than porting the HTML/CSS.
   `react-native-gesture-handler` + `react-native-reanimated` (swipe-to-delete,
   transpose gestures), `expo-file-system` / `expo-sharing` / `expo-clipboard`
   (export + share sheet), `@react-native-google-signin/google-signin` +
-  `expo-apple-authentication` (native auth), and `expo-build-properties`
-  (`useFrameworks: static`, required by google-signin). Add Expo deps with
+  `expo-apple-authentication` (native auth), `expo-network` (Wi-Fi-only gate for
+  offline downloads), and `expo-build-properties` (`useFrameworks: static`,
+  required by google-signin). Add Expo deps with
   `npx expo install <pkg>`; if the Expo API is unreachable, pin the SDK-correct
   version from `node_modules/expo/bundledNativeModules.json` and `npm install`.
 
@@ -170,7 +171,7 @@ duplicate logic here and never edit core internals to suit mobile.
 ## Settings & defaults
 
 - **Settings** (`app/settings.tsx` → `SettingsScreen`) is a grouped screen:
-  profile card (→ sprite picker), theme, chord style, Offline & downloads (stub),
+  profile card (→ sprite picker), theme, chord style, Offline & downloads,
   library shortcuts, Help/Feedback, About, sign-out, and **Delete account**
   (`supabase.rpc('delete_user')`). The Language row is a static "English".
 - **App-wide defaults** live in `src/lib/defaults.ts` — `theme`
@@ -198,33 +199,51 @@ duplicate logic here and never edit core internals to suit mobile.
   `toKey`). Queries live in core's `setlistsRepo` (injected client); mobile hooks
   are `useSetlists`, `useSetlistBuilder` (debounced wipe-and-replace autosave),
   and `useLastSet` (Home's "Last set" card).
-- **Local history is stubbed.** `src/lib/recents.ts` (`getRecentlyOpened`) returns
-  empty and will be backed by an on-device history of opened songs — the Viewer
-  should record opens when that layer ships; consume the stub, don't mock data.
+- **Recently-opened history** is real and device-local. `src/lib/recents.ts`
+  follows the `defaults.ts` pattern: storage is injected (`KVStorage`), hydrated
+  once at splash, then `getRecentlyOpened()` is **synchronous** (Home reads it in
+  render, no flash). The Viewer calls `recordSongOpened()` on load — it dedupes by
+  slug, moves the entry to the front, and caps at 20 (`gc.recents.songs.v1` in
+  AsyncStorage, NOT Supabase-synced). Feeds Home's "Continue where you left off".
   Editable greeting phrases live in `src/lib/greetings.ts` (`SUB_GREETINGS`).
 - **Daily Word / Reader** reads the day's M'Cheyne passages from Cloudflare R2.
   Shared, DOM-free logic (plan lookup, reading expansion, translation manifest,
   RTL, chapter/copy helpers) lives in core's `bible` module (`@gracechords/core`),
   base-URL injected. `src/lib/bibleSource.ts` is the **single source seam**
-  (`getPassage`/`getTranslations`) that reads R2 now via `EXPO_PUBLIC_R2_PUBLIC_URL`
-  (default `https://assets.gracechords.com`); a local offline-download source is
-  meant to slot in behind it later (branch stubbed, not wired). Hooks:
+  (`getPassage`/`getTranslations`) via `EXPO_PUBLIC_R2_PUBLIC_URL`
+  (default `https://assets.gracechords.com`); it now reads **offline-first** —
+  `getPassage` returns a downloaded chapter blob when one exists (see the
+  downloads module below) and falls back to R2 otherwise. Hooks:
   `useBibleTranslations`, `usePassageChapter` (`src/lib/useReader.ts`). Reader
   settings (size/typeface/layout/spacing) are **session-ephemeral** — not tied to
   Settings, so they reset on relaunch. **Follow-up:** `apps/web`'s
   `features/readings` + `utils/bible` still hold their own copy of this logic;
   migrate web onto core's `bible` module to remove the duplication.
+- **Offline downloads** (`src/lib/downloads/`, reached from Settings →
+  `OfflineDownloadsScreen`) let users save a **whole Bible translation** for
+  offline reading — every chapter is enumerated up front from core's
+  `BOOK_CHAPTER_COUNTS` (`packages/core/src/bible/chapterCounts.ts`), fetched from
+  R2, and written as on-device blobs (`expo-file-system`). The pure logic
+  (`downloader`, `manifest`, `resolver`, `staleness`) is **dependency-injected**
+  so it unit-tests headless with `memoryBlobStore`; `service.ts` wires the real
+  `expoBlobStore` + `fetch` + `expo-network`. State lives in a manifest
+  (`gc.downloads.v1`, same injected-storage/`useSyncExternalStore` pattern as
+  `defaults.ts`): completed downloads keyed by translation id + a **"Wi-Fi only"**
+  preference (enforced via `expo-network`, raising `WifiRequiredError`). Downloads
+  report progress, can be cancelled (`AbortToken`), retry transient failures with
+  backoff, and are **local-only** to delete (never touches Supabase). `getPassage`
+  in `bibleSource.ts` reads a downloaded chapter before falling back to R2.
+  Staleness compares the stored translations `version` against the live manifest.
 
 ## Out of scope (for now)
 
 The whole-set **Charts ZIP / ChordPro** export backends (whole-set PDF ships via
 `/api/export/setlist`; the ZIP/ChordPro tiles render disabled), **offline
-downloads / file management** (`OfflineDownloadsScreen` is a stub EmptyState and
-`bibleSource.ts`'s offline branch is commented out — the Reader needs network),
-the **on-device history** layer (`recents.ts` returns empty, so Home's "Continue"
-card never shows), the Song Library **"Add song"** button (a no-op) and Settings
-**Language** picker (static "English"), **password reset / email-confirmation**
-screens (the login "Forgot?" link is an informational alert only), tablet
-master-detail, EAS Build / TestFlight, Android (auth code is cross-platform-safe,
-but Android OAuth config — SHA-1, google-services — is not set up), GraceTracks,
-and migrating web's `features/readings` onto core's `bible` module.
+downloads for songs** (Bible-translation downloads ship — see the downloads
+module above — but on-device song/setlist persistence does not), the Song Library
+**"Add song"** button (a no-op) and Settings **Language** picker (static
+"English"), **password reset / email-confirmation** screens (the login "Forgot?"
+link is an informational alert only), tablet master-detail, EAS Build /
+TestFlight, Android (auth code is cross-platform-safe, but Android OAuth config —
+SHA-1, google-services — is not set up), GraceTracks, and migrating web's
+`features/readings` onto core's `bible` module.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -7,9 +7,14 @@ doc first.
 
 ## What this is
 
-A native (Expo / React Native) client for GraceChords. It carries real UI built
-from the design reference: a themed four-tab shell, the **Song Library** and
-**Home** screens, a placeholder **Song Viewer** route, and an
+A native (Expo / React Native) client for GraceChords, built from the design
+reference. The core worship-team flows all ship: a themed four-tab shell (Home ·
+Songs · Setlists · Daily Word), a full **Song Viewer** (real chord chart —
+transpose, key change, accidentals, view options, star, export/share), a
+**Performer** setlist play-through, the **Setlist Builder** (autosave, key
+overrides, sharing, whole-set PDF), the **Daily Word / Reader** (M'Cheyne plan,
+translations, highlights), native **Google/Apple auth** with a sprite avatar
+picker, and a grouped **Settings** screen — all behind an
 **authenticated-only** route gate. Build new screens on the shared theme +
 primitives below — don't add one-off styles or hardcoded colors where a
 primitive/token fits.
@@ -27,8 +32,13 @@ the visual rather than porting the HTML/CSS.
 - **Continuous Native Generation (CNG).** `ios/` and `android/` are **gitignored
   and never committed** — regenerate them with `npx expo prebuild`. Treat
   `app.json` (+ config plugins) as the source of truth for native config.
-- **UI deps:** `expo-symbols` (SF Symbols), `expo-linear-gradient` (the Home
-  hero), `expo-splash-screen` (auth-gate hold). Add Expo deps with
+- **UI/native deps:** `expo-symbols` (SF Symbols), `expo-linear-gradient` (the
+  Home hero), `expo-splash-screen` (auth-gate hold), `expo-haptics`,
+  `react-native-gesture-handler` + `react-native-reanimated` (swipe-to-delete,
+  transpose gestures), `expo-file-system` / `expo-sharing` / `expo-clipboard`
+  (export + share sheet), `@react-native-google-signin/google-signin` +
+  `expo-apple-authentication` (native auth), and `expo-build-properties`
+  (`useFrameworks: static`, required by google-signin). Add Expo deps with
   `npx expo install <pkg>`; if the Expo API is unreachable, pin the SDK-correct
   version from `node_modules/expo/bundledNativeModules.json` and `npm install`.
 
@@ -104,10 +114,13 @@ duplicate logic here and never edit core internals to suit mobile.
 
 - `app/(tabs)/_layout.tsx` — the four-tab shell (Home · Songs · Setlists · Daily
   Word), `headerShown:false` (screens draw their own large-title headers).
-- `app/viewer/[slug].tsx` — Song Viewer, **outside** the tab group (pushes over the
-  shell); currently a placeholder. `app/login.tsx` — the auth screen (sign in +
-  sign up modes in `src/screens/AuthScreen.tsx`); `app/choose-icon.tsx` — the
-  post-signup sprite avatar picker.
+- Routes **outside** the tab group push over the shell: `app/viewer/[slug].tsx`
+  (Song Viewer — real chord chart), `app/perform/[id].tsx` (Performer / setlist
+  play-through → `PerformerScreen`), `app/setlist/[id].tsx` (Setlist Builder),
+  `app/settings.tsx`, `app/about.tsx`, and `app/offline.tsx` (Offline &
+  downloads — scaffolded, no download logic yet). `app/login.tsx` — the auth
+  screen (sign in + sign up modes in `src/screens/AuthScreen.tsx`);
+  `app/choose-icon.tsx` — the post-signup sprite avatar picker.
 - **Authenticated-only.** `app/_layout.tsx` gates every route on the Supabase
   session (redirect to `/login` when signed out, into the tabs when signed in) and
   holds the native splash (`expo-splash-screen`) until the session resolves *and*
@@ -128,15 +141,58 @@ duplicate logic here and never edit core internals to suit mobile.
   (`src/lib/profile.ts`) — the same JSONB shape the web Profile page writes; ids in
   `src/lib/sprites.ts` must stay in sync with web's `SpritePicker.jsx`.
 
+## Song Viewer, Performer & export
+
+- **Song Viewer** (`app/viewer/[slug].tsx` + `src/components/ChordChart.tsx`)
+  renders a parsed `SongDoc` (core `parseChordProOrLegacy`): word-anchored chords
+  over lyrics, per-symbol transpose + chord style at render, `RawFallback` when a
+  parse yields nothing. Controls: floating `TransposeBar` (±1 semitone, haptic),
+  `ViewOptionsSheet` (chords/lyrics · section labels · font scale 80–160% · chord
+  style Letters/Solfège · sharp/flat accidentals · "Hide controls when idle"),
+  `StarButton`, and `ExportSheet`. Transpose/accidentals/chord-style are
+  **ephemeral** per open; only "Hide controls when idle" persists (separately, in
+  `src/lib/autoHideChrome.ts`). Opening from a setlist seeds transpose via the
+  `initialKey` route param.
+- **Performer** (`app/perform/[id].tsx` → `PerformerScreen`) runs a set one song
+  at a time (Prev/Next, swipe, tappable progress rail), prefetches every song
+  body, and reuses the same chart/transpose/view-options. Its
+  `PerformerShareSheet` has a This-song / Whole-set scope toggle — whole-set PDF
+  works here (not in the builder's `ShareSetSheet`).
+- **Export/share** is server-side via the web app's Pages Functions (base
+  `EXPO_PUBLIC_API_BASE_URL`, `src/lib/api.ts`): `src/lib/exportSong.ts` calls
+  `POST /api/export/song` (PDF, or a page-1 PNG for `jpg`) and
+  `POST /api/export/setlist` (whole-set PDF); bytes are cached with
+  `expo-file-system` and handed to the system share sheet via `expo-sharing`.
+  `src/lib/telegramPush.ts` posts to `/api/telegram/push` (song + setlist,
+  batched at 25; 409 → "link your Telegram" alert). **Charts ZIP / ChordPro
+  export backends don't exist anywhere** — those tiles render disabled.
+
+## Settings & defaults
+
+- **Settings** (`app/settings.tsx` → `SettingsScreen`) is a grouped screen:
+  profile card (→ sprite picker), theme, chord style, Offline & downloads (stub),
+  library shortcuts, Help/Feedback, About, sign-out, and **Delete account**
+  (`supabase.rpc('delete_user')`). The Language row is a static "English".
+- **App-wide defaults** live in `src/lib/defaults.ts` — `theme`
+  (`system`/`light`/`dark`) and `chordStyle` (`letters`/`solfege`), **device-local
+  in AsyncStorage, not Supabase-synced**. Storage is injected (KVStorage, like
+  `profile.ts`) so the module is RN-free and unit-tested. Hydrated once at the
+  splash hold; `getDefaultsSnapshot()` is then synchronous and `useAppDefaults()`
+  (a `useSyncExternalStore` hook) re-renders the ThemeProvider and Settings.
+  Viewer/Performer seed their chord style read-on-open; in-session changes don't
+  write back.
+
 ## Data & stubs
 
 - Song data uses core's `fetchSongList` (widen columns via its `opts.columns`);
   screen data hooks live in `src/lib/` (`useSongList`, `useStarredSongs`).
 - **Stars** are per-user Supabase data — table `user_starred_songs` (`song_id` is a
-  uuid FK to `songs.id`, RLS-scoped to `auth.uid()`). `useStarredSongs` reads them
-  via an inline joined query (read-only for now; starring/unstarring is later). This
-  inline query is the **one sanctioned exception** to "queries live in core" — kept
-  in mobile to avoid a core change; promote it to core when stars grow.
+  uuid FK to `songs.id`, RLS-scoped to `auth.uid()`). `useStarredSongs` reads the
+  list via an inline joined query; `useSongStar` reads/writes a single song's star
+  optimistically (upsert/delete, revert on failure) behind the Viewer's
+  `StarButton`. These inline queries are the **one sanctioned exception** to
+  "queries live in core" — kept in mobile to avoid a core change; promote them to
+  core when stars grow.
 - **Setlists are per-user Supabase data** — tables `setlists` / `setlist_songs`
   (per-entry key override in `setlist_songs.key_override`, exposed app-side as
   `toKey`). Queries live in core's `setlistsRepo` (injected client); mobile hooks
@@ -161,11 +217,14 @@ duplicate logic here and never edit core internals to suit mobile.
 
 ## Out of scope (for now)
 
-The whole-set Charts ZIP / ChordPro export backends (whole-set PDF ships via
-`/api/export/setlist`), the Daily Word **landing page** and **offline
-translation download / file management** (the Reader itself ships; downloads are
-a later stage), the on-device history layer + star writes,
-password reset / email-confirmation screens (the login "Forgot?" link is an
-informational alert only), tablet master-detail, EAS Build / TestFlight,
-Android (auth code is cross-platform-safe, but Android OAuth config — SHA-1,
-google-services — is not set up), GraceTracks.
+The whole-set **Charts ZIP / ChordPro** export backends (whole-set PDF ships via
+`/api/export/setlist`; the ZIP/ChordPro tiles render disabled), **offline
+downloads / file management** (`OfflineDownloadsScreen` is a stub EmptyState and
+`bibleSource.ts`'s offline branch is commented out — the Reader needs network),
+the **on-device history** layer (`recents.ts` returns empty, so Home's "Continue"
+card never shows), the Song Library **"Add song"** button (a no-op) and Settings
+**Language** picker (static "English"), **password reset / email-confirmation**
+screens (the login "Forgot?" link is an informational alert only), tablet
+master-detail, EAS Build / TestFlight, Android (auth code is cross-platform-safe,
+but Android OAuth config — SHA-1, google-services — is not set up), GraceTracks,
+and migrating web's `features/readings` onto core's `bible` module.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -10,52 +10,78 @@ conventions (theme/primitives, SF Symbols, auth gating, Metro resolution).
 
 ## What it is today
 
-A real (if still-growing) native client, built from the
-[`gc-ios-design-reference/`](../../gc-ios-design-reference/) design bundle:
+A real, feature-complete-enough-to-use native client, built from the
+[`gc-ios-design-reference/`](../../gc-ios-design-reference/) design bundle. The
+core worship-team flows all ship:
 
-- a themed **four-tab shell** (Home · Songs · Setlists · Daily Word),
-- the **Song Library** and **Home** screens,
-- a placeholder **Song Viewer** route, and
-- an **authenticated-only** route gate (redirects to login when signed out).
+- a themed **four-tab shell** — Home · Songs · Setlists · Daily Word,
+- a **Song Viewer** with a real chord chart: live transpose, key change,
+  sharp/flat accidentals toggle, view options (chords/lyrics, section labels,
+  font scale, letters/solfège), favorite star, and export/share,
+- a **Performer** (setlist play-through) screen — the native worship-mode analog,
+- **Setlists**: list, builder with debounced autosave and drag reorder,
+  swipe-to-delete, per-song key overrides, sharing, and whole-set PDF export,
+- a **Daily Word / Reader** — the M'Cheyne daily plan with translation picker,
+  reader settings, and day-scoped highlight persistence,
+- **auth** with email/password plus native **Google** and **Apple** sign-in, a
+  post-signup sprite avatar picker, and an **authenticated-only** route gate,
+- a grouped **Settings** screen with app-wide theme and chord-style defaults, an
+  **About** screen, sign-out, and account deletion.
 
-More screens are in progress — see [Roadmap](#roadmap) below.
+A few things are still stubs or later stages — see [Roadmap](#roadmap).
 
 - **Stack:** Expo SDK 55, Expo Router v7, TypeScript, React 19.2 / React Native 0.83.
-- **Native dirs:** `ios/` and `android/` use Continuous Native Generation — they are gitignored and regenerated via `npx expo prebuild`. Never commit them; treat `app.json` as the source of truth for native config.
-- **Theme:** the typed token map from `@gracechords/tokens/native` (iOS light/dark palette), consumed via `useTheme()`.
+- **Native dirs:** `ios/` and `android/` use Continuous Native Generation — they are gitignored and regenerated via `npx expo prebuild`. Never commit them; treat `app.json` (+ config plugins) as the source of truth for native config.
+- **Theme:** the typed token map from `@gracechords/tokens/native` (iOS light/dark palette), consumed via `useTheme()`. Icons are **SF Symbols only**.
+- **Backends:** Supabase (auth, stars, setlists) via core's `createGcSupabase`; the web app's Pages Functions for song/setlist **export** and **Telegram** push; Cloudflare R2 for **Daily Word** Bible JSON.
 
 ## Run it (macOS + Xcode required for the simulator)
 
 ```bash
 cd apps/mobile
-cp .env.example .env        # fill in the public Supabase URL + anon key
+cp .env.example .env        # fill in the public Supabase URL + anon key (and more)
 npx expo run:ios            # prebuild + build + launch on the iOS simulator
 ```
 
 Without a Mac you can still verify the JS bundle (resolution + transpile of the
-TS core) on any OS:
+TS core) and the RN-free logic on any OS:
 
 ```bash
 npm run export:ios          # expo export --platform ios (Metro only, no Xcode)
 npm run typecheck           # tsc --noEmit
+npm run test                # vitest over src/lib logic (auth, defaults, profile)
 npm run start               # Metro dev server
 ```
 
-Env vars (`EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_ANON_KEY`) use the
-**public anon** key — the same one the web client uses, never the service-role
-key. Mirror any new `EXPO_PUBLIC_*` var into `.env.example`.
+### Environment
+
+All app config comes from `apps/mobile/.env` (see `.env.example` for the full,
+annotated list). The Supabase vars use the **public anon** key — the same one
+the web client uses, never the service-role key. Mirror any new `EXPO_PUBLIC_*`
+var into `.env.example` in the same commit.
+
+- `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` — auth + data.
+- `EXPO_PUBLIC_API_BASE_URL` — deployed web app; mobile calls its Pages
+  Functions for export (`/api/export/song`, `/api/export/setlist`) and Telegram
+  push (`/api/telegram/push`). Use the canonical (non-redirecting) domain.
+- `EXPO_PUBLIC_R2_PUBLIC_URL` — Cloudflare R2 base for Daily Word Bible JSON
+  (defaults to `https://assets.gracechords.com`).
+- `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` / `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` —
+  native Google Sign-In (the reversed iOS client id also goes in `app.json`).
 
 ## Roadmap
 
-Out of scope in the current build, in rough priority order:
+Not yet in the build, in rough priority order:
 
-- The real **Song Viewer** (chord chart rendering).
-- The **Setlists** and **Daily Word / Reader** screens (placeholders today).
-- On-device **history / setlist storage** and star writes (reads are wired; `src/lib/recents.ts` is stubbed).
-- Auth screen redesign / **Google OAuth** (see `TODO: OAuth` in `src/screens/LoginScreen.tsx`).
+- **Offline downloads** — on-device song/reading persistence and file management
+  (`OfflineDownloadsScreen` is scaffolded; `bibleSource.ts` has the source seam).
+- On-device **history** — Home's "Continue where you left off" card
+  (`src/lib/recents.ts` is stubbed).
+- **Password reset / email-confirmation** screens (login "Forgot?" is an alert).
 - **Tablet** master-detail layout.
 - **EAS Build / TestFlight** distribution.
-- **Android** support.
+- **Android** — auth code is cross-platform-safe, but Android OAuth config
+  (SHA-1, `google-services`) is not set up.
 - **GraceTracks** practice-stem integration.
 
 See [`AGENTS.md`](./AGENTS.md) for the conventions that keep new screens

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -22,7 +22,8 @@ core worship-team flows all ship:
 - **Setlists**: list, builder with debounced autosave and drag reorder,
   swipe-to-delete, per-song key overrides, sharing, and whole-set PDF export,
 - a **Daily Word / Reader** — the M'Cheyne daily plan with translation picker,
-  reader settings, and day-scoped highlight persistence,
+  reader settings, day-scoped highlight persistence, and **offline downloads**
+  (save a whole Bible translation to the device; the reader reads it offline-first),
 - **auth** with email/password plus native **Google** and **Apple** sign-in, a
   post-signup sprite avatar picker, and an **authenticated-only** route gate,
 - a grouped **Settings** screen with app-wide theme and chord-style defaults, an
@@ -73,10 +74,8 @@ var into `.env.example` in the same commit.
 
 Not yet in the build, in rough priority order:
 
-- **Offline downloads** — on-device song/reading persistence and file management
-  (`OfflineDownloadsScreen` is scaffolded; `bibleSource.ts` has the source seam).
-- On-device **history** — Home's "Continue where you left off" card
-  (`src/lib/recents.ts` is stubbed).
+- **Offline downloads for songs/setlists** — on-device persistence beyond Bible
+  translations (Daily Word translation downloads already ship).
 - **Password reset / email-confirmation** screens (login "Forgot?" is an alert).
 - **Tablet** master-detail layout.
 - **EAS Build / TestFlight** distribution.

--- a/apps/mobile/app/offline.tsx
+++ b/apps/mobile/app/offline.tsx
@@ -1,6 +1,6 @@
 import OfflineDownloadsScreen from '../src/screens/OfflineDownloadsScreen'
 
-// Offline & downloads — pushed from Settings (stubbed until Stage 3).
+// Offline & downloads — pushed from Settings (Bible-translation downloads).
 export default function Offline() {
   return <OfflineDownloadsScreen />
 }

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -66,7 +66,7 @@ export default function HomeScreen() {
   const greeting = `${timeGreeting()}, ${getDisplayName(user)}`
   const subGreeting = pickSubGreeting()
 
-  // Recently-opened is still a stub (the Viewer's local history ships later);
+  // Recently-opened comes from on-device history (recorded by the Viewer);
   // the Last set card reads the real most-recently-edited setlist.
   const continueSong = getRecentlyOpened()[0] ?? null
   const { lastSet } = useLastSet()

--- a/apps/web/public/wiki/Mobile-App.md
+++ b/apps/web/public/wiki/Mobile-App.md
@@ -13,7 +13,8 @@ core worship-team flows end to end:
 - **Setlists** — a builder with debounced autosave, drag reorder,
   swipe-to-delete, per-song key overrides, sharing, and whole-set PDF export,
 - a **Daily Word / Reader** — the M'Cheyne daily plan with a translation picker,
-  reader settings, and highlights that persist for the day,
+  reader settings, highlights that persist for the day, and **offline downloads**
+  (save a whole Bible translation to the device; the reader reads it offline-first),
 - **auth** with email/password plus native **Google** and **Apple** sign-in, a
   post-signup **sprite avatar** picker, and an **authenticated-only** route gate,
 - a grouped **Settings** screen with app-wide theme and chord-style defaults, an
@@ -38,8 +39,7 @@ Without a Mac, verify the JS bundle and RN-free logic on any OS with
 `npm run export:ios`, `npm run typecheck`, and `npm run test`.
 
 ## Roadmap
-- **Offline downloads** — on-device song/reading persistence and file management (the screen is scaffolded; the Reader currently needs network).
-- On-device **history** — Home's "Continue where you left off" card.
+- **Offline downloads for songs/setlists** — on-device persistence beyond Bible translations (Daily Word translation downloads already ship).
 - **Password reset / email-confirmation** screens.
 - **Tablet** master-detail layout.
 - **EAS Build / TestFlight** distribution, then **Android** (Android OAuth config is not set up yet).

--- a/apps/web/public/wiki/Mobile-App.md
+++ b/apps/web/public/wiki/Mobile-App.md
@@ -2,43 +2,53 @@ The GraceChords native iOS app — an Expo / React Native client that shares the
 same `@gracechords/core` logic and Supabase backend as the web app.
 
 ## What it is today
-Built from the `gc-ios-design-reference/` design bundle, the app currently ships:
-- a themed **four-tab shell** (Home · Songs · Setlists · Daily Word),
-- the **Song Library** and **Home** screens,
-- a placeholder **Song Viewer** route, and
-- an **authenticated-only** route gate (redirects to login when signed out).
+Built from the `gc-ios-design-reference/` design bundle, the app now covers the
+core worship-team flows end to end:
+- a themed **four-tab shell** — Home · Songs · Setlists · Daily Word,
+- a **Song Viewer** with a real chord chart — live transpose, key change,
+  sharp/flat accidentals, view options (chords/lyrics, section labels, font
+  scale, letters/solfège), a favorite star, and PDF/JPG export + share,
+- a **Performer** screen that runs a setlist one song at a time (swipe, progress
+  rail, per-song key),
+- **Setlists** — a builder with debounced autosave, drag reorder,
+  swipe-to-delete, per-song key overrides, sharing, and whole-set PDF export,
+- a **Daily Word / Reader** — the M'Cheyne daily plan with a translation picker,
+  reader settings, and highlights that persist for the day,
+- **auth** with email/password plus native **Google** and **Apple** sign-in, a
+  post-signup **sprite avatar** picker, and an **authenticated-only** route gate,
+- a grouped **Settings** screen with app-wide theme and chord-style defaults, an
+  **About** screen, sign-out, and account deletion.
 
-It's a real, growing native client — not just a scaffold — but several screens
-are still placeholders (see [Roadmap](#roadmap)).
+A few pieces are still stubs or later stages (see [Roadmap](#roadmap)).
 
 ## Stack
 - **Expo SDK 55**, **Expo Router v7**, TypeScript, React Native 0.83.
 - **Theme:** the typed token map from `@gracechords/tokens/native` (iOS light/dark palette), consumed via `useTheme()`. Icons are **SF Symbols only** (iOS/iPadOS).
 - **Native dirs** (`ios/`, `android/`) use Continuous Native Generation — gitignored, regenerated via `npx expo prebuild`. `app.json` is the source of truth for native config.
-- **Auth/data:** Supabase via core's `createGcSupabase` factory; the public anon key, stored with AsyncStorage; token refresh driven by `AppState`.
+- **Backends:** Supabase (auth, stars, setlists) via core's `createGcSupabase` factory — the public anon key, stored with AsyncStorage, token refresh driven by `AppState`; the web app's **Pages Functions** for song/setlist export and Telegram push; Cloudflare **R2** for Daily Word Bible JSON.
 
 ## Running it
 Requires macOS + Xcode for the simulator:
 ```bash
 cd apps/mobile
-cp .env.example .env        # public Supabase URL + anon key
+cp .env.example .env        # public Supabase URL + anon key, API base, Google client ids
 npx expo run:ios
 ```
-Without a Mac, verify the JS bundle on any OS with `npm run export:ios` and
-`npm run typecheck`.
+Without a Mac, verify the JS bundle and RN-free logic on any OS with
+`npm run export:ios`, `npm run typecheck`, and `npm run test`.
 
 ## Roadmap
-- The real **Song Viewer** (chord chart rendering)
-- **Setlists** and **Daily Word / Reader** screens (placeholders today)
-- On-device **history / setlist storage** and star writes
-- Auth screen redesign / **Google OAuth**
-- **Tablet** master-detail layout
-- **EAS Build / TestFlight** distribution, then **Android**
-- **GraceTracks** practice-stem integration
+- **Offline downloads** — on-device song/reading persistence and file management (the screen is scaffolded; the Reader currently needs network).
+- On-device **history** — Home's "Continue where you left off" card.
+- **Password reset / email-confirmation** screens.
+- **Tablet** master-detail layout.
+- **EAS Build / TestFlight** distribution, then **Android** (Android OAuth config is not set up yet).
+- **GraceTracks** practice-stem integration.
 
 ## For developers
 Conventions (theme, primitives, SF Symbols, auth gating, Metro monorepo
-resolution, Supabase wiring) live in `apps/mobile/AGENTS.md`. Shared logic must be
-added to `@gracechords/core` as additive exports — never duplicated in the app.
+resolution, Supabase wiring, export/Telegram, defaults) live in
+`apps/mobile/AGENTS.md`. Shared logic must be added to `@gracechords/core` as
+additive exports — never duplicated in the app.
 
 [[Project-Structure]] [[Roles-and-Access]] [[Getting-Started]]

--- a/apps/web/public/wiki/Project-Structure.md
+++ b/apps/web/public/wiki/Project-Structure.md
@@ -46,8 +46,10 @@ The production single-page app.
 tokens from `packages/tokens/tokens.css` (imported via `src/styles/index.css`).
 
 ## `apps/mobile/`
-The native iOS client — a themed four-tab shell with the Song Library and Home
-screens, built on the shared core. See [[Mobile-App]] for details.
+The native iOS client — a themed four-tab shell (Home · Songs · Setlists · Daily
+Word) with a chord-chart Song Viewer, Performer mode, the setlist builder, the
+Daily Word reader, and native Google/Apple auth, built on the shared core. See
+[[Mobile-App]] for details.
 
 ## `packages/core/` (`@gracechords/core`)
 Pure TypeScript/JS shared by both apps, consumed as source with no build step:


### PR DESCRIPTION
The native iOS app now ships the core worship-team flows (real chord-chart
Song Viewer, Performer mode, setlist builder, Daily Word reader, native
Google/Apple auth, grouped Settings + app-wide defaults, star writes,
PDF/JPG/Telegram export/share). The docs still described it as an early
scaffold with a placeholder viewer and those features as roadmap items.

- apps/mobile/README.md, apps/mobile/AGENTS.md: rewrite "what this is",
  document Viewer/Performer/export/Settings/defaults, expand the dependency
  list, correct stars to read+write, refresh the out-of-scope/roadmap list.
- Mobile-App.md, Project-Structure.md (wiki): match the shipped feature set.
- Root README.md + AGENTS.md: update the workspace table, mobile summary,
  and roadmap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MKtvnGokFid3t683gRp7Lg