### PR TITLE
feat(mobile): iOS UI polish pass across viewer, library, reader, home, setlists

### DIFF
--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -20,6 +20,7 @@ import ChordChart, {
 } from '../../src/components/ChordChart'
 // CHART_LINE_HEIGHT / CHART_FONT_SIZE / CHART_LYRIC_FONT drive the raw-text fallback.
 import ExportSheet from '../../src/components/ExportSheet'
+import KeyPickerSheet from '../../src/components/setlist/KeyPickerSheet'
 import Screen from '../../src/components/Screen'
 import StarButton from '../../src/components/StarButton'
 import SymbolIcon from '../../src/components/SymbolIcon'
@@ -105,7 +106,7 @@ export default function ViewerScreen() {
     accidentalTouched.current = true
     setAccidental(v)
   }
-  const [sheet, setSheet] = useState<null | 'options' | 'export'>(null)
+  const [sheet, setSheet] = useState<null | 'options' | 'export' | 'key'>(null)
   // Header is a floating overlay so the chart runs edge-to-edge; its measured
   // height seeds the chart's top inset, so the first line starts where the
   // header sits and the user can scroll up into that space.
@@ -142,6 +143,21 @@ export default function ViewerScreen() {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {})
     reveal()
     setDelta((d) => d + dir)
+  }
+
+  // Long-press key selector: jump straight to a chosen key by deriving the
+  // relative delta the transpose model already uses (null = back to the song's
+  // own key). Uses the same transpose/accidental state as the ± taps.
+  const pickKey = (key: string | null) => {
+    Haptics.selectionAsync().catch(() => {})
+    if (key === null) {
+      setDelta(-seedSteps)
+      accidentalTouched.current = false
+      setAccidental(defaultAccidental(nativeKey))
+    } else {
+      setDelta(stepsBetween(nativeKey, key) - seedSteps)
+      setAccidentalManual(key.includes('b') ? 'flat' : 'sharp')
+    }
   }
 
   const displayTitle = song?.title || title || slug
@@ -252,7 +268,7 @@ export default function ViewerScreen() {
               accessibilityLabel="Export and share"
               style={headerButtonStyle}
             >
-              <SymbolIcon name="square.and.arrow.up" size={17} color={t.colors.ink} />
+              <SymbolIcon name="square.and.arrow.up" size={22} color={t.colors.ink} />
             </Pressable>
           </View>
         </View>
@@ -359,7 +375,12 @@ export default function ViewerScreen() {
                 alignItems: 'center',
               }}
             >
-              <TransposeBar keyLabel={keyLabel} onDown={() => transposeBy(-1)} onUp={() => transposeBy(1)} />
+              <TransposeBar
+                keyLabel={keyLabel}
+                onDown={() => transposeBy(-1)}
+                onUp={() => transposeBy(1)}
+                onLongPress={() => setSheet('key')}
+              />
             </Animated.View>
           ) : null}
         </View>
@@ -384,6 +405,15 @@ export default function ViewerScreen() {
         onAutoHide={setAutoHide}
         keepAwake={keepAwake}
         onKeepAwake={setDefaultKeepAwake}
+      />
+      <KeyPickerSheet
+        visible={sheet === 'key'}
+        onClose={() => setSheet(null)}
+        songTitle={displayTitle}
+        currentKey={effectiveKey || null}
+        nativeKey={nativeKey || null}
+        hasOverride={steps !== 0}
+        onPick={pickKey}
       />
       <ExportSheet
         visible={sheet === 'export'}

--- a/apps/mobile/src/components/AlphaScrubber.tsx
+++ b/apps/mobile/src/components/AlphaScrubber.tsx
@@ -1,4 +1,6 @@
-import { Pressable, Text, View } from 'react-native'
+import { useRef } from 'react'
+import { PanResponder, Text, View } from 'react-native'
+import * as Haptics from 'expo-haptics'
 import { useTheme } from '../theme/ThemeProvider'
 
 export const ALPHABET = [
@@ -7,8 +9,12 @@ export const ALPHABET = [
 ]
 
 // The right-edge A–Z index. Letters present in the list are drawn in the accent;
-// absent ones are dimmed and non-interactive. Tapping a present letter asks the
-// screen to jump to that section.
+// absent ones are dimmed. A pan/drag maps the finger's Y-position within the
+// strip to the matching section and asks the screen to scroll there
+// continuously; a tap jumps to the section under the touch. Each time the
+// resolved section changes, a light haptic tick fires. The inner letters are
+// pointer-transparent so every touch lands on the responder strip (keeping
+// locationY relative to it).
 export default function AlphaScrubber({
   present,
   onSelect,
@@ -17,6 +23,57 @@ export default function AlphaScrubber({
   onSelect: (letter: string) => void
 }) {
   const t = useTheme()
+
+  // Refs so the once-created PanResponder always sees the latest props/measure.
+  const heightRef = useRef(0)
+  const presentRef = useRef(present)
+  presentRef.current = present
+  const onSelectRef = useRef(onSelect)
+  onSelectRef.current = onSelect
+  const lastLetter = useRef<string | null>(null)
+
+  // Map a touch Y (relative to the strip) to the nearest present letter.
+  const resolve = (y: number): string | null => {
+    const h = heightRef.current
+    if (h <= 0) return null
+    const clamped = Math.max(0, Math.min(h - 0.001, y))
+    const idx = Math.min(ALPHABET.length - 1, Math.floor((clamped / h) * ALPHABET.length))
+    for (let d = 0; d < ALPHABET.length; d++) {
+      const hi = idx + d
+      const lo = idx - d
+      if (hi < ALPHABET.length && presentRef.current.has(ALPHABET[hi])) return ALPHABET[hi]
+      if (lo >= 0 && presentRef.current.has(ALPHABET[lo])) return ALPHABET[lo]
+    }
+    return null
+  }
+
+  const handle = (y: number) => {
+    const letter = resolve(y)
+    if (letter && letter !== lastLetter.current) {
+      lastLetter.current = letter
+      Haptics.selectionAsync().catch(() => {})
+      onSelectRef.current(letter)
+    }
+  }
+
+  const responder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: (e) => {
+        lastLetter.current = null
+        handle(e.nativeEvent.locationY)
+      },
+      onPanResponderMove: (e) => handle(e.nativeEvent.locationY),
+      onPanResponderRelease: () => {
+        lastLetter.current = null
+      },
+      onPanResponderTerminate: () => {
+        lastLetter.current = null
+      },
+    }),
+  ).current
+
   return (
     <View
       pointerEvents="box-none"
@@ -27,31 +84,36 @@ export default function AlphaScrubber({
         bottom: 0,
         justifyContent: 'center',
         alignItems: 'center',
-        paddingHorizontal: 3,
       }}
     >
-      {ALPHABET.map((letter) => {
-        const active = present.has(letter)
-        return (
-          <Pressable
-            key={letter}
-            disabled={!active}
-            onPress={() => onSelect(letter)}
-            hitSlop={{ top: 1, bottom: 1, left: 6, right: 6 }}
-          >
-            <Text
-              style={{
-                fontSize: 11,
-                fontWeight: '600',
-                lineHeight: 15,
-                color: active ? t.colors.accent : t.colors.off,
-              }}
-            >
-              {letter}
-            </Text>
-          </Pressable>
-        )
-      })}
+      <View
+        {...responder.panHandlers}
+        onLayout={(e) => {
+          heightRef.current = e.nativeEvent.layout.height
+        }}
+        hitSlop={{ top: 6, bottom: 6, left: 14, right: 8 }}
+        style={{ paddingHorizontal: 3 }}
+      >
+        <View pointerEvents="none">
+          {ALPHABET.map((letter) => {
+            const active = present.has(letter)
+            return (
+              <Text
+                key={letter}
+                style={{
+                  fontSize: 11,
+                  fontWeight: '600',
+                  lineHeight: 15,
+                  textAlign: 'center',
+                  color: active ? t.colors.accent : t.colors.off,
+                }}
+              >
+                {letter}
+              </Text>
+            )
+          })}
+        </View>
+      </View>
     </View>
   )
 }

--- a/apps/mobile/src/components/ChordChart.tsx
+++ b/apps/mobile/src/components/ChordChart.tsx
@@ -81,7 +81,7 @@ type RenderOpts = {
 function ChartSection({ section, first, ...opts }: RenderOpts & { section: SongSection; first: boolean }) {
   const t = useTheme()
   return (
-    <View style={{ marginTop: first ? 0 : t.spacing.lg }}>
+    <View style={{ marginTop: first ? 0 : t.spacing.md }}>
       {section.label && opts.showSections ? (
         <Text
           style={{
@@ -137,9 +137,9 @@ function ChartLine({ line, ...opts }: RenderOpts & { line: SongLine }) {
   const lyricSize = CHART_FONT_SIZE * fontScale
   const lineHeight = Math.round(CHART_LINE_HEIGHT * fontScale)
   const chordSize = 14 * fontScale
-  const chordLineHeight = Math.round(20 * fontScale)
+  const chordLineHeight = Math.round(16 * fontScale)
 
-  const lyric = { fontFamily: CHART_LYRIC_FONT, fontSize: lyricSize, lineHeight, color: t.colors.ink }
+  const lyric = { fontFamily: CHART_LYRIC_FONT, fontSize: lyricSize, lineHeight, fontWeight: '500' as const, color: t.colors.ink }
   const chordStyleObj = {
     fontFamily: CHART_MONO,
     fontSize: chordSize,

--- a/apps/mobile/src/components/EmptyState.tsx
+++ b/apps/mobile/src/components/EmptyState.tsx
@@ -54,7 +54,7 @@ export default function EmptyState({
         ) : null}
       </View>
       {actionLabel && onAction ? (
-        <Button title={actionLabel} onPress={onAction} fullWidth={false} />
+        <Button title={actionLabel} onPress={onAction} fullWidth={false} style={{ alignSelf: 'center' }} />
       ) : null}
     </View>
   )

--- a/apps/mobile/src/components/TransposeBar.tsx
+++ b/apps/mobile/src/components/TransposeBar.tsx
@@ -11,10 +11,14 @@ export default function TransposeBar({
   keyLabel,
   onDown,
   onUp,
+  onLongPress,
 }: {
   keyLabel: string
   onDown: () => void
   onUp: () => void
+  // Long-press the center key label to open the key selector. Optional so the
+  // bar still works where no picker is wired.
+  onLongPress?: () => void
 }) {
   const t = useTheme()
   const buttonStyle = {
@@ -52,17 +56,26 @@ export default function TransposeBar({
       >
         <SymbolIcon name="chevron.down" size={20} color={t.colors.accent} weight="semibold" />
       </Pressable>
-      <Text
-        style={{
-          minWidth: 48,
-          textAlign: 'center',
-          fontSize: 24,
-          fontWeight: '700',
-          color: t.colors.ink,
-        }}
+      <Pressable
+        onLongPress={onLongPress}
+        disabled={!onLongPress}
+        accessibilityRole="button"
+        accessibilityLabel="Choose key"
+        accessibilityHint="Opens the key selector"
+        style={({ pressed }) => [pressed && onLongPress ? { opacity: 0.6 } : null]}
       >
-        {keyLabel}
-      </Text>
+        <Text
+          style={{
+            minWidth: 48,
+            textAlign: 'center',
+            fontSize: 24,
+            fontWeight: '700',
+            color: t.colors.ink,
+          }}
+        >
+          {keyLabel}
+        </Text>
+      </Pressable>
       <Pressable
         onPress={onUp}
         accessibilityRole="button"

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -140,15 +140,22 @@ export default function ViewOptionsSheet({
   return (
     <BottomSheet visible={visible} onClose={onClose} title="View options">
       <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom }}>
-        <OverlineLabel first>Show</OverlineLabel>
-        <Segmented
-          options={[
-            { value: 'chords', label: 'Chords & lyrics' },
-            { value: 'lyrics', label: 'Lyrics only' },
-          ]}
-          value={showChords ? 'chords' : 'lyrics'}
-          onChange={(v) => onShowChords(v === 'chords')}
-        />
+        {/* Show chords */}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Text style={{ fontSize: 16, color: t.colors.ink }}>Show chords</Text>
+          <Switch
+            value={showChords}
+            onValueChange={onShowChords}
+            trackColor={{ true: t.colors.accent }}
+            accessibilityLabel="Show chords"
+          />
+        </View>
 
         {/* Section labels */}
         <View
@@ -246,13 +253,17 @@ export default function ViewOptionsSheet({
         {/* Accidentals — ♯/♭ spelling (session-scoped). Rendered only when the
             screen wires it. */}
         {onAccidental && accidental ? (
-          <>
-            <OverlineLabel>Accidentals</OverlineLabel>
-            <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-              <Text style={{ fontSize: 16, color: t.colors.ink }}>Spelling</Text>
-              <AccidentalToggle value={accidental} onChange={onAccidental} />
-            </View>
-          </>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginTop: t.spacing.xl,
+            }}
+          >
+            <Text style={{ fontSize: 16, color: t.colors.ink }}>Accidentals</Text>
+            <AccidentalToggle value={accidental} onChange={onAccidental} />
+          </View>
         ) : null}
 
         {/* Screen preferences — persist across launches (unlike the options

--- a/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
+++ b/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
@@ -20,7 +20,7 @@ function Segmented<T extends string>({
   value,
   onChange,
 }: {
-  options: { value: T; label: string }[]
+  options: { value: T; label: string; labelFontFamily?: string }[]
   value: T
   onChange: (v: T) => void
 }) {
@@ -51,7 +51,12 @@ function Segmented<T extends string>({
             }}
           >
             <Text
-              style={{ fontSize: 14, fontWeight: '600', color: selected ? t.colors.onAccent : t.colors.sec }}
+              style={{
+                fontSize: 14,
+                fontWeight: '600',
+                fontFamily: opt.labelFontFamily,
+                color: selected ? t.colors.onAccent : t.colors.sec,
+              }}
             >
               {opt.label}
             </Text>
@@ -157,7 +162,9 @@ export default function ReaderSettingsSheet({
         <OverlineLabel>Typeface</OverlineLabel>
         <Segmented<Typeface>
           options={[
-            { value: 'serif', label: 'Serif' },
+            // Render "Serif" in the serif face it selects so the choice is
+            // self-evident (matches the reading font — Georgia).
+            { value: 'serif', label: 'Serif', labelFontFamily: 'Georgia' },
             { value: 'sans', label: 'Sans' },
           ]}
           value={settings.typeface}

--- a/apps/mobile/src/lib/autoHideChrome.ts
+++ b/apps/mobile/src/lib/autoHideChrome.ts
@@ -7,7 +7,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 // this preference PERSISTS across launches, so it lives in AsyncStorage.
 
 const PREF_KEY = 'gc.viewer.autoHideChrome'
-const HIDE_DELAY_MS = 6500
+const HIDE_DELAY_MS = 4500
 
 // Persisted on/off toggle. Defaults OFF; loads asynchronously so the toggle
 // reflects the stored value once it resolves, and writes through on change.

--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -74,6 +74,8 @@ export default function DailyWordScreen() {
   const [reloadToken, setReloadToken] = useState(0)
 
   const fade = useRef(new Animated.Value(1)).current
+  // Copy FAB press feedback: 0 = resting, 1 = pressed (scale-down + dim).
+  const fabPress = useRef(new Animated.Value(0)).current
 
   const passages = useMemo(() => expandReadings(getPlanForDate(date).readings), [date])
   const currentPassage: Passage | null = passages[passageIndex] || passages[0] || null
@@ -294,7 +296,7 @@ export default function DailyWordScreen() {
         ) : (
           <ScrollView
             contentContainerStyle={{
-              paddingHorizontal: t.spacing.xl,
+              paddingHorizontal: 18,
               paddingTop: t.spacing.xs,
               paddingBottom: t.spacing.xxl,
             }}
@@ -358,29 +360,44 @@ export default function DailyWordScreen() {
 
         {/* Copy FAB — appears while a selection exists (no count badge). */}
         {selection.size > 0 ? (
-          <Pressable
-            onPress={onCopy}
-            accessibilityRole="button"
-            accessibilityLabel={`Copy ${selection.size} verse${selection.size === 1 ? '' : 's'}`}
+          <Animated.View
             style={{
               position: 'absolute',
               bottom: t.spacing.xl,
               [rtl ? 'left' : 'right']: t.spacing.lg,
-              width: 56,
-              height: 56,
-              borderRadius: t.radii.pill,
-              backgroundColor: t.colors.accent,
-              alignItems: 'center',
-              justifyContent: 'center',
-              shadowColor: t.colors.accent,
-              shadowOpacity: 0.45,
-              shadowRadius: 12,
-              shadowOffset: { width: 0, height: 6 },
-              elevation: 8,
+              opacity: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.85] }),
+              transform: [
+                { scale: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.9] }) },
+              ],
             }}
           >
-            <SymbolIcon name="doc.on.doc" size={23} color={t.colors.onAccent} />
-          </Pressable>
+            <Pressable
+              onPress={onCopy}
+              onPressIn={() =>
+                Animated.timing(fabPress, { toValue: 1, duration: 90, useNativeDriver: true }).start()
+              }
+              onPressOut={() =>
+                Animated.spring(fabPress, { toValue: 0, useNativeDriver: true }).start()
+              }
+              accessibilityRole="button"
+              accessibilityLabel={`Copy ${selection.size} verse${selection.size === 1 ? '' : 's'}`}
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: t.radii.pill,
+                backgroundColor: t.colors.accent,
+                alignItems: 'center',
+                justifyContent: 'center',
+                shadowColor: t.colors.accent,
+                shadowOpacity: 0.45,
+                shadowRadius: 12,
+                shadowOffset: { width: 0, height: 6 },
+                elevation: 8,
+              }}
+            >
+              <SymbolIcon name="doc.on.doc" size={23} color={t.colors.onAccent} />
+            </Pressable>
+          </Animated.View>
         ) : null}
       </Animated.View>
 

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -162,7 +162,7 @@ export default function HomeScreen() {
                   }}
                 >
                   {spriteSource ? (
-                    <Image source={spriteSource} style={{ width: 36, height: 36 }} resizeMode="cover" />
+                    <Image source={spriteSource} style={{ width: 30, height: 30 }} resizeMode="contain" />
                   ) : (
                     <SymbolIcon name="person" size={20} color={t.colors.accent} />
                   )}

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -378,7 +378,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
               accessibilityLabel="Export and share"
               style={headerButtonStyle}
             >
-              <SymbolIcon name="square.and.arrow.up" size={17} color={t.colors.ink} />
+              <SymbolIcon name="square.and.arrow.up" size={22} color={t.colors.ink} />
             </Pressable>
           </View>
         </View>

--- a/apps/mobile/src/screens/SetlistsScreen.tsx
+++ b/apps/mobile/src/screens/SetlistsScreen.tsx
@@ -88,7 +88,6 @@ export default function SetlistsScreen() {
         <EmptyState
           icon="list.bullet"
           title="No setlists yet"
-          subtitle="Create one to start planning a service."
           actionLabel="New set"
           onAction={onCreate}
         />

--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -188,7 +188,9 @@ export default function SongLibraryScreen() {
     const index = sections.findIndex((s) => s.letter === letter)
     if (index < 0) return
     pendingSection.current = index
-    listRef.current?.scrollToLocation({ sectionIndex: index, itemIndex: 0, animated: true })
+    // Non-animated so continuous scrubbing tracks the finger without lag; the
+    // failure fallback still animates a single recovery scroll.
+    listRef.current?.scrollToLocation({ sectionIndex: index, itemIndex: 0, animated: false })
   }
 
   const rowMeta = (song: Song) => ({


### PR DESCRIPTION
Song Library
- Replace tap-only alphabet index with a pan/drag scrubber that maps finger
  Y-position to the matching section, scrolls continuously, taps jump to the
  section (not the top), and ticks a light haptic on each section change.

Song Viewer
- Reduce auto-hide idle timeout 6500ms -> 4500ms.
- Tighten chord-to-lyric line spacing and section spacing (-25%); lyric weight
  -> medium.
- Long-press the transpose island's key label to open the key selector
  (reuses KeyPickerSheet); short-tap transpose behavior unchanged.

Viewer Options
- "Show chords" segmented control -> single Switch (same bound state).
- Accidentals: drop the section header, relabel "Spelling" -> "Accidentals".

Icons
- Bump the undersized share icon 17 -> 22 in Viewer and Performer for native
  optical sizing.

Daily Word Reader
- Add a pressed-state scale/opacity animation to the Copy FAB.
- Reduce reader horizontal margins ~25% (24 -> 18).
- Render the "Serif" typeface label in its serif face (Georgia).

Home
- Inset/contain the avatar sprite so full artwork sits inside the circle.

Setlists
- Center the empty-state action button and drop the helper subtext.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Rk1HVubPFukPEaJWczUs2