### PR TITLE
Handle missing Supabase config gracefully with error screen

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { ScrollView, Text, View } from 'react-native'
 import { Stack, useRouter, useSegments } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -6,7 +7,11 @@ import { SafeAreaProvider } from 'react-native-safe-area-context'
 import type { Session } from '@supabase/supabase-js'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { ThemeProvider, ThemedStatusBar } from '../src/theme/ThemeProvider'
-import { registerAuthAutoRefresh, supabase } from '../src/lib/supabase'
+import {
+  registerAuthAutoRefresh,
+  supabase,
+  supabaseConfigError,
+} from '../src/lib/supabase'
 import { flushPendingSprite } from '../src/lib/profile'
 import { hydrateDefaults } from '../src/lib/defaults'
 import { prefetchToday } from '../src/lib/bibleSource'
@@ -62,13 +67,67 @@ function useProtectedRoute(session: Session | null, ready: boolean) {
   }, [ready])
 }
 
+// Shown instead of the app when required public config is missing (e.g. a
+// release/TestFlight build made without the EXPO_PUBLIC_* env vars). Better a
+// readable message than an instant, unexplained crash on launch.
+function ConfigErrorScreen({ message }: { message: string }) {
+  useEffect(() => {
+    // The auth gate never resolves here, so lift the native splash ourselves.
+    SplashScreen.hideAsync().catch(() => {})
+  }, [])
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#14171A',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}
+    >
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text
+          style={{
+            color: '#FFFFFF',
+            fontSize: 20,
+            fontWeight: '700',
+            marginBottom: 12,
+            textAlign: 'center',
+          }}
+        >
+          Configuration missing
+        </Text>
+        <Text
+          style={{
+            color: '#B7C0C9',
+            fontSize: 15,
+            lineHeight: 22,
+            textAlign: 'center',
+          }}
+        >
+          {message}
+        </Text>
+      </ScrollView>
+    </View>
+  )
+}
+
 export default function RootLayout() {
   const [session, setSession] = useState<Session | null>(null)
   const [ready, setReady] = useState(false)
 
-  useEffect(() => registerAuthAutoRefresh(), [])
+  useEffect(() => {
+    if (supabaseConfigError) return
+    return registerAuthAutoRefresh()
+  }, [])
 
   useEffect(() => {
+    // Missing public config: skip the session read entirely (the supabase client
+    // is null here) and let the ConfigErrorScreen below take over.
+    if (supabaseConfigError) return
     // Load app-wide defaults (theme/chord style) before the splash lifts so the
     // resolved theme is applied on first paint — no light→dark flash. Runs in
     // parallel with the session read; both must resolve before `ready`.
@@ -105,6 +164,10 @@ export default function RootLayout() {
   }, [session])
 
   useProtectedRoute(session, ready)
+
+  if (supabaseConfigError) {
+    return <ConfigErrorScreen message={supabaseConfigError} />
+  }
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -2,29 +2,46 @@ import 'react-native-url-polyfill/auto'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { AppState } from 'react-native'
 import { createGcSupabase } from '@gracechords/core'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL
 const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
 
-if (!url || !anonKey) {
-  throw new Error(
-    'Missing EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY. ' +
-      'Copy apps/mobile/.env.example to apps/mobile/.env and fill in the values.',
-  )
-}
+// If the public Supabase env vars are missing, DO NOT throw at module import:
+// a top-level throw aborts the whole JS bundle before React (and any error
+// boundary) can mount, which on a release build is an instant, unexplained
+// SIGABRT crash on launch. The classic cause is a release/TestFlight build made
+// without the EXPO_PUBLIC_* vars (a gitignored .env never reaches an EAS cloud
+// build — set them as EAS environment variables instead). Surface the problem
+// as a value the app root can render as a readable screen.
+export const supabaseConfigError: string | null =
+  !url || !anonKey
+    ? 'Missing EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY.\n\n' +
+      'For local/simulator builds: copy apps/mobile/.env.example to ' +
+      'apps/mobile/.env and fill in the values.\n\n' +
+      'For TestFlight/EAS builds: a gitignored .env is NOT uploaded to the ' +
+      'cloud build — set these as EAS environment variables ' +
+      '(eas env:create --environment production ...).'
+    : null
 
 // Consume the SAME core factory the web app uses. We inject AsyncStorage as the
 // native session store; persistSession + autoRefreshToken default to true in
 // the factory. detectSessionInUrl is irrelevant on native (no URL redirect),
 // so turn it off — the factory defaults it to true for the web.
-export const supabase = createGcSupabase({
-  url,
-  anonKey,
-  storage: AsyncStorage,
-  auth: {
-    detectSessionInUrl: false,
-  },
-})
+//
+// When config is missing we skip client creation (createClient itself throws on
+// an undefined url) and export a null client. The app root short-circuits to the
+// config-error screen in that case, so this client is never actually used.
+export const supabase: SupabaseClient = supabaseConfigError
+  ? (null as unknown as SupabaseClient)
+  : createGcSupabase({
+      url: url as string,
+      anonKey: anonKey as string,
+      storage: AsyncStorage,
+      auth: {
+        detectSessionInUrl: false,
+      },
+    })
 
 // Supabase only refreshes tokens while the tab/app is foregrounded. On native
 // there is no tab visibility event, so drive it from AppState: refresh while


### PR DESCRIPTION
## Summary
Prevent app crashes when required Supabase environment variables are missing by deferring the error from module import time to app initialization, where it can be rendered as a user-friendly error screen instead of an unexplained SIGABRT crash.

## Changes
- **apps/mobile/src/lib/supabase.ts**: Replace top-level throw with exported `supabaseConfigError` string that captures the missing config state. Conditionally create the Supabase client only when config is present; export a null client (typed as SupabaseClient) when missing. Enhanced error message with instructions for both local builds (.env file) and cloud builds (EAS environment variables).

- **apps/mobile/app/_layout.tsx**: 
  - Import `supabaseConfigError` from supabase module
  - Add `ConfigErrorScreen` component that displays a readable error message with proper styling and manually dismisses the splash screen
  - Guard `registerAuthAutoRefresh()` and session initialization to skip when config is missing
  - Return `ConfigErrorScreen` early from `RootLayout` if config error exists

## Implementation Details
The key insight is avoiding a top-level throw at module import time, which aborts the entire JS bundle before React can mount and render an error boundary. This is especially problematic for release/TestFlight builds where the gitignored .env file never reaches the cloud build. By deferring the error to app initialization, the error can be surfaced as a normal React component with helpful instructions for fixing the issue.

https://claude.ai/code/session_01FsUJ2JhCTQahCycHjGMBtU