### PR TITLE
Configure EAS build and submission for iOS app

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -11,7 +11,10 @@
       "bundleIdentifier": "com.gracechords.app",
       "buildNumber": "1",
       "supportsTablet": true,
-      "usesAppleSignIn": true
+      "usesAppleSignIn": true,
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.gracechords.app"

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,36 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "resourceClass": "m-medium",
+        "simulator": false
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "ascAppId": "PLACEHOLDER_FILLED_AT_SUBMIT",
+        "appleTeamId": "PLACEHOLDER_FILLED_AT_SUBMIT"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add EAS (Expo Application Services) configuration for building and submitting the mobile app to Apple App Store, along with required iOS app metadata.

## Changes
- **Added `eas.json`**: Configured EAS build profiles for development, preview, and production environments with appropriate iOS resource classes and distribution settings
- **Updated `app.json`**: Added iOS-specific `infoPlist` configuration to declare that the app does not use non-exempt encryption, which is required for App Store submission

## Implementation Details
- Development and preview builds use `m-medium` resource class for iOS builds
- Preview builds target physical devices (`simulator: false`)
- Production builds have auto-increment enabled for build numbers
- Submit configuration includes placeholders for ASC App ID and Apple Team ID to be filled during submission
- The encryption declaration (`ITSAppUsesNonExemptEncryption: false`) satisfies App Store requirements for apps that don't implement cryptographic functionality

https://claude.ai/code/session_01AYzz9ARWvdUoEtfrhR3AUU