### PR TITLE
Add shared setlist import preview with deep-link support

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -129,18 +129,23 @@ duplicate logic here and never edit core internals to suit mobile.
   via AsyncStorage until uninstall — don't add proactive sign-outs. Exception:
   `choose-icon` is reachable both with and without a session (post-signup step —
   email confirmation may still be pending).
-- **Deep links / Universal Links.** iOS Universal Links are wired for **song
-  pages only**: `ios.associatedDomains: ["applinks:gracechords.com"]` (apex only,
-  no `www`) + `app/+native-intent.tsx` `redirectSystemPath`, which rewrites the
-  web `/song/:id` and `/songs/:id` paths (id == slug) to `/viewer/:slug` — the app
-  has no matching `/song` route. The AASA file lives in the **web** repo at
-  `apps/web/public/.well-known/apple-app-site-association`. Changing
-  `associatedDomains` / `intentFilters` needs a **fresh native build** (prebuild +
-  EAS), not an OTA. Two TODOs: **TODO(setlist)** — shared setlist links
-  (`/setlist`, `/set`, `/worship`) are *excluded* in the AASA and fall back to web
-  because they carry an ephemeral slug-list payload the app can't yet decode (would
-  reuse core's `decodeSet` against the catalog); **TODO(android)** — `android.intentFilters`
-  are wired but dormant until an Android signing key exists and its SHA-256 lands in
+- **Deep links / Universal Links.** iOS Universal Links are wired via
+  `ios.associatedDomains: ["applinks:gracechords.com"]` (apex only, no `www`) +
+  `app/+native-intent.tsx` `redirectSystemPath`, and the AASA file lives in the
+  **web** repo at `apps/web/public/.well-known/apple-app-site-association`.
+  Handled paths:
+  - `/song/:id`, `/songs/:id` (id == slug) → `/viewer/:slug` (the app has no
+    `/song` route).
+  - Shared setlists `/setlist/<slugs>?toKeys=`, `/set/<CODE>`, and the
+    `/worship/...` mirrors → `/setlist/import` (the read-only import preview,
+    `SetlistImportScreen`). Decode/resolve lives in `src/lib/setlistImport.ts`
+    (unit-tested), reusing core `decodeSet` for the compact code form and a plain
+    split for the slug-list form; slugs resolve against the shared catalog, misses
+    are dropped with a warning, and "Save to my setlists" creates a normal setlist
+    row (default name "Imported setlist"). Shared links never carry a title.
+  Changing `associatedDomains` / `intentFilters` needs a **fresh native build**
+  (prebuild + EAS), not an OTA. **TODO(android)** — `android.intentFilters` are
+  wired but dormant until an Android signing key exists and its SHA-256 lands in
   the web `assetlinks.json`.
 - **Auth flows.** Email/password plus native Google
   (`@react-native-google-signin/google-signin`) and Apple

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -129,6 +129,19 @@ duplicate logic here and never edit core internals to suit mobile.
   via AsyncStorage until uninstall — don't add proactive sign-outs. Exception:
   `choose-icon` is reachable both with and without a session (post-signup step —
   email confirmation may still be pending).
+- **Deep links / Universal Links.** iOS Universal Links are wired for **song
+  pages only**: `ios.associatedDomains: ["applinks:gracechords.com"]` (apex only,
+  no `www`) + `app/+native-intent.tsx` `redirectSystemPath`, which rewrites the
+  web `/song/:id` and `/songs/:id` paths (id == slug) to `/viewer/:slug` — the app
+  has no matching `/song` route. The AASA file lives in the **web** repo at
+  `apps/web/public/.well-known/apple-app-site-association`. Changing
+  `associatedDomains` / `intentFilters` needs a **fresh native build** (prebuild +
+  EAS), not an OTA. Two TODOs: **TODO(setlist)** — shared setlist links
+  (`/setlist`, `/set`, `/worship`) are *excluded* in the AASA and fall back to web
+  because they carry an ephemeral slug-list payload the app can't yet decode (would
+  reuse core's `decodeSet` against the catalog); **TODO(android)** — `android.intentFilters`
+  are wired but dormant until an Android signing key exists and its SHA-256 lands in
+  the web `assetlinks.json`.
 - **Auth flows.** Email/password plus native Google
   (`@react-native-google-signin/google-signin`) and Apple
   (`expo-apple-authentication`, iOS-only button) via

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -13,12 +13,24 @@
       "buildNumber": "1",
       "supportsTablet": true,
       "usesAppleSignIn": true,
+      "associatedDomains": ["applinks:gracechords.com"],
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {
-      "package": "com.gracechords.app"
+      "package": "com.gracechords.app",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/song/" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/songs/" }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "plugins": [
       "expo-router",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -26,7 +26,10 @@
           "autoVerify": true,
           "data": [
             { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/song/" },
-            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/songs/" }
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/songs/" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/setlist/" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/set/" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/worship/" }
           ],
           "category": ["BROWSABLE", "DEFAULT"]
         }

--- a/apps/mobile/app/+native-intent.tsx
+++ b/apps/mobile/app/+native-intent.tsx
@@ -1,0 +1,25 @@
+// Remaps inbound deep-link / Universal Link paths to Expo Router routes.
+//
+// Songs only today: the web has /song/:id and /songs/:id (id == song slug), but the
+// app's song screen is viewer/[slug], so those paths must be rewritten. Shared-setlist
+// links (/setlist, /set, /worship) are excluded in the web AASA and fall back to the
+// web app until the app can decode the ephemeral slug-list payloads — see
+// apps/web/public/.well-known/README.md (TODO(setlist)). Anything unrecognised is passed
+// through unchanged. Native-only file; Expo Router ignores it on web.
+//
+// redirectSystemPath runs for every externally-launched link, on both cold start
+// (initial === true) and warm start (initial === false).
+export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
+  try {
+    const url = new URL(path, 'https://gracechords.com')
+    const seg = url.pathname.split('/').filter(Boolean)
+    // /song/:id or /songs/:id -> /viewer/:id  (bare /songs falls through to the tab)
+    if ((seg[0] === 'song' || seg[0] === 'songs') && seg[1]) {
+      const slug = decodeURIComponent(seg.slice(1).join('/'))
+      return `/viewer/${encodeURIComponent(slug)}`
+    }
+    return path
+  } catch {
+    return path
+  }
+}

--- a/apps/mobile/app/+native-intent.tsx
+++ b/apps/mobile/app/+native-intent.tsx
@@ -1,23 +1,58 @@
 // Remaps inbound deep-link / Universal Link paths to Expo Router routes.
 //
-// Songs only today: the web has /song/:id and /songs/:id (id == song slug), but the
-// app's song screen is viewer/[slug], so those paths must be rewritten. Shared-setlist
-// links (/setlist, /set, /worship) are excluded in the web AASA and fall back to the
-// web app until the app can decode the ephemeral slug-list payloads — see
-// apps/web/public/.well-known/README.md (TODO(setlist)). Anything unrecognised is passed
-// through unchanged. Native-only file; Expo Router ignores it on web.
+// Songs: the web has /song/:id and /songs/:id (id == song slug), but the app's
+// song screen is viewer/[slug], so those paths are rewritten.
 //
-// redirectSystemPath runs for every externally-launched link, on both cold start
-// (initial === true) and warm start (initial === false).
+// Shared setlists: the web shares a set as an ephemeral link the app can't route
+// to directly, so both forms are remapped to the import-preview screen
+// (setlist/import), which decodes + previews + saves a copy:
+//   - slug list:   /setlist/<slugs>?toKeys=  and  /worship/<slugs>?toKeys=
+//   - compact code: /set/<CODE>              and  /worship/set/<CODE>
+// /worship/* is imported as a plain setlist (we materialize a saved copy). The
+// app's own /setlist/<uuid> and /setlist/import routes are left untouched.
+//
+// Anything unrecognised is passed through unchanged. Native-only file; Expo
+// Router ignores it on web. redirectSystemPath runs for every externally-launched
+// link, on both cold start (initial === true) and warm start (initial === false).
+
+// Raw (still-encoded) query value — keep per-item encoding intact so the import
+// parser can split on comma then decode each item (mirrors the web parser).
+function rawParam(search: string, key: string): string {
+  const m = new RegExp(`[?&]${key}=([^&]*)`).exec(search || '')
+  return m ? m[1] : ''
+}
+
 export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
   try {
     const url = new URL(path, 'https://gracechords.com')
     const seg = url.pathname.split('/').filter(Boolean)
+
     // /song/:id or /songs/:id -> /viewer/:id  (bare /songs falls through to the tab)
     if ((seg[0] === 'song' || seg[0] === 'songs') && seg[1]) {
       const slug = decodeURIComponent(seg.slice(1).join('/'))
       return `/viewer/${encodeURIComponent(slug)}`
     }
+
+    // Compact code form -> import preview.
+    if (seg[0] === 'set' && seg[1]) {
+      return `/setlist/import?code=${encodeURIComponent(seg[1])}`
+    }
+    if (seg[0] === 'worship' && seg[1] === 'set' && seg[2]) {
+      return `/setlist/import?code=${encodeURIComponent(seg[2])}`
+    }
+
+    // Slug-list form -> import preview. seg[1] is the comma-joined, per-item
+    // URI-encoded slug list; forward it and the raw toKeys value verbatim.
+    // Skip the app's own routes (/setlist/import, /setlist/<uuid> personal sets).
+    if (seg[0] === 'setlist' && seg[1] && seg[1] !== 'import') {
+      const toKeys = rawParam(url.search, 'toKeys')
+      return `/setlist/import?ids=${seg[1]}${toKeys ? `&toKeys=${toKeys}` : ''}`
+    }
+    if (seg[0] === 'worship' && seg[1]) {
+      const toKeys = rawParam(url.search, 'toKeys')
+      return `/setlist/import?ids=${seg[1]}${toKeys ? `&toKeys=${toKeys}` : ''}`
+    }
+
     return path
   } catch {
     return path

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -179,6 +179,7 @@ export default function RootLayout() {
             <Stack.Screen name="login" />
             <Stack.Screen name="choose-icon" />
             <Stack.Screen name="viewer/[slug]" />
+            <Stack.Screen name="setlist/import" />
             <Stack.Screen name="setlist/[id]" />
             <Stack.Screen name="perform/[id]" />
             <Stack.Screen name="settings" />

--- a/apps/mobile/app/setlist/import.tsx
+++ b/apps/mobile/app/setlist/import.tsx
@@ -1,0 +1,19 @@
+import { useLocalSearchParams } from 'expo-router'
+import SetlistImportScreen from '../../src/screens/SetlistImportScreen'
+
+// Shared-setlist IMPORT preview. Reached via a shared-link deep link
+// (app/+native-intent.tsx remaps /setlist/<slugs>?toKeys=, /set/<CODE>, and the
+// /worship/... variants here) and directly navigable for testing. The static
+// `import` segment takes precedence over the dynamic `setlist/[id]` route.
+function first(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v
+}
+
+export default function SetlistImportRoute() {
+  const { ids, toKeys, code } = useLocalSearchParams<{
+    ids?: string | string[]
+    toKeys?: string | string[]
+    code?: string | string[]
+  }>()
+  return <SetlistImportScreen ids={first(ids)} toKeys={first(toKeys)} code={first(code)} />
+}

--- a/apps/mobile/src/lib/__tests__/setlistImport.test.ts
+++ b/apps/mobile/src/lib/__tests__/setlistImport.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import { encodeSet } from '@gracechords/core'
+import {
+  buildMissingWarning,
+  buildSavePayload,
+  deslugify,
+  parseCodeForm,
+  parseSlugForm,
+  resolveEntries,
+  resolveImport,
+  type ImportedEntry,
+} from '../setlistImport'
+import type { Song } from '../useSongList'
+
+function song(slug: string, over: Partial<Song> = {}): Song {
+  return {
+    id: `uuid-${slug}`,
+    slug,
+    title: over.title ?? slug,
+    artist: over.artist ?? null,
+    default_key: over.default_key ?? 'C',
+    time_signature: over.time_signature ?? null,
+    tags: over.tags ?? null,
+    tempo: over.tempo ?? null,
+    created_at: over.created_at ?? null,
+  }
+}
+
+const CATALOG: Song[] = [
+  song('amazing-grace', { title: 'Amazing Grace', default_key: 'G' }),
+  song('how-great-thou-art', { title: 'How Great Thou Art', default_key: 'Bb' }),
+  song('cornerstone', { title: 'Cornerstone', default_key: 'C' }),
+]
+
+describe('parseSlugForm', () => {
+  it('zips ids and toKeys by index; empty key means native (null)', () => {
+    const out = parseSlugForm('amazing-grace,how-great-thou-art', 'G,')
+    expect(out).toEqual<ImportedEntry[]>([
+      { slug: 'amazing-grace', toKey: 'G' },
+      { slug: 'how-great-thou-art', toKey: null },
+    ])
+  })
+
+  it('URI-decodes per item (keys like C#) and drops empty ids', () => {
+    const out = parseSlugForm('amazing-grace,,cornerstone', 'C%23,,')
+    expect(out).toEqual<ImportedEntry[]>([
+      { slug: 'amazing-grace', toKey: 'C#' },
+      // second id is empty -> dropped, so keys realign by the filtered index
+      { slug: 'cornerstone', toKey: null },
+    ])
+  })
+
+  it('handles garbage input without throwing', () => {
+    expect(parseSlugForm('', '')).toEqual([])
+    expect(() => parseSlugForm('%%%bad', '%')).not.toThrow()
+  })
+})
+
+describe('parseCodeForm (round-trip via core encodeSet)', () => {
+  it('decodes a compact code back to slugs + key names', () => {
+    // The web hashes the catalog id, which is the slug — mirror that here.
+    const bySlug = CATALOG.map((s) => ({ id: s.slug }))
+    const code = encodeSet(bySlug, [
+      { id: 'amazing-grace', toKey: 'G' },
+      { id: 'cornerstone', toKey: 'D' },
+    ])
+    expect(parseCodeForm(code, CATALOG)).toEqual<ImportedEntry[]>([
+      { slug: 'amazing-grace', toKey: 'G' },
+      { slug: 'cornerstone', toKey: 'D' },
+    ])
+  })
+
+  it('returns [] for a malformed code (never throws)', () => {
+    expect(parseCodeForm('!!!', CATALOG)).toEqual([])
+    expect(parseCodeForm('', CATALOG)).toEqual([])
+  })
+})
+
+describe('resolveEntries', () => {
+  it('splits hits from misses and preserves per-song keys', () => {
+    const { resolved, unresolved } = resolveEntries(
+      [
+        { slug: 'amazing-grace', toKey: 'G' },
+        { slug: 'ghost-song', toKey: 'A' },
+        { slug: 'cornerstone', toKey: null },
+      ],
+      CATALOG,
+    )
+    expect(resolved.map((r) => [r.song.slug, r.toKey])).toEqual([
+      ['amazing-grace', 'G'],
+      ['cornerstone', null],
+    ])
+    expect(unresolved).toEqual(['Ghost Song'])
+  })
+})
+
+describe('deslugify', () => {
+  it('title-cases a kebab slug', () => {
+    expect(deslugify('amazing-grace')).toBe('Amazing Grace')
+    expect(deslugify('how_great-thou-art')).toBe('How Great Thou Art')
+  })
+
+  it('returns "" for opaque ids with no derivable name', () => {
+    expect(deslugify('verse:bsb:john-3-16')).toBe('')
+    expect(deslugify('12345')).toBe('')
+    expect(deslugify('')).toBe('')
+  })
+})
+
+describe('buildMissingWarning (grammar for 1 / 2 / 3+)', () => {
+  it('returns null when nothing is missing', () => {
+    expect(buildMissingWarning([])).toBeNull()
+  })
+
+  it('names a single dropped song', () => {
+    expect(buildMissingWarning(['Amazing Grace'])).toBe('Amazing Grace could not be found.')
+  })
+
+  it('joins two named songs with "and"', () => {
+    expect(buildMissingWarning(['Amazing Grace', 'Cornerstone'])).toBe(
+      'Amazing Grace and Cornerstone could not be found.',
+    )
+  })
+
+  it('names up to two then counts the rest as "others"', () => {
+    expect(buildMissingWarning(['Amazing Grace', 'Cornerstone', 'Doxology'])).toBe(
+      'Amazing Grace, Cornerstone and 1 other could not be found.',
+    )
+    expect(
+      buildMissingWarning(['Amazing Grace', 'Cornerstone', 'Doxology', 'Sanctus']),
+    ).toBe('Amazing Grace, Cornerstone and 2 others could not be found.')
+  })
+
+  it('mixes a named song with unnamed misses', () => {
+    expect(buildMissingWarning(['Amazing Grace', ''])).toBe(
+      'Amazing Grace and 1 other could not be found.',
+    )
+  })
+
+  it('falls back to a count when no name is derivable (never "1 songs")', () => {
+    expect(buildMissingWarning([''])).toBe('1 song could not be found.')
+    expect(buildMissingWarning(['', '', ''])).toBe('3 songs could not be found.')
+  })
+})
+
+describe('buildSavePayload', () => {
+  it('uses the song uuid and normalizes empty key to null', () => {
+    const { resolved } = resolveEntries(
+      [
+        { slug: 'amazing-grace', toKey: 'G' },
+        { slug: 'cornerstone', toKey: null },
+      ],
+      CATALOG,
+    )
+    expect(buildSavePayload(resolved)).toEqual([
+      { id: 'uuid-amazing-grace', toKey: 'G' },
+      { id: 'uuid-cornerstone', toKey: null },
+    ])
+  })
+})
+
+describe('resolveImport (screen entrypoint)', () => {
+  it('parses the slug-list form when no code is given', () => {
+    const res = resolveImport(
+      { ids: 'amazing-grace,ghost-song', toKeys: 'G,A' },
+      CATALOG,
+    )
+    expect(res.resolved.map((r) => r.song.slug)).toEqual(['amazing-grace'])
+    expect(res.unresolved).toEqual(['Ghost Song'])
+  })
+
+  it('prefers the code form when present', () => {
+    const bySlug = CATALOG.map((s) => ({ id: s.slug }))
+    const code = encodeSet(bySlug, [{ id: 'cornerstone', toKey: 'C' }])
+    const res = resolveImport({ code }, CATALOG)
+    expect(res.resolved.map((r) => [r.song.slug, r.toKey])).toEqual([['cornerstone', 'C']])
+  })
+})

--- a/apps/mobile/src/lib/setlistImport.ts
+++ b/apps/mobile/src/lib/setlistImport.ts
@@ -1,0 +1,145 @@
+import { decodeSet } from '@gracechords/core'
+import type { Song } from './useSongList'
+
+// Decode + resolve a SHARED setlist link into songs the current user can import
+// (materialize as their own saved copy). Two link forms are supported:
+//
+//   - Slug-list (what the web app actually emits):
+//       /setlist/<slug1>,<slug2>?toKeys=<k1>,<k2>   (and the /worship/... mirror)
+//     ids are song slugs; toKeys are literal key names, each URI-encoded per
+//     item, comma-joined, aligned by index; an empty key = the song's native
+//     key. Mirrors the web parser in apps/web/src/pages/SetlistPage.jsx.
+//   - Compact code (decode-only; no live web UI emits it, but /set/<CODE> and
+//       /worship/set/<CODE> decode through core's setcode codec).
+//
+// The song catalog is a single shared library visible to every user, so slugs
+// normally resolve; misses (stale link / catalog skew / malformed link) are the
+// rare exception and are collected separately — this never throws on a miss.
+
+// Shared links never carry a title (the web share URL is only slugs + toKeys),
+// so the imported copy lands with this placeholder that the user can rename in
+// the builder.
+export const DEFAULT_IMPORT_NAME = 'Imported setlist'
+
+export type ImportedEntry = { slug: string; toKey: string | null }
+export type ResolvedEntry = { song: Song; toKey: string | null }
+export type ImportResolution = { resolved: ResolvedEntry[]; unresolved: string[] }
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
+/** Parse the slug-list form into slug + per-song key entries. */
+export function parseSlugForm(idsParam: string, toKeysParam: string): ImportedEntry[] {
+  const ids = String(idsParam || '')
+    .split(',')
+    .map((s) => safeDecode(s.trim()))
+    .filter(Boolean)
+  // Keys are aligned by index and NOT filtered — an empty slot means "native key".
+  const keys = String(toKeysParam || '')
+    .split(',')
+    .map((s) => safeDecode(s))
+  return ids.map((slug, i) => ({ slug, toKey: keys[i] || null }))
+}
+
+/**
+ * Parse the compact code form via core's decodeSet. The web generated these
+ * codes by hashing the web catalog id, which IS the song slug, so key the
+ * catalog by slug here to match. decodeSet yields { id: slug, toKey: keyName };
+ * non-song entries (Bible verses) return ids that match no slug and simply fall
+ * through to "unresolved". A malformed code decodes to an empty list.
+ */
+export function parseCodeForm(code: string, songs: Song[]): ImportedEntry[] {
+  const catalogBySlug = (songs || []).map((s) => ({ id: s.slug }))
+  const res = decodeSet(catalogBySlug, code)
+  if (!res || res.error) return []
+  return (res.entries || []).map((e: { id: string; toKey: string }) => ({
+    slug: String(e.id),
+    toKey: e.toKey || null,
+  }))
+}
+
+/**
+ * Best-effort display name for a slug: "amazing-grace" -> "Amazing Grace".
+ * Opaque ids (Bible-verse ids contain ':', anything with no letters) have no
+ * sensible name and return '' so the warning falls back to a count.
+ */
+export function deslugify(slug: string): string {
+  const s = String(slug || '')
+  if (!s || s.includes(':')) return ''
+  const words = s.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (!/[a-zA-Z]/.test(words)) return ''
+  return words.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+/**
+ * Resolve decoded entries against the shared catalog. Hits keep their imported
+ * key override; misses are collected as best-effort display names ('' when none
+ * can be derived) for the warning.
+ */
+export function resolveEntries(entries: ImportedEntry[], songs: Song[]): ImportResolution {
+  const bySlug = new Map((songs || []).map((s) => [s.slug, s]))
+  const resolved: ResolvedEntry[] = []
+  const unresolved: string[] = []
+  for (const e of entries) {
+    const song = bySlug.get(e.slug)
+    if (song) resolved.push({ song, toKey: e.toKey })
+    else unresolved.push(deslugify(e.slug))
+  }
+  return { resolved, unresolved }
+}
+
+function joinAnd(list: string[]): string {
+  if (list.length <= 1) return list[0] || ''
+  return `${list.slice(0, -1).join(', ')} and ${list[list.length - 1]}`
+}
+
+/**
+ * Grammatically-correct warning naming the dropped song(s). `unresolved` holds a
+ * best-effort display name per miss, or '' where none could be derived. Returns
+ * null when nothing is missing. Never produces "1 songs".
+ */
+export function buildMissingWarning(unresolved: string[]): string | null {
+  const n = unresolved.length
+  if (n === 0) return null
+  const named = unresolved.filter(Boolean)
+  if (named.length === 0) {
+    return `${n} ${n === 1 ? 'song' : 'songs'} could not be found.`
+  }
+  const shown = named.slice(0, 2)
+  const others = n - shown.length
+  const subject =
+    others === 0
+      ? joinAnd(shown)
+      : `${shown.join(', ')} and ${others} ${others === 1 ? 'other' : 'others'}`
+  return `${subject} could not be found.`
+}
+
+/**
+ * The song rows to persist, in the normal setlist-creation shape: `id` is the
+ * Supabase song uuid (NOT the slug), `toKey` the per-entry key override (null =
+ * native key). Unresolved entries are already excluded from `resolved`.
+ */
+export function buildSavePayload(
+  resolved: ResolvedEntry[],
+): Array<{ id: string; toKey: string | null }> {
+  return resolved.map((r) => ({ id: r.song.id, toKey: r.toKey || null }))
+}
+
+/**
+ * Single entrypoint for the screen. `code` wins when present (compact form),
+ * otherwise the slug-list form is parsed. Resolution needs the loaded catalog.
+ */
+export function resolveImport(
+  params: { ids?: string; toKeys?: string; code?: string },
+  songs: Song[],
+): ImportResolution {
+  const entries = params.code
+    ? parseCodeForm(params.code, songs)
+    : parseSlugForm(params.ids || '', params.toKeys || '')
+  return resolveEntries(entries, songs)
+}

--- a/apps/mobile/src/screens/SetlistImportScreen.tsx
+++ b/apps/mobile/src/screens/SetlistImportScreen.tsx
@@ -1,0 +1,246 @@
+import { useMemo, useState } from 'react'
+import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import {
+  createSetlist,
+  effectiveKey,
+  formatSetSummary,
+  summarizeSet,
+  updateSetlist,
+} from '@gracechords/core'
+import Screen from '../components/Screen'
+import Card from '../components/Card'
+import Button from '../components/Button'
+import ListRow from '../components/ListRow'
+import EmptyState from '../components/EmptyState'
+import SymbolIcon from '../components/SymbolIcon'
+import { useTheme } from '../theme/ThemeProvider'
+import { useSongList } from '../lib/useSongList'
+import { supabase } from '../lib/supabase'
+import { uuidv4 } from '../lib/uuid'
+import { errMessage } from '../lib/errors'
+import {
+  buildMissingWarning,
+  buildSavePayload,
+  DEFAULT_IMPORT_NAME,
+  resolveImport,
+} from '../lib/setlistImport'
+
+// Read-only PREVIEW of a shared setlist link, with a "Save to my setlists"
+// action that materializes the user's own copy. This is IMPORT (not viewing
+// someone else's set): decode the link, resolve slugs against the shared
+// catalog, show the resolved songs with their imported keys, warn about any
+// dropped (unresolved) songs, then create a normal setlist row on save. Reached
+// via the shared-link deep link (app/+native-intent.tsx remaps to this route)
+// and directly navigable for testing: /setlist/import?ids=<slugs>&toKeys=<keys>
+// or /setlist/import?code=<CODE>.
+export default function SetlistImportScreen({
+  ids,
+  toKeys,
+  code,
+}: {
+  ids?: string
+  toKeys?: string
+  code?: string
+}) {
+  const t = useTheme()
+  const router = useRouter()
+  const { songs, loading: songsLoading, error: songsError } = useSongList()
+  const [saving, setSaving] = useState(false)
+
+  // Resolution needs the full catalog, so compute only once it's loaded (an
+  // empty catalog would mark every song "unresolved").
+  const resolution = useMemo(
+    () => (songsLoading ? { resolved: [], unresolved: [] } : resolveImport({ ids, toKeys, code }, songs)),
+    [songsLoading, songs, ids, toKeys, code],
+  )
+  const warning = buildMissingWarning(resolution.unresolved)
+  const summary = useMemo(
+    () =>
+      formatSetSummary(
+        summarizeSet(
+          resolution.resolved.map((r) => ({
+            toKey: r.toKey,
+            default_key: r.song.default_key,
+            tempo: r.song.tempo,
+          })),
+        ),
+      ),
+    [resolution.resolved],
+  )
+
+  function goBack() {
+    if (router.canGoBack()) router.back()
+    else router.replace('/setlists')
+  }
+
+  async function save() {
+    if (resolution.resolved.length === 0 || saving) return
+    setSaving(true)
+    const id = uuidv4()
+    try {
+      // Mirror the builder's create-then-populate flow (createSetlist +
+      // wipe-and-replace updateSetlist), so the imported copy is an ordinary
+      // setlist row. Unresolved songs are dropped (never persisted).
+      await createSetlist(supabase, { id, name: DEFAULT_IMPORT_NAME })
+      await updateSetlist(supabase, id, {
+        name: DEFAULT_IMPORT_NAME,
+        songs: buildSavePayload(resolution.resolved),
+      })
+      router.replace(`/setlist/${id}`)
+    } catch (err: unknown) {
+      setSaving(false)
+      Alert.alert('Could not import setlist', errMessage(err))
+    }
+  }
+
+  const header = (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: t.spacing.lg,
+        paddingVertical: t.spacing.sm,
+      }}
+    >
+      <Pressable
+        onPress={goBack}
+        accessibilityRole="button"
+        accessibilityLabel="Back"
+        hitSlop={8}
+        style={{ flexDirection: 'row', alignItems: 'center', gap: 3 }}
+      >
+        <SymbolIcon name="chevron.left" size={17} color={t.colors.textAccent} weight="semibold" />
+        <Text style={{ fontSize: 16, color: t.colors.textAccent }}>Back</Text>
+      </Pressable>
+    </View>
+  )
+
+  if (songsLoading) {
+    return (
+      <Screen edges={['top', 'left', 'right', 'bottom']}>
+        {header}
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={t.colors.accent} />
+        </View>
+      </Screen>
+    )
+  }
+
+  if (songsError) {
+    return (
+      <Screen edges={['top', 'left', 'right', 'bottom']}>
+        {header}
+        <EmptyState
+          icon="wifi.slash"
+          title="Couldn't load songs"
+          subtitle="Check your connection and try opening the link again."
+        />
+      </Screen>
+    )
+  }
+
+  if (resolution.resolved.length === 0) {
+    return (
+      <Screen edges={['top', 'left', 'right', 'bottom']}>
+        {header}
+        <EmptyState
+          icon="music.note.list"
+          title="Couldn't import this setlist"
+          subtitle={warning ?? "This link didn't contain any songs we could find."}
+          actionLabel="Back to setlists"
+          onAction={goBack}
+        />
+      </Screen>
+    )
+  }
+
+  return (
+    <Screen edges={['top', 'left', 'right', 'bottom']}>
+      {header}
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingHorizontal: t.spacing.lg, paddingBottom: t.spacing.xl }}
+      >
+        <View style={{ marginBottom: t.spacing.lg }}>
+          <Text
+            style={{
+              fontSize: t.typography.largeTitle.fontSize,
+              fontWeight: t.typography.largeTitle.fontWeight,
+              letterSpacing: t.typography.largeTitle.letterSpacing,
+              color: t.colors.ink,
+            }}
+          >
+            Import setlist
+          </Text>
+          <Text style={{ marginTop: 4, fontSize: 14, color: t.colors.sec }}>{summary}</Text>
+        </View>
+
+        {warning ? (
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'flex-start',
+              gap: t.spacing.sm,
+              padding: t.spacing.md,
+              marginBottom: t.spacing.lg,
+              borderRadius: t.radii.md,
+              backgroundColor: t.colors.surfaceAlt,
+              borderWidth: 0.5,
+              borderColor: t.colors.border,
+            }}
+          >
+            <SymbolIcon name="exclamationmark.triangle.fill" size={16} color={t.colors.danger} />
+            <Text style={{ flex: 1, fontSize: 13.5, lineHeight: 19, color: t.colors.sec }}>
+              {warning}
+            </Text>
+          </View>
+        ) : null}
+
+        <Card>
+          {resolution.resolved.map((entry, i) => (
+            <ListRow
+              key={`${entry.song.id}:${i}`}
+              title={entry.song.title}
+              subtitle={entry.song.artist}
+              trailingTop={effectiveKey({ toKey: entry.toKey }, entry.song)}
+              leading={
+                <View
+                  style={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: 12,
+                    backgroundColor: t.colors.accentSoft,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Text style={{ fontSize: 12, fontWeight: '600', color: t.colors.textAccent }}>
+                    {i + 1}
+                  </Text>
+                </View>
+              }
+              isLast={i === resolution.resolved.length - 1}
+            />
+          ))}
+        </Card>
+      </ScrollView>
+
+      <View
+        style={{
+          paddingHorizontal: t.spacing.lg,
+          paddingTop: t.spacing.sm,
+          paddingBottom: t.spacing.md,
+          borderTopWidth: 0.5,
+          borderTopColor: t.colors.border,
+        }}
+      >
+        <Button
+          title={saving ? 'Saving…' : 'Save to my setlists'}
+          onPress={save}
+          disabled={saving}
+        />
+      </View>
+    </Screen>
+  )
+}

--- a/apps/web/public/.well-known/README.md
+++ b/apps/web/public/.well-known/README.md
@@ -8,20 +8,16 @@ forces `Content-Type: application/json` for both files (Apple/Android require
 JSON, served over HTTPS, with no redirect).
 
 ## `apple-app-site-association` (iOS — active)
-App ID `J7Y8NYZ48Q.com.gracechords.app`. Currently claims only song detail
-pages, which map to the app's `viewer/[slug]` screen:
+App ID `J7Y8NYZ48Q.com.gracechords.app`. Claims:
 
-- `/song/*` and `/songs/*` → open in app.
-- `/setlist/*`, `/set/*`, `/worship/*` → `exclude: true` (open in web).
-
-### TODO(setlist)
-The web "Share Set" button emits *ephemeral* links carrying a slug list + keys
-(`/setlist/<slug1>,<slug2>?toKeys=...`, plus `/set/<CODE>` and `/worship/...`).
-The app's setlist screens only load personal setlists by Supabase UUID, so they
-cannot yet reconstruct an ephemeral set from these links — hence the excludes.
-When the app gains a screen that decodes the shared payload (reusing
-`packages/core/src/setlists/setcode.js` `decodeSet` against the song catalog),
-flip these entries from `exclude: true` to includes.
+- `/song/*` and `/songs/*` → app song viewer (`viewer/[slug]`).
+- `/setlist/*`, `/set/*`, `/worship/*` → app shared-setlist import preview
+  (`setlist/import`), which decodes the shared payload, previews the resolved
+  songs, and saves the user a copy. The web "Share Set" button emits the
+  ephemeral slug-list form (`/setlist/<slug1>,<slug2>?toKeys=...`); the compact
+  `/set/<CODE>` and `/worship/set/<CODE>` forms decode through
+  `packages/core/src/setlists/setcode.js` `decodeSet`. When the app isn't
+  installed these paths open the web app as usual (Universal Links fallback).
 
 ## `assetlinks.json` (Android — inert scaffold)
 ### TODO(android)

--- a/apps/web/public/.well-known/README.md
+++ b/apps/web/public/.well-known/README.md
@@ -1,0 +1,34 @@
+# `.well-known` — mobile deep-link association files
+
+These static files are served at the site root by Cloudflare Pages
+(`https://gracechords.com/.well-known/...`). They let the native GraceChords
+apps claim `https://gracechords.com/...` links (iOS Universal Links / Android
+App Links) so eligible links open the app instead of the browser. `_headers`
+forces `Content-Type: application/json` for both files (Apple/Android require
+JSON, served over HTTPS, with no redirect).
+
+## `apple-app-site-association` (iOS — active)
+App ID `J7Y8NYZ48Q.com.gracechords.app`. Currently claims only song detail
+pages, which map to the app's `viewer/[slug]` screen:
+
+- `/song/*` and `/songs/*` → open in app.
+- `/setlist/*`, `/set/*`, `/worship/*` → `exclude: true` (open in web).
+
+### TODO(setlist)
+The web "Share Set" button emits *ephemeral* links carrying a slug list + keys
+(`/setlist/<slug1>,<slug2>?toKeys=...`, plus `/set/<CODE>` and `/worship/...`).
+The app's setlist screens only load personal setlists by Supabase UUID, so they
+cannot yet reconstruct an ephemeral set from these links — hence the excludes.
+When the app gains a screen that decodes the shared payload (reusing
+`packages/core/src/setlists/setcode.js` `decodeSet` against the song catalog),
+flip these entries from `exclude: true` to includes.
+
+## `assetlinks.json` (Android — inert scaffold)
+### TODO(android)
+Wired ahead of an Android release but **inert**: `sha256_cert_fingerprints`
+holds a placeholder. No Android app is published, so verification cannot
+succeed yet. When an Android signing key exists, replace
+`TODO_ANDROID_RELEASE_SHA256_FINGERPRINT` with the release key's SHA-256
+fingerprint (e.g. from `keytool -list -v` or the Play Console app-signing page)
+and add the same song paths to `android.intentFilters` in
+`apps/mobile/app.json`.

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,17 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": ["J7Y8NYZ48Q.com.gracechords.app"],
+        "components": [
+          { "/": "/song/*", "comment": "Song detail -> viewer/[slug]" },
+          { "/": "/songs/*", "comment": "Song detail alias -> viewer/[slug]" },
+          { "/": "/setlist/*", "exclude": true, "comment": "TODO(setlist): open in web until app decodes shared slug-list payloads" },
+          { "/": "/set/*", "exclude": true, "comment": "TODO(setlist): compact short-code, needs decodeSet + catalog" },
+          { "/": "/worship/*", "exclude": true, "comment": "TODO(setlist): worship-mode shared sets" }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -7,9 +7,9 @@
         "components": [
           { "/": "/song/*", "comment": "Song detail -> viewer/[slug]" },
           { "/": "/songs/*", "comment": "Song detail alias -> viewer/[slug]" },
-          { "/": "/setlist/*", "exclude": true, "comment": "TODO(setlist): open in web until app decodes shared slug-list payloads" },
-          { "/": "/set/*", "exclude": true, "comment": "TODO(setlist): compact short-code, needs decodeSet + catalog" },
-          { "/": "/worship/*", "exclude": true, "comment": "TODO(setlist): worship-mode shared sets" }
+          { "/": "/setlist/*", "comment": "Shared setlist (slug list) -> setlist import preview" },
+          { "/": "/set/*", "comment": "Shared setlist (compact code) -> setlist import preview" },
+          { "/": "/worship/*", "comment": "Shared worship set -> setlist import preview" }
         ]
       }
     ]

--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.gracechords.app",
+      "sha256_cert_fingerprints": ["TODO_ANDROID_RELEASE_SHA256_FINGERPRINT"]
+    }
+  }
+]

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -2,3 +2,9 @@
   Content-Security-Policy: frame-ancestors 'none'
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff
+
+# Mobile deep-link association files must be served as JSON (Apple/Android require it).
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+/.well-known/assetlinks.json
+  Content-Type: application/json

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -70,7 +70,10 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         { src: 'src/sw.js', dest: '' },
-        { src: '404.html', dest: '' }
+        { src: '404.html', dest: '' },
+        // Ensure the dot-directory deep-link files land in dist/ deterministically.
+        { src: 'public/.well-known/apple-app-site-association', dest: '.well-known' },
+        { src: 'public/.well-known/assetlinks.json', dest: '.well-known' }
       ]
     }),
     injectLcpPreload,


### PR DESCRIPTION
## Summary
Adds a read-only import preview screen for shared setlists, accessible via deep links (iOS Universal Links / Android App Links) and direct navigation. Users can preview resolved songs from a shared link and save their own copy to the app.

## Key Changes

### Mobile App
- **New `SetlistImportScreen`** (`apps/mobile/src/screens/SetlistImportScreen.tsx`): Read-only preview of a shared setlist with song resolution, key overrides, warnings for unresolved songs, and a "Save to my setlists" action that materializes a user's own copy.
- **New `setlistImport` utilities** (`apps/mobile/src/lib/setlistImport.ts`): Decode and resolve shared setlist links in two forms:
  - Slug-list form: `/setlist/<slug1>,<slug2>?toKeys=<k1>,<k2>` (what the web app emits)
  - Compact code form: `/set/<CODE>` (decoded via core's `decodeSet`)
  - Resolves slugs against the shared song catalog; drops unresolved entries with grammatically-correct warnings
- **Comprehensive unit tests** (`apps/mobile/src/lib/__tests__/setlistImport.test.ts`): Full coverage of parsing, resolution, and warning generation.
- **Deep-link routing** (`apps/mobile/app/+native-intent.tsx`): Remaps inbound deep-link paths to the import preview:
  - `/song/:id`, `/songs/:id` → `/viewer/:slug` (song detail)
  - `/setlist/<slugs>?toKeys=`, `/set/<CODE>`, `/worship/...` variants → `/setlist/import` (import preview)
- **Route registration** (`apps/mobile/app/setlist/import.tsx`): Static route that takes precedence over the dynamic `setlist/[id]` route.
- **App config updates** (`apps/mobile/app.json`): Added iOS `associatedDomains` and Android `intentFilters` to claim `gracechords.com` links.

### Web App
- **Deep-link association files** (`apps/web/public/.well-known/`):
  - `apple-app-site-association`: iOS Universal Links configuration claiming `/song/*`, `/songs/*`, `/setlist/*`, `/set/*`, `/worship/*` paths.
  - `assetlinks.json`: Android App Links scaffold (inert; placeholder SHA-256 fingerprint pending Android release).
  - `README.md`: Documentation of the deep-link setup.
- **Web server config** (`apps/web/public/_headers`): Ensures `.well-known` files are served as `application/json` (required by Apple/Android).
- **Build config** (`apps/web/vite.config.js`): Copies `.well-known` files to the dist directory during build.

## Implementation Details

- **No title in shared links**: Imported setlists land with a placeholder name (`"Imported setlist"`) that users can rename in the builder.
- **Catalog-based resolution**: Slugs resolve against the shared song catalog; misses are collected with best-effort display names (derived from slug format) for the warning.
- **Graceful degradation**: Malformed links, network errors, and unresolved songs never crash the screen; users see appropriate empty states or warnings.
- **Mirrors web parser**: The slug-list form parsing mirrors the web app's implementation in `apps/web/src/pages/SetlistPage.jsx`.
- **Reuses core codec**: The compact code form leverages core's `decodeSet` for consistency with the web app.

https://claude.ai/code/session_01SVbyb1xJyCzkMUuK89SUcA