### PR TITLE
Fix account deletion for song suggestion authors/reviewers

### DIFF
--- a/supabase/migrations/20260703000000_fix_song_suggestions_user_fk_ondelete.sql
+++ b/supabase/migrations/20260703000000_fix_song_suggestions_user_fk_ondelete.sql
@@ -1,0 +1,67 @@
+-- =============================================================================
+-- GraceChords: Make account deletion succeed for suggestion authors/reviewers
+-- (song_suggestions FK ON DELETE repair, 2026-07-03)
+--
+-- Context: delete_user() (and admin_delete_user()) delete the row from
+-- auth.users and rely on FK cascades to clean up dependent rows. Every
+-- user-referencing FK cascades or nulls EXCEPT the two on song_suggestions:
+--
+--   song_suggestions.suggested_by -> public.users(id)   (no ON DELETE clause)
+--   song_suggestions.reviewed_by  -> public.users(id)   (no ON DELETE clause)
+--
+-- A missing ON DELETE clause defaults to NO ACTION, so when auth.users ->
+-- public.users cascades, these two constraints block the delete with a foreign
+-- key violation (SQLSTATE 23503) for any user who has submitted or reviewed a
+-- suggestion. The mobile "Delete account" and web Profile "Delete account" both
+-- fail with "Delete failed" for those users.
+--
+-- Fix: switch both FKs to ON DELETE SET NULL, matching how the other
+-- actor/author references already behave (posts.author_id,
+-- editor_audit_log.actor_id). The suggestion/review record is preserved (an
+-- editor may still need to act on a pending suggestion); only the link to the
+-- deleted user is cleared. Both columns are already nullable.
+--
+-- Idempotent: discovers the actual FK constraint on each column (guarding
+-- against name drift) and recreates it with the correct ON DELETE action.
+-- =============================================================================
+
+DO $$
+DECLARE
+  _con text;
+BEGIN
+  -- suggested_by
+  SELECT conname INTO _con
+  FROM   pg_constraint
+  WHERE  conrelid = 'public.song_suggestions'::regclass
+    AND  contype  = 'f'
+    AND  conkey   = ARRAY[(
+           SELECT attnum FROM pg_attribute
+           WHERE  attrelid = 'public.song_suggestions'::regclass
+             AND  attname  = 'suggested_by'
+         )];
+  IF _con IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.song_suggestions DROP CONSTRAINT %I', _con);
+  END IF;
+
+  ALTER TABLE public.song_suggestions
+    ADD CONSTRAINT song_suggestions_suggested_by_fkey
+    FOREIGN KEY (suggested_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+  -- reviewed_by
+  SELECT conname INTO _con
+  FROM   pg_constraint
+  WHERE  conrelid = 'public.song_suggestions'::regclass
+    AND  contype  = 'f'
+    AND  conkey   = ARRAY[(
+           SELECT attnum FROM pg_attribute
+           WHERE  attrelid = 'public.song_suggestions'::regclass
+             AND  attname  = 'reviewed_by'
+         )];
+  IF _con IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.song_suggestions DROP CONSTRAINT %I', _con);
+  END IF;
+
+  ALTER TABLE public.song_suggestions
+    ADD CONSTRAINT song_suggestions_reviewed_by_fkey
+    FOREIGN KEY (reviewed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+END $$;


### PR DESCRIPTION
## Summary
Fixes a foreign key constraint issue that prevented users from deleting their accounts if they had authored or reviewed song suggestions. The `song_suggestions` table had two foreign keys (`suggested_by` and `reviewed_by`) with no `ON DELETE` clause, which defaulted to `NO ACTION` and blocked cascading deletes from `auth.users`.

## Changes
- Added migration to repair `song_suggestions.suggested_by` FK: changed from `NO ACTION` to `ON DELETE SET NULL`
- Added migration to repair `song_suggestions.reviewed_by` FK: changed from `ON ACTION` to `ON DELETE SET NULL`
- Migration is idempotent: discovers actual constraint names and recreates them with correct behavior
- Preserves suggestion/review records while clearing the link to deleted users, matching the pattern used by other actor/author references (`posts.author_id`, `editor_audit_log.actor_id`)

## Impact
Users can now successfully delete their accounts via mobile "Delete account" and web Profile "Delete account" flows, even if they have submitted or reviewed suggestions. Pending suggestions remain in the system for editors to act on, but are no longer attributed to the deleted user.

https://claude.ai/code/session_01LpB13QcSyPEpEqaEmmrXyq