### PR TITLE
Add "keep screen awake" toggle to Song Viewer & Performer

### DIFF
--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -34,7 +34,8 @@ import { pushSongToTelegram, TELEGRAM_BOT_URL } from '../../src/lib/telegramPush
 import { useSong } from '../../src/lib/useSong'
 import { recordSongOpened } from '../../src/lib/recents'
 import { useAutoHideChrome, useAutoHidePref } from '../../src/lib/autoHideChrome'
-import { getDefaultsSnapshot } from '../../src/lib/defaults'
+import { getDefaultsSnapshot, setDefaultKeepAwake, useAppDefaults } from '../../src/lib/defaults'
+import { useKeepAwakeWhileFocused } from '../../src/lib/keepAwake'
 import { useTheme } from '../../src/theme/ThemeProvider'
 
 // Song Viewer. Pass 1 built the static monospaced chart; pass 2 adds the live
@@ -123,6 +124,10 @@ export default function ViewerScreen() {
   // Chrome auto-hide (persisted preference). Pinned visible while a sheet is
   // open so it can't hide behind one. Tap the chart to bring it back.
   const [autoHide, setAutoHide] = useAutoHidePref()
+  // Keep-awake: shared persisted preference (defaults store), engaged only while
+  // this screen is focused so it never holds the lock in the background.
+  const { keepAwake } = useAppDefaults()
+  useKeepAwakeWhileFocused(keepAwake)
   // Only arm auto-hide when there's a chart to tap (tap-to-reveal lives on the
   // chart); otherwise the header could hide with no way to bring it back.
   const { visible: chromeVisible, opacity: chromeOpacity, reveal } = useAutoHideChrome(
@@ -377,6 +382,8 @@ export default function ViewerScreen() {
         onAccidental={setAccidentalManual}
         autoHide={autoHide}
         onAutoHide={setAutoHide}
+        keepAwake={keepAwake}
+        onKeepAwake={setDefaultKeepAwake}
       />
       <ExportSheet
         visible={sheet === 'export'}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,6 +27,7 @@
     "expo-crypto": "~55.0.16",
     "expo-file-system": "~55.0.23",
     "expo-haptics": "~55.0.15",
+    "expo-keep-awake": "~55.0.8",
     "expo-linear-gradient": "~55.0.15",
     "expo-linking": "~55.0.16",
     "expo-network": "~55.0.15",

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -102,6 +102,8 @@ export default function ViewOptionsSheet({
   onAccidental,
   autoHide,
   onAutoHide,
+  keepAwake,
+  onKeepAwake,
 }: {
   visible: boolean
   onClose: () => void
@@ -120,6 +122,10 @@ export default function ViewOptionsSheet({
   // wires it (Song Viewer + Setlist Performer).
   autoHide?: boolean
   onAutoHide?: (v: boolean) => void
+  // Optional "keep screen awake" toggle — persisted shared preference, rendered
+  // only when the screen wires it (Song Viewer + Setlist Performer).
+  keepAwake?: boolean
+  onKeepAwake?: (v: boolean) => void
 }) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
@@ -249,23 +255,39 @@ export default function ViewOptionsSheet({
           </>
         ) : null}
 
-        {/* Hide controls when idle — persists across launches (unlike the
-            options above). Rendered only when the screen wires it. */}
+        {/* Screen preferences — persist across launches (unlike the options
+            above). Each row renders only when the screen wires it. */}
+        {onAutoHide || onKeepAwake ? <OverlineLabel>Screen</OverlineLabel> : null}
         {onAutoHide ? (
-          <>
-            <OverlineLabel>Screen</OverlineLabel>
-            <View
-              style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
-            >
-              <Text style={{ fontSize: 16, color: t.colors.ink }}>Hide controls when idle</Text>
-              <Switch
-                value={!!autoHide}
-                onValueChange={onAutoHide}
-                trackColor={{ true: t.colors.accent }}
-                accessibilityLabel="Hide controls when idle"
-              />
-            </View>
-          </>
+          <View
+            style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
+          >
+            <Text style={{ fontSize: 16, color: t.colors.ink }}>Hide controls when idle</Text>
+            <Switch
+              value={!!autoHide}
+              onValueChange={onAutoHide}
+              trackColor={{ true: t.colors.accent }}
+              accessibilityLabel="Hide controls when idle"
+            />
+          </View>
+        ) : null}
+        {onKeepAwake ? (
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginTop: onAutoHide ? t.spacing.xl : 0,
+            }}
+          >
+            <Text style={{ fontSize: 16, color: t.colors.ink }}>Keep screen awake</Text>
+            <Switch
+              value={!!keepAwake}
+              onValueChange={onKeepAwake}
+              trackColor={{ true: t.colors.accent }}
+              accessibilityLabel="Keep screen awake"
+            />
+          </View>
         ) : null}
       </View>
     </BottomSheet>

--- a/apps/mobile/src/components/setlist/ShareSetSheet.tsx
+++ b/apps/mobile/src/components/setlist/ShareSetSheet.tsx
@@ -6,23 +6,25 @@ import SymbolIcon, { type SymbolIconProps } from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
 
 // The setlist "Export & share" sheet (modeled on the viewer's ExportSheet).
-// Copy link and Telegram work today; the set-PDF / Charts ZIP / ChordPro
-// exports need backend endpoints that don't exist yet, so those tiles render
-// disabled as "Coming soon" (a later pass, alongside the Setlist Viewer's
-// export work).
+// Set PDF, Copy link, and Telegram work today (the same combined-PDF export the
+// Performer uses, via /api/export/setlist). Only the Charts ZIP / ChordPro
+// exports still need backend endpoints that don't exist yet, so those two tiles
+// render disabled as "Coming soon".
 
-type Busy = 'link' | 'telegram' | null
+type Busy = 'pdf' | 'link' | 'telegram' | null
 
 export default function ShareSetSheet({
   visible,
   onClose,
   songCount,
+  onExport,
   onCopyLink,
   onTelegram,
 }: {
   visible: boolean
   onClose: () => void
   songCount: number
+  onExport: () => Promise<void>
   onCopyLink: () => Promise<void>
   onTelegram: () => Promise<void>
 }) {
@@ -70,9 +72,12 @@ export default function ShareSetSheet({
       closeAccessibilityLabel="Close export and share"
     >
       <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.md }}>
-        {/* Primary set-PDF export — endpoint not built yet. */}
-        <View
-          accessibilityLabel="Export set as PDF — coming soon"
+        {/* Primary set-PDF export — combined PDF via /api/export/setlist. */}
+        <Pressable
+          onPress={run('pdf', onExport)}
+          disabled={!!busy}
+          accessibilityRole="button"
+          accessibilityLabel="Export set as PDF"
           style={{
             height: 50,
             borderRadius: 13,
@@ -81,14 +86,18 @@ export default function ShareSetSheet({
             alignItems: 'center',
             justifyContent: 'center',
             gap: t.spacing.sm,
-            opacity: 0.45,
+            opacity: busy && busy !== 'pdf' ? 0.5 : 1,
           }}
         >
-          <SymbolIcon name="square.and.arrow.down" size={19} color={t.colors.onAccent} />
+          {busy === 'pdf' ? (
+            <ActivityIndicator color={t.colors.onAccent} />
+          ) : (
+            <SymbolIcon name="square.and.arrow.down" size={19} color={t.colors.onAccent} />
+          )}
           <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.onAccent }}>
-            Export set as PDF · {songCount} {songCount === 1 ? 'song' : 'songs'} (soon)
+            Export set as PDF · {songCount} {songCount === 1 ? 'song' : 'songs'}
           </Text>
-        </View>
+        </Pressable>
 
         <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
           {disabledTile('Charts ZIP', 'folder')}

--- a/apps/mobile/src/lib/__tests__/defaults.test.ts
+++ b/apps/mobile/src/lib/__tests__/defaults.test.ts
@@ -6,6 +6,7 @@ import {
   initialChordStyle,
   resolveThemeMode,
   setDefaultChordStyle,
+  setDefaultKeepAwake,
   setDefaultTheme,
   type KVStorage,
 } from '../defaults'
@@ -24,7 +25,7 @@ describe('defaults store', () => {
   it('falls back to DEFAULT_APP_DEFAULTS when nothing is stored', async () => {
     await hydrateDefaults(memoryStorage())
     expect(getDefaultsSnapshot()).toEqual(DEFAULT_APP_DEFAULTS)
-    expect(getDefaultsSnapshot()).toEqual({ theme: 'system', chordStyle: 'letters' })
+    expect(getDefaultsSnapshot()).toEqual({ theme: 'system', chordStyle: 'letters', keepAwake: false })
   })
 
   it('ignores invalid stored values and uses fallbacks', async () => {
@@ -38,10 +39,12 @@ describe('defaults store', () => {
 
     setDefaultTheme('dark')
     setDefaultChordStyle('solfege')
+    setDefaultKeepAwake(true)
 
-    expect(getDefaultsSnapshot()).toEqual({ theme: 'dark', chordStyle: 'solfege' })
+    expect(getDefaultsSnapshot()).toEqual({ theme: 'dark', chordStyle: 'solfege', keepAwake: true })
     expect(s.store.get('gc.defaults.theme')).toBe('dark')
     expect(s.store.get('gc.defaults.chordStyle')).toBe('solfege')
+    expect(s.store.get('gc.defaults.keepAwake')).toBe('1')
   })
 
   it('survives a simulated reload (re-hydrate from the same storage)', async () => {
@@ -49,13 +52,25 @@ describe('defaults store', () => {
     await hydrateDefaults(s)
     setDefaultTheme('light')
     setDefaultChordStyle('solfege')
+    setDefaultKeepAwake(true)
 
     // Reset the cache to defaults via a fresh empty hydrate, then reload from `s`.
     await hydrateDefaults(memoryStorage())
     expect(getDefaultsSnapshot()).toEqual(DEFAULT_APP_DEFAULTS)
 
     await hydrateDefaults(s)
-    expect(getDefaultsSnapshot()).toEqual({ theme: 'light', chordStyle: 'solfege' })
+    expect(getDefaultsSnapshot()).toEqual({ theme: 'light', chordStyle: 'solfege', keepAwake: true })
+  })
+
+  it('hydrates keepAwake from storage and defaults it off', async () => {
+    await hydrateDefaults(memoryStorage())
+    expect(getDefaultsSnapshot().keepAwake).toBe(false)
+
+    await hydrateDefaults(memoryStorage({ 'gc.defaults.keepAwake': '1' }))
+    expect(getDefaultsSnapshot().keepAwake).toBe(true)
+
+    await hydrateDefaults(memoryStorage({ 'gc.defaults.keepAwake': '0' }))
+    expect(getDefaultsSnapshot().keepAwake).toBe(false)
   })
 
   it('returns a stable snapshot reference between changes', async () => {
@@ -85,7 +100,7 @@ describe('resolveThemeMode', () => {
 
 describe('initialChordStyle', () => {
   it('seeds the viewer from the stored default', () => {
-    expect(initialChordStyle({ theme: 'system', chordStyle: 'solfege' })).toBe('solfege')
-    expect(initialChordStyle({ theme: 'system', chordStyle: 'letters' })).toBe('letters')
+    expect(initialChordStyle({ theme: 'system', chordStyle: 'solfege', keepAwake: false })).toBe('solfege')
+    expect(initialChordStyle({ theme: 'system', chordStyle: 'letters', keepAwake: false })).toBe('letters')
   })
 })

--- a/apps/mobile/src/lib/defaults.ts
+++ b/apps/mobile/src/lib/defaults.ts
@@ -24,15 +24,19 @@ export type ChordStyle = 'letters' | 'solfege'
 export type AppDefaults = {
   theme: ThemePref
   chordStyle: ChordStyle
+  /** Keep the screen awake in the Song Viewer / Performer (default off). */
+  keepAwake: boolean
 }
 
 export const DEFAULT_APP_DEFAULTS: AppDefaults = {
   theme: 'system',
   chordStyle: 'letters',
+  keepAwake: false,
 }
 
 const THEME_KEY = 'gc.defaults.theme'
 const CHORD_STYLE_KEY = 'gc.defaults.chordStyle'
+const KEEP_AWAKE_KEY = 'gc.defaults.keepAwake'
 
 const THEME_PREFS: readonly ThemePref[] = ['system', 'light', 'dark']
 const CHORD_STYLES: readonly ChordStyle[] = ['letters', 'solfege']
@@ -64,17 +68,20 @@ export async function hydrateDefaults(store: KVStorage): Promise<AppDefaults> {
   storage = store
   let theme: ThemePref = DEFAULT_APP_DEFAULTS.theme
   let chordStyle: ChordStyle = DEFAULT_APP_DEFAULTS.chordStyle
+  let keepAwake: boolean = DEFAULT_APP_DEFAULTS.keepAwake
   try {
-    const [rawTheme, rawChord] = await Promise.all([
+    const [rawTheme, rawChord, rawKeepAwake] = await Promise.all([
       store.getItem(THEME_KEY),
       store.getItem(CHORD_STYLE_KEY),
+      store.getItem(KEEP_AWAKE_KEY),
     ])
     if (isThemePref(rawTheme)) theme = rawTheme
     if (isChordStyle(rawChord)) chordStyle = rawChord
+    if (rawKeepAwake != null) keepAwake = rawKeepAwake === '1'
   } catch {
     // Best-effort — a bad read must never crash the app; fall back to defaults.
   }
-  cache = { theme, chordStyle }
+  cache = { theme, chordStyle, keepAwake }
   emit()
   return cache
 }
@@ -96,6 +103,13 @@ export function setDefaultChordStyle(v: ChordStyle): void {
   cache = { ...cache, chordStyle: v }
   emit()
   storage?.setItem(CHORD_STYLE_KEY, v).catch(() => {})
+}
+
+export function setDefaultKeepAwake(v: boolean): void {
+  if (cache.keepAwake === v) return
+  cache = { ...cache, keepAwake: v }
+  emit()
+  storage?.setItem(KEEP_AWAKE_KEY, v ? '1' : '0').catch(() => {})
 }
 
 function subscribe(listener: () => void): () => void {

--- a/apps/mobile/src/lib/keepAwake.ts
+++ b/apps/mobile/src/lib/keepAwake.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useIsFocused } from '@react-navigation/native'
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake'
+
+// "Keep screen awake" — engaged from the Song Viewer / Setlist Performer view
+// options. The on/off preference persists in defaults.ts (shared across both
+// viewers); this hook only owns activation. The lock is tied to screen focus:
+// it holds ONLY while the toggle is on AND the screen is focused, and releases
+// on blur, unmount, or toggle-off, so it never keeps the display awake in the
+// background.
+
+const TAG = 'gc-viewer-keep-awake'
+
+export function useKeepAwakeWhileFocused(enabled: boolean): void {
+  const isFocused = useIsFocused()
+
+  useEffect(() => {
+    if (!(enabled && isFocused)) return
+    activateKeepAwakeAsync(TAG).catch(() => {})
+    return () => {
+      deactivateKeepAwake(TAG).catch(() => {})
+    }
+  }, [enabled, isFocused])
+}

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -45,7 +45,8 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { prefetchSong, useSong } from '../lib/useSong'
 import { useAutoHideChrome, useAutoHidePref } from '../lib/autoHideChrome'
-import { getDefaultsSnapshot } from '../lib/defaults'
+import { getDefaultsSnapshot, setDefaultKeepAwake, useAppDefaults } from '../lib/defaults'
+import { useKeepAwakeWhileFocused } from '../lib/keepAwake'
 import { exportSetlist, exportSong } from '../lib/exportSong'
 import { buildSetlistShareUrl } from '../lib/setlistShare'
 import {
@@ -136,6 +137,10 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   // Chrome auto-hide (persisted). Pinned visible while a sheet is open; tap the
   // chart, change songs, or use the transpose bar to bring it back.
   const [autoHide, setAutoHide] = useAutoHidePref()
+  // Keep-awake: shared persisted preference (defaults store), engaged only while
+  // this screen is focused so it never holds the lock in the background.
+  const { keepAwake } = useAppDefaults()
+  useKeepAwakeWhileFocused(keepAwake)
   // Arm only when a chart is on screen (tap-to-reveal lives on the chart) and
   // no sheet is open, so chrome can't hide behind a spinner or a sheet.
   const { visible: chromeVisible, opacity: chromeOpacity, reveal } = useAutoHideChrome(
@@ -568,6 +573,8 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         onAccidental={setAccidentalManual}
         autoHide={autoHide}
         onAutoHide={setAutoHide}
+        keepAwake={keepAwake}
+        onKeepAwake={setDefaultKeepAwake}
       />
       <PerformerShareSheet
         visible={sheet === 'share'}

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native'
 import { useRouter } from 'expo-router'
 import * as Clipboard from 'expo-clipboard'
+import * as Sharing from 'expo-sharing'
 import {
   createSetlist,
   effectiveKey,
@@ -30,6 +31,7 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { supabase } from '../lib/supabase'
 import { buildSetlistShareUrl } from '../lib/setlistShare'
+import { exportSetlist } from '../lib/exportSong'
 import { pushSetToTelegram, TELEGRAM_BOT_URL } from '../lib/telegramPush'
 import { timeAgo } from '../lib/relativeTime'
 import { uuidv4 } from '../lib/uuid'
@@ -183,6 +185,23 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
       showToast('Set link copied')
     } catch (err: unknown) {
       Alert.alert('Could not copy link', errMessage(err))
+    }
+  }
+
+  async function exportSet() {
+    if (items.length === 0) {
+      showToast('Add songs first')
+      return
+    }
+    try {
+      // Combined-set PDF via the same /api/export/setlist endpoint the Performer
+      // uses; keys resolve to each entry's effective key (override or default).
+      const uri = await exportSetlist(
+        items.map((item, i) => ({ songId: item.songId, key: effectiveKeys[i] })),
+      )
+      await Sharing.shareAsync(uri)
+    } catch (err: unknown) {
+      Alert.alert('Export failed', errMessage(err))
     }
   }
 
@@ -491,6 +510,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
         visible={shareOpen}
         onClose={() => setShareOpen(false)}
         songCount={items.length}
+        onExport={exportSet}
         onCopyLink={copyLink}
         onTelegram={sendTelegram}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "expo-crypto": "~55.0.16",
         "expo-file-system": "~55.0.23",
         "expo-haptics": "~55.0.15",
+        "expo-keep-awake": "~55.0.8",
         "expo-linear-gradient": "~55.0.15",
         "expo-linking": "~55.0.16",
         "expo-network": "~55.0.15",
@@ -878,6 +879,16 @@
         "expo": "*"
       }
     },
+    "apps/mobile/node_modules/expo-keep-awake": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-55.0.8.tgz",
+      "integrity": "sha512-PfIpMfM+STOBwkR5XOE+yVtER86c44MD+W8QD8JxuO0sT9pF7Y1SJYakWlpvX8xsGA+bjKLxftm9403s9kQhKA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "apps/mobile/node_modules/expo-linear-gradient": {
       "version": "55.0.15",
       "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.15.tgz",
@@ -1456,16 +1467,6 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "apps/mobile/node_modules/expo/node_modules/expo-keep-awake": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-55.0.8.tgz",
-      "integrity": "sha512-PfIpMfM+STOBwkR5XOE+yVtER86c44MD+W8QD8JxuO0sT9pF7Y1SJYakWlpvX8xsGA+bjKLxftm9403s9kQhKA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*"
       }
     },
     "apps/mobile/node_modules/expo/node_modules/expo-modules-core": {

--- a/packages/core/src/chordpro/parser.ts
+++ b/packages/core/src/chordpro/parser.ts
@@ -105,7 +105,7 @@ function parseInstrumentalDirective(body: string): InstrumentalDirective {
   return { chords, repeat };
 }
 
-type Dir = { start: boolean; kind: string; label?: string };
+type Dir = { start: boolean; kind: string; label?: string | undefined };
 function parseDirective(raw: string): Dir | null {
   const t = raw.trim();
   let m = RX_LONG_DIR.exec(t);

--- a/packages/core/src/chordpro/types.ts
+++ b/packages/core/src/chordpro/types.ts
@@ -2,7 +2,7 @@ export type ChordPlacement = { sym: string; index: number };
 
 export type InstrumentalDirective = {
   chords: string[];
-  repeat?: number;
+  repeat?: number | undefined;
 };
 
 export type SongLine = {
@@ -14,7 +14,7 @@ export type SongLine = {
 
 export type SongSection = {
   kind: string; // e.g., 'verse', 'chorus'
-  label?: string;
+  label?: string | undefined;
   lines: SongLine[];
   instrumental?: InstrumentalDirective;
 };


### PR DESCRIPTION
Adds a persistent "keep screen awake" preference to the Song Viewer and Setlist Performer, allowing users to prevent the display from sleeping during practice or performance.

## Summary
Implements a new screen preference that keeps the device display awake while enabled in the viewers. The preference persists across app launches via the defaults store and is tied to screen focus—the wake lock is only held while the toggle is on AND the screen is focused, releasing automatically on blur or unmount.

## Key Changes

- **New keep-awake hook** (`keepAwake.ts`): `useKeepAwakeWhileFocused()` manages the expo-keep-awake lock lifecycle, tied to screen focus and the toggle state
- **Defaults store extension** (`defaults.ts`): Added `keepAwake` boolean preference with persistence via `setDefaultKeepAwake()` and `useAppDefaults()` hook
- **ViewOptionsSheet updates**: Added optional `keepAwake` / `onKeepAwake` props; refactored screen preferences section to group "Hide controls when idle" and "Keep screen awake" under a shared "Screen" label
- **Viewer integration** (`[slug].tsx`, `PerformerScreen.tsx`): Both screens now read the preference from defaults, engage the keep-awake hook, and wire the toggle to ViewOptionsSheet
- **Setlist Builder export** (`SetlistBuilderScreen.tsx`): Wired the new `onExport` callback to ShareSetSheet for set PDF export
- **ShareSetSheet activation** (`ShareSetSheet.tsx`): Converted set PDF tile from disabled "coming soon" to functional export button using the `/api/export/setlist` endpoint
- **Type refinements** (`chordpro/types.ts`, `chordpro/parser.ts`): Clarified optional field types with explicit `| undefined` annotations
- **Dependencies**: Added `expo-keep-awake` (~55.0.8)

## Implementation Details

- The keep-awake preference is stored as `'1'` (true) or `'0'` (false) in the KV store, defaulting to false
- The wake lock uses a stable tag (`'gc-viewer-keep-awake'`) and is safely idempotent across multiple activations
- Screen preferences now render conditionally only when wired by the screen, with proper spacing between toggles
- Set PDF export reuses the same combined-PDF endpoint as the Performer's existing export flow

https://claude.ai/code/session_01DosceFqgMeMupVo4y196JF