### PR TITLE
Add guitar tuner to Utilities tab with YIN pitch detection

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -39,6 +39,16 @@
         }
       ],
       [
+        "react-native-audio-api",
+        {
+          "iosMicrophonePermission": "GraceChords uses the microphone only for the real-time instrument tuner. Audio is analyzed on this device to detect pitch and is never recorded, stored, or transmitted.",
+          "iosBackgroundMode": false,
+          "androidPermissions": ["android.permission.RECORD_AUDIO"],
+          "androidForegroundService": false,
+          "disableFFmpeg": true
+        }
+      ],
+      [
         "expo-build-properties",
         {
           "ios": {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -184,6 +184,7 @@ export default function RootLayout() {
             <Stack.Screen name="settings" />
             <Stack.Screen name="about" />
             <Stack.Screen name="offline" />
+            <Stack.Screen name="tuner" />
           </Stack>
         </SafeAreaProvider>
       </ThemeProvider>

--- a/apps/mobile/app/dev/tuner-spike.tsx
+++ b/apps/mobile/app/dev/tuner-spike.tsx
@@ -1,0 +1,8 @@
+import TunerSpikeScreen from '../../spike/tuner/TunerSpikeScreen'
+
+// SPIKE-ONLY route: on-device probe for the tuner audio pipeline. Reached from
+// the Utilities tab's Tuner row in __DEV__ builds; delete with spike/tuner/
+// when the real tuner ships.
+export default function TunerSpike() {
+  return <TunerSpikeScreen />
+}

--- a/apps/mobile/app/dev/tuner-spike.tsx
+++ b/apps/mobile/app/dev/tuner-spike.tsx
@@ -1,8 +1,14 @@
-import TunerSpikeScreen from '../../spike/tuner/TunerSpikeScreen'
+import { Redirect } from 'expo-router'
 
-// SPIKE-ONLY route: on-device probe for the tuner audio pipeline. Reached from
-// the Utilities tab's Tuner row in __DEV__ builds; delete with spike/tuner/
-// when the real tuner ships.
+// SPIKE-ONLY route: on-device probe for the tuner audio pipeline, kept for
+// device-verifying the pipeline numbers (spike/tuner/RESULTS.md). The __DEV__
+// guard is compile-time (babel constant-folds it), so the spike harness is
+// excluded from production bundles entirely; release builds just redirect.
 export default function TunerSpike() {
-  return <TunerSpikeScreen />
+  if (__DEV__) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const TunerSpikeScreen = require('../../spike/tuner/TunerSpikeScreen').default
+    return <TunerSpikeScreen />
+  }
+  return <Redirect href="/" />
 }

--- a/apps/mobile/app/tuner.tsx
+++ b/apps/mobile/app/tuner.tsx
@@ -1,0 +1,6 @@
+import TunerScreen from '../src/screens/TunerScreen'
+
+// Guitar tuner — pushed from the Utilities tab.
+export default function Tuner() {
+  return <TunerScreen />
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -41,6 +41,7 @@
     "expo-web-browser": "~55.0.17",
     "react": "19.2.0",
     "react-native": "0.83.6",
+    "react-native-audio-api": "^0.13.1",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",

--- a/apps/mobile/spike/tuner/RESULTS.md
+++ b/apps/mobile/spike/tuner/RESULTS.md
@@ -1,0 +1,124 @@
+# Tuner spike — Phase 1 results (gate report)
+
+Spike for the Utilities-tab guitar tuner: prove the low-latency pitch pipeline
+before any UI is built. Everything in `spike/tuner/` is throwaway; the pure
+detection logic it exercises lives in `src/lib/tuner/` (unit-tested) and is the
+piece Phase 2 keeps.
+
+## Pipeline viability: `react-native-audio-api` — CONFIRMED
+
+Verified against the published package source (v0.13.1, npm, July 2026 —
+actively maintained, nightly builds current), not training-data assumptions:
+
+- **Raw real-time buffers: yes.** `AudioRecorder.onAudioReady({ sampleRate,
+  bufferLength, channelCount }, cb)` pushes Float32 PCM `AudioBuffer`s to JS at
+  the requested cadence (native side: AVAudioEngine input tap → ring buffer →
+  event per `bufferLength` frames). No file is ever written unless
+  `enableFileOutput()` is explicitly called — we never call it, so "no audio
+  recorded/stored" holds by construction.
+- **New architecture / SDK 55: yes.** TurboModule (codegen spec), peer-depends
+  on `react-native-worklets >= 0.6.0` (app has 0.7.4). Podspec explicitly
+  handles static/dynamic frameworks (app uses `useFrameworks: static`).
+- **Permissions: built in.** `AudioManager.request/checkRecordingPermissions()`
+  (`Undetermined | Denied | Granted`) — supports ask-on-first-use.
+- **Expo config plugin: yes.** `app.json` now carries the plugin with
+  `iosMicrophonePermission` (on-device-only wording), `iosBackgroundMode:
+  false`, `androidPermissions: [RECORD_AUDIO]` (future parity — Android build
+  isn't configured otherwise; TODO(android)), `androidForegroundService: false`,
+  and `disableFFmpeg: true` (drops 4 vendored FFmpeg xcframeworks the tuner
+  doesn't need; re-enable if a future feature must decode m4a/ogg/etc.).
+- **Session control matters:** `AudioManager.setAudioSessionOptions({
+  iosCategory: 'record', iosMode: 'measurement' })` — `measurement` disables
+  system input processing (AGC/voice isolation) that would otherwise mangle
+  the signal. The harness sets this.
+
+`AnalyserNode`/`getFloatTimeDomainData` also exists, but `onAudioReady` is the
+better fit (push, not poll) and is what the pipeline uses.
+
+## Method
+
+Headless benchmark (`bench.ts`, run with `npx -y tsx spike/tuner/bench.ts`)
+streams synthetic plucks through the exact device pipeline shape — hop-sized
+callbacks → decimation → ring buffer → YIN (`src/lib/tuner/yin.ts`, CMNDF +
+absolute threshold 0.12 + parabolic interpolation, no global-min fallback) →
+median-5 + EMA-0.35 smoothing. Signals model what breaks naive detectors:
+stiff-string inharmonicity, per-partial decay, pick transient, **weak low-E
+fundamental (0.3×)**, and background noise. Matrix: 6 strings × detune
+{0, +8, −20}¢ × SNR {clean, 25 dB, 15 dB} × 3 seeds = 270 plucks per config.
+
+Caveats to confirm on device (harness below): synthetic ≠ real guitar/room;
+compute times are Node/V8 — Hermes is typically a few × slower; real iOS mic
+adds its own IO buffer (~10–20 ms).
+
+## Numbers
+
+| config | 1st reading ms (med/p90) | worst bias (c) | raw jitter std med (c) | raw p95 dev med (c) | gross err % | settle ms med | smoothed jitter med (c) | detect ms/call (Node) |
+|---|---|---|---|---|---|---|---|---|
+| 48k w2048 h1024 | 35 / 57 | 31.9 | 2.30 | 4.72 | 1.35 | 99 | 0.82 | 1.29 |
+| 48k w4096 h1024 | 57 / 78 | 24.7 | 1.42 | 2.66 | 0.44 | 142 | 0.74 | 3.20 |
+| 24k w1024 h512 | 35 / 57 | 15.3 | 0.97 | 2.08 | 0.26 | 121 | 0.45 | 0.32 |
+| **24k w2048 h512** | **35 / 57** | **8.8** | **0.52** | **1.08** | **0.02** | **142** | **0.43** | **0.80** |
+| 12k w1024 h256 | 35 / 57 | 2.8 | 0.29 | 0.60 | 0.00 | 163 | 0.38 | 0.20 |
+
+("worst bias" is the single worst pluck's steady-state mean error across the
+whole matrix — dominated by the 15 dB noisy-room cases. At ≥25 dB SNR the
+recommended config's worst bias is 1.6 c.)
+
+Recommended config, per string (includes the 15 dB cases):
+
+| string | 1st reading ms med | bias c med | raw jitter std med c | gross % | settle ms med | smoothed jitter med c |
+|---|---|---|---|---|---|---|
+| **E2 (low E)** | 57 | 1.3 | 0.77 | 0.00 | 270 | 0.57 |
+| A2 | 57 | 0.6 | 0.57 | 0.00 | 206 | 0.45 |
+| D3 | 35 | 0.5 | 0.55 | 0.00 | 185 | 0.34 |
+| G3 | 35 | 0.3 | 0.46 | 0.00 | 142 | 0.23 |
+| B3 | 35 | 0.3 | 0.42 | 0.00 | 57 | 0.20 |
+| E4 | 35 | 0.3 | 0.45 | 0.14 | 35 | 0.21 |
+
+Full sweep output: run the bench; per-string tables for every config are
+printed.
+
+## Latency vs. stability — recommended starting balance
+
+**Capture 48 kHz mono, `bufferLength` 1024 (21.3 ms callbacks) → decimate ×2 →
+24 kHz, YIN window 2048 (85.3 ms), detect every callback, median-5 + EMA-0.35
+on cents, RMS gate ~0.008, in-tune hold when |cents| ≤ 4 for ~500 ms.**
+
+- Update cadence: every 21.3 ms (needle redraws ~47×/s).
+- Pluck → first correct reading (algorithmic): 35–57 ms. Add iOS input buffer
+  (~10–20 ms) + detect (≈1–4 ms Hermes est.) + one render frame (≤16.7 ms):
+  **~70–100 ms perceived**, i.e. "immediate".
+- Held-note needle: raw jitter ≈ 0.5 c std (low E 0.8 c); smoothed ≈ 0.4 c —
+  visually still. Smoothing costs ~2 hops (~43 ms) of lag; settle to ±3 c in
+  ~140 ms (low E ~270 ms).
+- Gross (octave) errors: 0.02% of readings across the matrix, all in the
+  15 dB noisy case, and single-frame — the median absorbs them.
+- Low E specifically: with a 0.3× fundamental it tracks with zero octave
+  errors; it is simply the slowest to settle (~270 ms) — acceptable.
+- The window is the stability lever: 1024 halves compute and settles slightly
+  faster but triples noisy-room bias (15.3 c worst); 12 kHz analysis is even
+  steadier and cheaper but relies on a crude decimator and thinner margins at
+  E4 — keep as an optimization candidate, validate on device before adopting.
+
+## On-device harness
+
+`TunerSpikeScreen` (this folder) runs the exact recommended pipeline on
+hardware — dev builds only, via Utilities → Tuner ("Spike harness") or
+`/dev/tuner-spike`. It shows live Hz / raw vs smoothed cents / clarity, ~1 s
+jitter std, callback cadence avg/max, detect cost avg/max, and permission
+state, so the numbers above can be confirmed with a real guitar. Requires a
+dev build on device (`npx expo run:ios --device`); the audio stack is native,
+so nothing runs in a simulator mic-free or in Expo Go.
+
+## Phase 2 notes discovered during the spike
+
+- Privacy policy lives at `apps/web/src/content/privacy-policy.md`, rendered by
+  the web app's `PrivacyPage` — web-hosted (Cloudflare Pages), so the tuner
+  section ships with a web deploy, not the app build.
+- `src/lib/tuner/` (notes/yin/smoothing) is the reusable, unit-tested core;
+  Phase 2 adds only the capture glue + UI. Tuning is data (`STANDARD_TUNING`),
+  so alternate tunings are a later additive change.
+- Everything under `spike/tuner/` + `app/dev/tuner-spike.tsx` is deletable when
+  the real tuner ships.
+
+## Go / no-go: **GO** (pending on-device confirmation of the same numbers)

--- a/apps/mobile/spike/tuner/TunerSpikeScreen.tsx
+++ b/apps/mobile/spike/tuner/TunerSpikeScreen.tsx
@@ -2,7 +2,9 @@
 // production tuner UI — it exists to validate the headless benchmark numbers
 // on real hardware: capture health (callback cadence), detection latency,
 // reading stability (raw + smoothed cents jitter), and low-E reliability.
-// Reached via the Utilities tab's Tuner row in __DEV__ builds only.
+// Reached via the Utilities tab's DEV section in __DEV__ builds only; the
+// __DEV__-guarded require in app/dev/tuner-spike.tsx keeps this file (and
+// everything under spike/) out of production bundles.
 
 import { useEffect, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'

--- a/apps/mobile/spike/tuner/TunerSpikeScreen.tsx
+++ b/apps/mobile/spike/tuner/TunerSpikeScreen.tsx
@@ -1,0 +1,272 @@
+// SPIKE-ONLY on-device harness for the tuner pipeline. Deliberately NOT the
+// production tuner UI — it exists to validate the headless benchmark numbers
+// on real hardware: capture health (callback cadence), detection latency,
+// reading stability (raw + smoothed cents jitter), and low-E reliability.
+// Reached via the Utilities tab's Tuner row in __DEV__ builds only.
+
+import { useEffect, useRef, useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import { AudioManager, AudioRecorder } from 'react-native-audio-api'
+import type { PermissionStatus } from 'react-native-audio-api'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Screen from '../../src/components/Screen'
+import { useTheme } from '../../src/theme/ThemeProvider'
+import { nearestString } from '../../src/lib/tuner/notes'
+import { createCentsSmoother } from '../../src/lib/tuner/smoothing'
+import { createYinDetector, decimate, rmsLevel } from '../../src/lib/tuner/yin'
+
+// Spike-recommended pipeline parameters (see spike/tuner/RESULTS.md).
+const CAPTURE_RATE = 48000
+const CALLBACK_LENGTH = 1024 // 21.3 ms cadence at 48 kHz
+const DECIMATION = 2 // analyze at 24 kHz
+const WINDOW = 2048 // 85.3 ms analysis window at 24 kHz
+const RMS_GATE = 0.008
+
+interface LiveStats {
+  status: string
+  hz: number | null
+  stringName: string | null
+  rawCents: number | null
+  smoothedCents: number | null
+  clarity: number | null
+  jitterStd: number | null
+  callbackAvgMs: number | null
+  callbackMaxMs: number
+  detectAvgMs: number | null
+  detectMaxMs: number
+  callbacks: number
+  reads: number
+  rms: number
+}
+
+const INITIAL: LiveStats = {
+  status: 'idle',
+  hz: null,
+  stringName: null,
+  rawCents: null,
+  smoothedCents: null,
+  clarity: null,
+  jitterStd: null,
+  callbackAvgMs: null,
+  callbackMaxMs: 0,
+  detectAvgMs: null,
+  detectMaxMs: 0,
+  callbacks: 0,
+  reads: 0,
+  rms: 0,
+}
+
+function std(values: number[]): number {
+  const mean = values.reduce((a, b) => a + b, 0) / values.length
+  return Math.sqrt(values.reduce((a, v) => a + (v - mean) * (v - mean), 0) / values.length)
+}
+
+export default function TunerSpikeScreen() {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const [permission, setPermission] = useState<PermissionStatus>('Undetermined')
+  const [running, setRunning] = useState(false)
+  const [stats, setStats] = useState<LiveStats>(INITIAL)
+
+  const recorderRef = useRef<AudioRecorder | null>(null)
+  const liveRef = useRef<LiveStats>({ ...INITIAL })
+
+  useEffect(() => {
+    AudioManager.checkRecordingPermissions().then(setPermission).catch(() => {})
+    return () => {
+      stopCapture()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(() => setStats({ ...liveRef.current }), 100)
+    return () => clearInterval(id)
+  }, [running])
+
+  function stopCapture() {
+    recorderRef.current?.stop().catch(() => {})
+    recorderRef.current?.clearOnAudioReady()
+    recorderRef.current = null
+    AudioManager.setAudioSessionActivity(false).catch(() => {})
+    setRunning(false)
+  }
+
+  async function startCapture() {
+    const granted = await AudioManager.requestRecordingPermissions()
+    setPermission(granted)
+    if (granted !== 'Granted') {
+      liveRef.current = { ...INITIAL, status: 'mic permission denied — enable in Settings' }
+      setStats({ ...liveRef.current })
+      return
+    }
+
+    // 'measurement' disables system input processing (AGC/voice isolation),
+    // which otherwise mangles a tuner's view of the raw signal.
+    AudioManager.setAudioSessionOptions({ iosCategory: 'record', iosMode: 'measurement' })
+    await AudioManager.setAudioSessionActivity(true)
+
+    const detector = createYinDetector({
+      sampleRate: CAPTURE_RATE / DECIMATION,
+      windowSize: WINDOW,
+    })
+    const smoother = createCentsSmoother()
+    const ring = new Float32Array(WINDOW)
+    let filled = 0
+    let lastCallbackAt = 0
+    const recentCents: number[] = []
+
+    const live = { ...INITIAL, status: 'listening' }
+    liveRef.current = live
+
+    const recorder = new AudioRecorder()
+    recorderRef.current = recorder
+    recorder.onAudioReady(
+      { sampleRate: CAPTURE_RATE, bufferLength: CALLBACK_LENGTH, channelCount: 1 },
+      (event) => {
+        const now = performance.now()
+        if (lastCallbackAt > 0) {
+          const interval = now - lastCallbackAt
+          live.callbackAvgMs =
+            live.callbackAvgMs === null ? interval : live.callbackAvgMs * 0.95 + interval * 0.05
+          if (interval > live.callbackMaxMs) live.callbackMaxMs = interval
+        }
+        lastCallbackAt = now
+        live.callbacks++
+
+        const chunk = decimate(event.buffer.getChannelData(0), DECIMATION)
+        ring.copyWithin(0, chunk.length)
+        ring.set(chunk, WINDOW - chunk.length)
+        filled = Math.min(WINDOW, filled + chunk.length)
+        if (filled < WINDOW) return
+
+        live.rms = rmsLevel(ring)
+        if (live.rms < RMS_GATE) {
+          smoother.reset()
+          recentCents.length = 0
+          live.status = 'listening (below gate)'
+          live.hz = null
+          live.rawCents = null
+          live.smoothedCents = null
+          live.jitterStd = null
+          return
+        }
+
+        const t0 = performance.now()
+        const reading = detector.detect(ring)
+        const detectMs = performance.now() - t0
+        live.detectAvgMs =
+          live.detectAvgMs === null ? detectMs : live.detectAvgMs * 0.9 + detectMs * 0.1
+        if (detectMs > live.detectMaxMs) live.detectMaxMs = detectMs
+
+        if (!reading) {
+          live.status = 'no pitch'
+          return
+        }
+        const match = nearestString(reading.frequency)
+        if (!match) {
+          live.status = `out of range (${reading.frequency.toFixed(1)} Hz)`
+          return
+        }
+        live.reads++
+        live.status = 'tracking'
+        live.hz = reading.frequency
+        live.clarity = reading.clarity
+        live.stringName = match.string.name
+        live.rawCents = match.cents
+        live.smoothedCents = smoother.push(match.cents)
+        recentCents.push(match.cents)
+        if (recentCents.length > 48) recentCents.shift()
+        live.jitterStd = recentCents.length >= 8 ? std(recentCents) : null
+      }
+    )
+    recorder.onError((e) => {
+      live.status = `recorder error: ${e.message}`
+    })
+    await recorder.start()
+    setRunning(true)
+  }
+
+  const rows: [string, string][] = [
+    ['status', stats.status],
+    ['permission', permission],
+    ['string', stats.stringName ?? '—'],
+    ['frequency', stats.hz ? `${stats.hz.toFixed(2)} Hz` : '—'],
+    ['raw cents', stats.rawCents !== null ? stats.rawCents.toFixed(1) : '—'],
+    ['smoothed cents', stats.smoothedCents !== null ? stats.smoothedCents.toFixed(1) : '—'],
+    ['clarity', stats.clarity !== null ? stats.clarity.toFixed(3) : '—'],
+    ['jitter std (last ~1s)', stats.jitterStd !== null ? `${stats.jitterStd.toFixed(2)} c` : '—'],
+    [
+      'callback cadence',
+      stats.callbackAvgMs !== null
+        ? `${stats.callbackAvgMs.toFixed(1)} ms avg / ${stats.callbackMaxMs.toFixed(0)} ms max`
+        : '—',
+    ],
+    [
+      'detect cost',
+      stats.detectAvgMs !== null
+        ? `${stats.detectAvgMs.toFixed(2)} ms avg / ${stats.detectMaxMs.toFixed(1)} ms max`
+        : '—',
+    ],
+    ['callbacks / reads', `${stats.callbacks} / ${stats.reads}`],
+    ['rms', stats.rms.toFixed(4)],
+  ]
+
+  return (
+    <Screen edges={['top', 'left', 'right']}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: t.spacing.lg,
+          paddingBottom: insets.bottom + t.spacing.xxl,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: t.typography.largeTitle.fontSize,
+            fontWeight: t.typography.largeTitle.fontWeight,
+            color: t.colors.ink,
+            paddingVertical: t.spacing.md,
+          }}
+        >
+          Tuner spike harness
+        </Text>
+        <Text style={{ color: t.colors.sec, marginBottom: t.spacing.md }}>
+          Dev-only pipeline probe: pluck each string (low E especially) and watch raw vs smoothed
+          cents, jitter, callback cadence, and detect cost. Nothing here is recorded or saved.
+        </Text>
+
+        <Pressable
+          onPress={running ? stopCapture : startCapture}
+          style={{
+            backgroundColor: t.colors.accent,
+            borderRadius: t.radii.md,
+            paddingVertical: t.spacing.md,
+            alignItems: 'center',
+            marginBottom: t.spacing.lg,
+          }}
+        >
+          <Text style={{ color: t.colors.onAccent, fontWeight: '600' }}>
+            {running ? 'Stop' : 'Start listening'}
+          </Text>
+        </Pressable>
+
+        {rows.map(([label, value]) => (
+          <View
+            key={label}
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              paddingVertical: t.spacing.sm,
+              borderBottomWidth: 1,
+              borderBottomColor: t.colors.border,
+            }}
+          >
+            <Text style={{ color: t.colors.sec }}>{label}</Text>
+            <Text style={{ color: t.colors.ink, fontVariant: ['tabular-nums'] }}>{value}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    </Screen>
+  )
+}

--- a/apps/mobile/spike/tuner/bench.ts
+++ b/apps/mobile/spike/tuner/bench.ts
@@ -1,0 +1,218 @@
+// SPIKE-ONLY: headless benchmark for the tuner pitch pipeline.
+// Streams synthetic plucks (see signals.ts) through the YIN detector exactly
+// the way the device pipeline would — hop-sized callbacks filling a ring
+// buffer — and measures latency, accuracy, jitter, gross-error rate, and the
+// cost of smoothing, per configuration and per string (low E called out).
+//
+// Run from apps/mobile/:  npx -y tsx spike/tuner/bench.ts
+
+import { performance } from 'node:perf_hooks'
+import { STANDARD_TUNING, centsBetween } from '../../src/lib/tuner/notes'
+import { createYinDetector, decimate, rmsLevel } from '../../src/lib/tuner/yin'
+import { createCentsSmoother } from '../../src/lib/tuner/smoothing'
+import { synthPluck } from './signals'
+
+const CAPTURE_RATE = 48000
+
+interface Config {
+  name: string
+  decim: number
+  window: number
+  hop: number // in decimated samples
+}
+
+const CONFIGS: Config[] = [
+  { name: '48k w2048 h1024', decim: 1, window: 2048, hop: 1024 },
+  { name: '48k w4096 h1024', decim: 1, window: 4096, hop: 1024 },
+  { name: '24k w1024 h512 ', decim: 2, window: 1024, hop: 512 },
+  { name: '24k w2048 h512 ', decim: 2, window: 2048, hop: 512 },
+  { name: '12k w1024 h256 ', decim: 4, window: 1024, hop: 256 },
+]
+
+// Per-string physical character: low wound strings ring longer, are stiffer
+// (more inharmonic), and the low E's fundamental is notoriously weak.
+const STRING_CHARACTER: Record<string, { fundamentalGain: number; inharmonicity: number; decay: number }> = {
+  E2: { fundamentalGain: 0.3, inharmonicity: 1.7e-4, decay: 3.0 },
+  A2: { fundamentalGain: 0.6, inharmonicity: 1.2e-4, decay: 3.0 },
+  D3: { fundamentalGain: 0.8, inharmonicity: 1.0e-4, decay: 2.5 },
+  G3: { fundamentalGain: 1.0, inharmonicity: 0.8e-4, decay: 2.0 },
+  B3: { fundamentalGain: 1.0, inharmonicity: 0.5e-4, decay: 1.8 },
+  E4: { fundamentalGain: 1.0, inharmonicity: 0.4e-4, decay: 1.5 },
+}
+
+const DETUNES_CENTS = [0, 8, -20]
+const SNRS_DB = [Infinity, 25, 15]
+const SEEDS = [1, 2, 3]
+const ONSET_S = 0.05
+const RMS_GATE = 0.015
+const STEADY_MS: [number, number] = [250, 1000]
+
+interface PluckStats {
+  stringName: string
+  firstReadingMs: number | null
+  steadyMeanErr: number | null
+  steadyJitterStd: number | null
+  steadyP95Dev: number | null
+  grossRate: number
+  settleMs: number | null
+  smoothedJitterStd: number | null
+  detectCalls: number
+  detectMsTotal: number
+}
+
+function std(values: number[]): number {
+  const mean = values.reduce((a, b) => a + b, 0) / values.length
+  return Math.sqrt(values.reduce((a, v) => a + (v - mean) * (v - mean), 0) / values.length)
+}
+function median(values: number[]): number {
+  const s = [...values].sort((a, b) => a - b)
+  return s[Math.floor(s.length / 2)]
+}
+function quantile(values: number[], q: number): number {
+  const s = [...values].sort((a, b) => a - b)
+  return s[Math.min(s.length - 1, Math.floor(q * s.length))]
+}
+
+function runPluck(config: Config, stringName: string, f0True: number, snrDb: number, seed: number): PluckStats {
+  const character = STRING_CHARACTER[stringName]
+  const raw = synthPluck({
+    sampleRate: CAPTURE_RATE,
+    durationSeconds: 1.3,
+    f0: f0True,
+    onsetSeconds: ONSET_S,
+    fundamentalGain: character.fundamentalGain,
+    inharmonicity: character.inharmonicity,
+    decaySeconds: character.decay,
+    snrDb,
+    seed,
+  })
+  const audio = config.decim === 1 ? raw : decimate(raw, config.decim)
+  const sr = CAPTURE_RATE / config.decim
+
+  const detector = createYinDetector({ sampleRate: sr, windowSize: config.window })
+  const smoother = createCentsSmoother()
+
+  const stats: PluckStats = {
+    stringName,
+    firstReadingMs: null,
+    steadyMeanErr: null,
+    steadyJitterStd: null,
+    steadyP95Dev: null,
+    grossRate: 0,
+    settleMs: null,
+    smoothedJitterStd: null,
+    detectCalls: 0,
+    detectMsTotal: 0,
+  }
+
+  const steady: number[] = []
+  const smoothedSteady: number[] = []
+  let validCount = 0
+  let grossCount = 0
+  let settledAt: number | null = null
+
+  for (let end = config.window; end <= audio.length; end += config.hop) {
+    const frame = audio.subarray(end - config.window, end)
+    if (rmsLevel(frame) < RMS_GATE) {
+      smoother.reset()
+      continue
+    }
+    const t0 = performance.now()
+    const reading = detector.detect(frame)
+    stats.detectMsTotal += performance.now() - t0
+    stats.detectCalls++
+    if (!reading) continue
+
+    const tMs = (end / sr - ONSET_S) * 1000
+    const err = centsBetween(reading.frequency, f0True)
+    validCount++
+    if (Math.abs(err) > 50) {
+      grossCount++
+      continue
+    }
+    if (stats.firstReadingMs === null) stats.firstReadingMs = tMs
+
+    const smoothed = smoother.push(err)
+    if (settledAt === null && Math.abs(smoothed) <= 3) settledAt = tMs
+
+    if (tMs >= STEADY_MS[0] && tMs <= STEADY_MS[1]) {
+      steady.push(err)
+      smoothedSteady.push(smoothed)
+    }
+  }
+
+  if (steady.length >= 4) {
+    const mean = steady.reduce((a, b) => a + b, 0) / steady.length
+    stats.steadyMeanErr = mean
+    stats.steadyJitterStd = std(steady)
+    stats.steadyP95Dev = quantile(steady.map((v) => Math.abs(v - mean)), 0.95)
+    stats.smoothedJitterStd = std(smoothedSteady)
+  }
+  stats.grossRate = validCount > 0 ? grossCount / validCount : 1
+  stats.settleMs = settledAt
+  return stats
+}
+
+function fmt(v: number | null, digits = 1): string {
+  return v === null ? '—' : v.toFixed(digits)
+}
+
+const perConfig: Record<string, PluckStats[]> = {}
+for (const config of CONFIGS) {
+  const all: PluckStats[] = []
+  for (const string of STANDARD_TUNING) {
+    for (const detune of DETUNES_CENTS) {
+      const f0True = string.frequency * Math.pow(2, detune / 1200)
+      for (const snrDb of SNRS_DB) {
+        for (const seed of SEEDS) {
+          all.push(runPluck(config, string.name, f0True, snrDb, seed))
+        }
+      }
+    }
+  }
+  perConfig[config.name] = all
+}
+
+console.log(
+  `## Config comparison (all 6 strings × detunes ${DETUNES_CENTS.join('/')}c × SNR ${SNRS_DB.map((s) => (Number.isFinite(s) ? `${s}dB` : '∞')).join('/')} × ${SEEDS.length} seeds)\n`
+)
+console.log('| config | 1st reading ms (med/p90) | |bias| max (c) | raw jitter std med (c) | raw p95 dev med (c) | gross err % | settle ms med | smoothed jitter med (c) | detect ms/call |')
+console.log('|---|---|---|---|---|---|---|---|---|')
+for (const config of CONFIGS) {
+  const all = perConfig[config.name]
+  const first = all.map((s) => s.firstReadingMs).filter((v): v is number => v !== null)
+  const bias = all.map((s) => s.steadyMeanErr).filter((v): v is number => v !== null)
+  const jit = all.map((s) => s.steadyJitterStd).filter((v): v is number => v !== null)
+  const p95 = all.map((s) => s.steadyP95Dev).filter((v): v is number => v !== null)
+  const settle = all.map((s) => s.settleMs).filter((v): v is number => v !== null)
+  const smoothJit = all.map((s) => s.smoothedJitterStd).filter((v): v is number => v !== null)
+  const gross = all.reduce((a, s) => a + s.grossRate, 0) / all.length
+  const detectMs = all.reduce((a, s) => a + s.detectMsTotal, 0) / all.reduce((a, s) => a + s.detectCalls, 0)
+  const noReading = all.length - first.length
+  console.log(
+    `| ${config.name} | ${fmt(median(first), 0)} / ${fmt(quantile(first, 0.9), 0)}${noReading ? ` (${noReading} misses)` : ''} ` +
+      `| ${fmt(Math.max(...bias.map(Math.abs)))} | ${fmt(median(jit), 2)} | ${fmt(median(p95), 2)} ` +
+      `| ${(gross * 100).toFixed(2)} | ${fmt(median(settle), 0)} | ${fmt(median(smoothJit), 2)} | ${detectMs.toFixed(2)} |`
+  )
+}
+
+console.log('\n## Per-string detail')
+for (const config of CONFIGS) {
+  console.log(`\n### ${config.name}\n`)
+  console.log('| string | 1st reading ms med | bias c med | raw jitter std med c | gross % | settle ms med | smoothed jitter med c |')
+  console.log('|---|---|---|---|---|---|---|')
+  for (const string of STANDARD_TUNING) {
+    const rows = perConfig[config.name].filter((s) => s.stringName === string.name)
+    const first = rows.map((s) => s.firstReadingMs).filter((v): v is number => v !== null)
+    const bias = rows.map((s) => s.steadyMeanErr).filter((v): v is number => v !== null)
+    const jit = rows.map((s) => s.steadyJitterStd).filter((v): v is number => v !== null)
+    const settle = rows.map((s) => s.settleMs).filter((v): v is number => v !== null)
+    const smoothJit = rows.map((s) => s.smoothedJitterStd).filter((v): v is number => v !== null)
+    const gross = rows.reduce((a, s) => a + s.grossRate, 0) / rows.length
+    console.log(
+      `| ${string.name} | ${first.length ? fmt(median(first), 0) : 'NO READ'} | ${bias.length ? fmt(median(bias)) : '—'} ` +
+        `| ${jit.length ? fmt(median(jit), 2) : '—'} | ${(gross * 100).toFixed(2)} | ${settle.length ? fmt(median(settle), 0) : '—'} ` +
+        `| ${smoothJit.length ? fmt(median(smoothJit), 2) : '—'} |`
+    )
+  }
+}

--- a/apps/mobile/spike/tuner/signals.ts
+++ b/apps/mobile/spike/tuner/signals.ts
@@ -1,0 +1,101 @@
+// SPIKE-ONLY: synthetic plucked-guitar-string generator for benchmarking the
+// pitch pipeline headless. Models the properties that actually break naive
+// pitch detectors: string inharmonicity, per-partial decay, a noisy pluck
+// attack, a weak low-E fundamental, and background noise.
+
+/** Deterministic PRNG (mulberry32) so benchmark runs are reproducible. */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export interface PluckOptions {
+  sampleRate: number
+  durationSeconds: number
+  /** True fundamental in Hz (ground truth for the benchmark). */
+  f0: number
+  /** Silence before the pluck, seconds (models "waiting for the player"). */
+  onsetSeconds?: number
+  /** Number of partials to synthesize. */
+  partials?: number
+  /** Stiff-string inharmonicity coefficient B (f_k = k f0 sqrt(1 + B k^2)). */
+  inharmonicity?: number
+  /** Gain applied to the fundamental only — low E often has a weak one. */
+  fundamentalGain?: number
+  /** 1/k^rolloff spectral envelope for partial amplitudes. */
+  rolloff?: number
+  /** Base decay time constant, seconds; higher partials decay ~k^1.5 faster. */
+  decaySeconds?: number
+  /** Background white-noise SNR in dB relative to the pluck's initial level; Infinity = clean. */
+  snrDb?: number
+  seed?: number
+}
+
+export function synthPluck(options: PluckOptions): Float32Array {
+  const {
+    sampleRate,
+    durationSeconds,
+    f0,
+    onsetSeconds = 0.05,
+    partials = 12,
+    inharmonicity = 1e-4,
+    fundamentalGain = 1,
+    rolloff = 1.2,
+    decaySeconds = 2.5,
+    snrDb = Infinity,
+    seed = 1,
+  } = options
+  const rng = makeRng(seed)
+  const length = Math.floor(durationSeconds * sampleRate)
+  const out = new Float32Array(length)
+  const onset = Math.floor(onsetSeconds * sampleRate)
+
+  interface Partial {
+    omega: number
+    phase: number
+    amp: number
+    decayRate: number
+  }
+  const parts: Partial[] = []
+  for (let k = 1; k <= partials; k++) {
+    const fk = k * f0 * Math.sqrt(1 + inharmonicity * k * k)
+    if (fk >= sampleRate / 2) break
+    parts.push({
+      omega: (2 * Math.PI * fk) / sampleRate,
+      phase: rng() * 2 * Math.PI,
+      amp: (1 / Math.pow(k, rolloff)) * (k === 1 ? fundamentalGain : 1),
+      decayRate: Math.pow(k, 1.5) / decaySeconds,
+    })
+  }
+
+  let peak = 0
+  for (let i = onset; i < length; i++) {
+    const t = (i - onset) / sampleRate
+    // Fast attack so the first analysis window sees a transient, like a pick.
+    const attack = 1 - Math.exp(-t / 0.004)
+    let sample = 0
+    for (const p of parts) {
+      sample += p.amp * Math.exp(-t * p.decayRate) * Math.sin(p.omega * (i - onset) + p.phase)
+    }
+    // Short broadband pick scrape at the very start.
+    if (t < 0.02) sample += (rng() * 2 - 1) * 0.3 * Math.exp(-t / 0.005)
+    out[i] = sample * attack
+    const abs = Math.abs(out[i])
+    if (abs > peak) peak = abs
+  }
+
+  // Normalize to a nominal level, then add background noise at the target SNR.
+  const level = 0.5
+  const gain = peak > 0 ? level / peak : 1
+  const noiseAmp = Number.isFinite(snrDb) ? level * Math.pow(10, -snrDb / 20) : 0
+  for (let i = 0; i < length; i++) {
+    out[i] = out[i] * gain + (noiseAmp > 0 ? (rng() * 2 - 1) * noiseAmp : 0)
+  }
+  return out
+}

--- a/apps/mobile/src/lib/tuner/__tests__/tuner.test.ts
+++ b/apps/mobile/src/lib/tuner/__tests__/tuner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { STANDARD_TUNING, centsBetween, nearestString } from '../notes'
+import { STANDARD_TUNING, centsBetween, nearestString, stringReading } from '../notes'
+import { createInTuneHold } from '../hold'
 import { createYinDetector, rmsLevel } from '../yin'
 import { createCentsSmoother } from '../smoothing'
 
@@ -40,6 +41,61 @@ describe('nearestString', () => {
     expect(nearestString(2000)).toBeNull()
     expect(nearestString(0)).toBeNull()
     expect(nearestString(NaN)).toBeNull()
+  })
+})
+
+describe('stringReading (manual lock)', () => {
+  const A2 = STANDARD_TUNING[1]
+  it('auto-detects when no lock is set', () => {
+    expect(stringReading(82.4069, null)?.string.name).toBe('E2')
+  })
+  it('measures against the locked string even when another is nearer', () => {
+    const reading = stringReading(82.4069, A2) // low E pitch, locked to A
+    expect(reading?.string.name).toBe('A2')
+    expect(reading?.cents).toBeCloseTo(-500, 0) // a fourth flat of A2
+  })
+  it('locked mode has no auto-mode range cutoff near the target', () => {
+    const reading = stringReading(A2.frequency * Math.pow(2, -450 / 1200), A2)
+    expect(reading?.string.name).toBe('A2')
+    expect(reading?.cents).toBeCloseTo(-450, 0)
+  })
+  it('still rejects invalid frequencies when locked', () => {
+    expect(stringReading(0, A2)).toBeNull()
+    expect(stringReading(NaN, A2)).toBeNull()
+  })
+})
+
+describe('createInTuneHold', () => {
+  it('reports settling inside the threshold and locks only after the hold', () => {
+    const hold = createInTuneHold({ thresholdCents: 4, holdMs: 500 })
+    expect(hold.push(2, 0)).toBe('settling')
+    expect(hold.push(-3, 250)).toBe('settling')
+    expect(hold.push(1, 499)).toBe('settling')
+    expect(hold.push(0, 500)).toBe('inTune')
+    expect(hold.push(2, 600)).toBe('inTune')
+  })
+  it('restarts the hold when the pitch leaves the threshold', () => {
+    const hold = createInTuneHold({ thresholdCents: 4, holdMs: 500 })
+    hold.push(2, 0)
+    expect(hold.push(10, 300)).toBe('off')
+    expect(hold.push(2, 400)).toBe('settling')
+    expect(hold.push(2, 899)).toBe('settling')
+    expect(hold.push(2, 900)).toBe('inTune')
+  })
+  it('keeps the lock through slack-sized drift but drops beyond it', () => {
+    const hold = createInTuneHold({ thresholdCents: 4, holdMs: 500, exitSlackCents: 2 })
+    hold.push(0, 0)
+    hold.push(0, 500)
+    expect(hold.push(5.5, 600)).toBe('inTune') // within threshold + slack
+    expect(hold.push(7, 700)).toBe('off')
+    expect(hold.push(5.5, 800)).toBe('off') // slack gone until re-held
+  })
+  it('reset clears an active lock', () => {
+    const hold = createInTuneHold()
+    hold.push(0, 0)
+    hold.push(0, 1000)
+    hold.reset()
+    expect(hold.push(0, 1100)).toBe('settling')
   })
 })
 

--- a/apps/mobile/src/lib/tuner/__tests__/tuner.test.ts
+++ b/apps/mobile/src/lib/tuner/__tests__/tuner.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { STANDARD_TUNING, centsBetween, nearestString } from '../notes'
+import { createYinDetector, rmsLevel } from '../yin'
+import { createCentsSmoother } from '../smoothing'
+
+describe('centsBetween', () => {
+  it('is 0 at the reference frequency', () => {
+    expect(centsBetween(440, 440)).toBe(0)
+  })
+  it('is +1200 an octave up and -1200 an octave down', () => {
+    expect(centsBetween(880, 440)).toBeCloseTo(1200, 6)
+    expect(centsBetween(220, 440)).toBeCloseTo(-1200, 6)
+  })
+  it('is +100 one equal-tempered semitone up', () => {
+    expect(centsBetween(440 * Math.pow(2, 1 / 12), 440)).toBeCloseTo(100, 6)
+  })
+})
+
+describe('nearestString', () => {
+  it('maps each exact string frequency to itself at 0 cents', () => {
+    for (const s of STANDARD_TUNING) {
+      const reading = nearestString(s.frequency)
+      expect(reading?.string.name).toBe(s.name)
+      expect(reading?.cents).toBeCloseTo(0, 6)
+    }
+  })
+  it('reads 85 Hz as a sharp low E', () => {
+    const reading = nearestString(85)
+    expect(reading?.string.name).toBe('E2')
+    expect(reading?.cents).toBeGreaterThan(0)
+    expect(reading?.cents).toBeCloseTo(53.7, 0)
+  })
+  it('reads 100 Hz as a flat A (nearer A2 than E2)', () => {
+    const reading = nearestString(100)
+    expect(reading?.string.name).toBe('A2')
+    expect(reading?.cents).toBeLessThan(0)
+  })
+  it('rejects frequencies far outside the guitar range', () => {
+    expect(nearestString(30)).toBeNull()
+    expect(nearestString(2000)).toBeNull()
+    expect(nearestString(0)).toBeNull()
+    expect(nearestString(NaN)).toBeNull()
+  })
+})
+
+function sine(frequency: number, sampleRate: number, length: number): Float32Array {
+  const out = new Float32Array(length)
+  for (let i = 0; i < length; i++) out[i] = Math.sin((2 * Math.PI * frequency * i) / sampleRate)
+  return out
+}
+
+describe('createYinDetector', () => {
+  const sampleRate = 24000
+  const detector = createYinDetector({ sampleRate, windowSize: 2048 })
+
+  it('detects each standard-tuning string frequency within 1 cent on a pure tone', () => {
+    for (const s of STANDARD_TUNING) {
+      const reading = detector.detect(sine(s.frequency, sampleRate, 2048))
+      expect(reading, s.name).not.toBeNull()
+      expect(Math.abs(centsBetween(reading!.frequency, s.frequency)), s.name).toBeLessThan(1)
+    }
+  })
+  it('detects low E (82.41 Hz) specifically', () => {
+    const reading = detector.detect(sine(82.4069, sampleRate, 2048))
+    expect(reading).not.toBeNull()
+    expect(nearestString(reading!.frequency)?.string.name).toBe('E2')
+  })
+  it('returns null on silence and on white noise', () => {
+    expect(detector.detect(new Float32Array(2048))).toBeNull()
+    const noise = new Float32Array(2048)
+    let seed = 42
+    for (let i = 0; i < noise.length; i++) {
+      seed = (seed * 1664525 + 1013904223) >>> 0
+      noise[i] = seed / 2 ** 31 - 1
+    }
+    expect(detector.detect(noise)).toBeNull()
+  })
+  it('throws when the window cannot hold the lowest period', () => {
+    expect(() => createYinDetector({ sampleRate: 48000, windowSize: 512 })).toThrow()
+  })
+})
+
+describe('rmsLevel', () => {
+  it('is 0 for silence and ~0.707 for a full-scale sine', () => {
+    expect(rmsLevel(new Float32Array(512))).toBe(0)
+    expect(rmsLevel(sine(440, 48000, 4800))).toBeCloseTo(Math.SQRT1_2, 2)
+  })
+})
+
+describe('createCentsSmoother', () => {
+  it('suppresses a single-frame glitch via the median', () => {
+    const smoother = createCentsSmoother({ medianWindow: 5, emaAlpha: 1 })
+    smoother.push(10)
+    smoother.push(10)
+    smoother.push(10)
+    expect(smoother.push(600)).toBe(10) // octave glitch ignored
+    expect(smoother.push(10)).toBe(10)
+  })
+  it('converges to a steady input after reset', () => {
+    const smoother = createCentsSmoother()
+    smoother.push(-40)
+    smoother.reset()
+    let value = 0
+    for (let i = 0; i < 20; i++) value = smoother.push(5)
+    expect(value).toBeCloseTo(5, 1)
+  })
+})

--- a/apps/mobile/src/lib/tuner/hold.ts
+++ b/apps/mobile/src/lib/tuner/hold.ts
@@ -1,0 +1,50 @@
+// In-tune hold: the needle should only read "in tune" after the pitch has
+// *stayed* within the threshold for a hold period — a settling low E must not
+// flash green on its way through zero. Pure and clock-injected so it
+// unit-tests headless.
+
+export type HoldState = 'off' | 'settling' | 'inTune'
+
+export interface InTuneHoldOptions {
+  /** |cents| that counts as in tune. Spike-recommended: 4. */
+  thresholdCents?: number
+  /** How long the pitch must stay inside the threshold before locking. */
+  holdMs?: number
+  /**
+   * Once locked, allow this much extra drift before dropping the lock, so a
+   * reading hovering right at the threshold doesn't flicker.
+   */
+  exitSlackCents?: number
+}
+
+export interface InTuneHold {
+  /** Feeds one smoothed cents reading with its timestamp. */
+  push(cents: number, nowMs: number): HoldState
+  reset(): void
+}
+
+export function createInTuneHold(options: InTuneHoldOptions = {}): InTuneHold {
+  const threshold = options.thresholdCents ?? 4
+  const holdMs = options.holdMs ?? 500
+  const exitSlack = options.exitSlackCents ?? 2
+  let enteredAt: number | null = null
+  let locked = false
+
+  return {
+    push(cents: number, nowMs: number): HoldState {
+      const limit = locked ? threshold + exitSlack : threshold
+      if (Math.abs(cents) > limit) {
+        enteredAt = null
+        locked = false
+        return 'off'
+      }
+      if (enteredAt === null) enteredAt = nowMs
+      if (nowMs - enteredAt >= holdMs) locked = true
+      return locked ? 'inTune' : 'settling'
+    },
+    reset() {
+      enteredAt = null
+      locked = false
+    },
+  }
+}

--- a/apps/mobile/src/lib/tuner/notes.ts
+++ b/apps/mobile/src/lib/tuner/notes.ts
@@ -51,3 +51,19 @@ export function nearestString(
   if (best && Math.abs(best.cents) > 400) return null
   return best
 }
+
+/**
+ * Resolves a detected frequency to a string reading, honoring a manual lock.
+ * Locked: cents are measured against the locked string regardless of which
+ * string is actually nearest (that's the point — a badly-out-of-tune string
+ * should still read against its target). Unlocked: auto-detect the nearest.
+ */
+export function stringReading(
+  frequency: number,
+  lock: TunerString | null,
+  tuning: readonly TunerString[] = STANDARD_TUNING
+): StringReading | null {
+  if (lock === null) return nearestString(frequency, tuning)
+  if (!Number.isFinite(frequency) || frequency <= 0) return null
+  return { string: lock, cents: centsBetween(frequency, lock.frequency) }
+}

--- a/apps/mobile/src/lib/tuner/notes.ts
+++ b/apps/mobile/src/lib/tuner/notes.ts
@@ -1,0 +1,53 @@
+// Pure note math for the tuner. RN-free so it unit-tests headless.
+// Standard tuning only for v1; the string list is data, so alternate tunings
+// can be added later by passing a different array.
+
+export interface TunerString {
+  /** Display letter (what the string row shows). */
+  label: string
+  /** Scientific pitch name, unique per string. */
+  name: string
+  /** Target fundamental in Hz (A4 = 440). */
+  frequency: number
+}
+
+export const STANDARD_TUNING: readonly TunerString[] = [
+  { label: 'E', name: 'E2', frequency: 82.4069 },
+  { label: 'A', name: 'A2', frequency: 110.0 },
+  { label: 'D', name: 'D3', frequency: 146.8324 },
+  { label: 'G', name: 'G3', frequency: 195.9977 },
+  { label: 'B', name: 'B3', frequency: 246.9417 },
+  { label: 'E', name: 'E4', frequency: 329.6276 },
+]
+
+/** Signed cents from `reference` to `frequency` (positive = sharp). */
+export function centsBetween(frequency: number, reference: number): number {
+  return 1200 * Math.log2(frequency / reference)
+}
+
+export interface StringReading {
+  string: TunerString
+  cents: number
+}
+
+/**
+ * Picks the tuning string nearest (in cents) to a detected frequency.
+ * Returns null for frequencies wildly outside the guitar range, where a
+ * "nearest string" reading would be meaningless noise.
+ */
+export function nearestString(
+  frequency: number,
+  tuning: readonly TunerString[] = STANDARD_TUNING
+): StringReading | null {
+  if (!Number.isFinite(frequency) || frequency <= 0) return null
+  let best: StringReading | null = null
+  for (const string of tuning) {
+    const cents = centsBetween(frequency, string.frequency)
+    if (best === null || Math.abs(cents) < Math.abs(best.cents)) {
+      best = { string, cents }
+    }
+  }
+  // More than ~4 semitones from every string: not a plausible string pitch.
+  if (best && Math.abs(best.cents) > 400) return null
+  return best
+}

--- a/apps/mobile/src/lib/tuner/smoothing.ts
+++ b/apps/mobile/src/lib/tuner/smoothing.ts
@@ -1,0 +1,39 @@
+// Cents smoothing for the tuner needle: median (kills single-frame octave/
+// attack glitches) followed by an EMA (damps residual jitter). Pure and
+// RN-free so the spike benchmark and unit tests can drive it headless.
+
+export interface SmootherOptions {
+  /** Median window length in readings. Odd; 5 ≈ 100 ms at a ~21 ms hop. */
+  medianWindow?: number
+  /** EMA coefficient in (0, 1]; higher tracks faster, lower is steadier. */
+  emaAlpha?: number
+}
+
+export interface CentsSmoother {
+  /** Feeds one raw cents reading; returns the smoothed value. */
+  push(cents: number): number
+  /** Call when detection drops out (new pluck, silence) to avoid smearing. */
+  reset(): void
+}
+
+export function createCentsSmoother(options: SmootherOptions = {}): CentsSmoother {
+  const medianWindow = options.medianWindow ?? 5
+  const emaAlpha = options.emaAlpha ?? 0.35
+  const history: number[] = []
+  let ema: number | null = null
+
+  return {
+    push(cents: number): number {
+      history.push(cents)
+      if (history.length > medianWindow) history.shift()
+      const sorted = [...history].sort((a, b) => a - b)
+      const median = sorted[Math.floor(sorted.length / 2)]
+      ema = ema === null ? median : ema + emaAlpha * (median - ema)
+      return ema
+    },
+    reset() {
+      history.length = 0
+      ema = null
+    },
+  }
+}

--- a/apps/mobile/src/lib/tuner/useTuner.ts
+++ b/apps/mobile/src/lib/tuner/useTuner.ts
@@ -1,0 +1,226 @@
+// Native capture glue for the tuner — the only tuner module that imports
+// react-native-audio-api. Pipeline and parameters are the spike-proven config
+// (see spike/tuner/RESULTS.md): 48 kHz mono capture, decimate ×2 → 24 kHz,
+// YIN window 2048 (~85 ms) at a 1024-frame callback hop (~21 ms updates),
+// median-5 + EMA-0.35 smoothing, in-tune hold |cents| ≤ 4 for 500 ms.
+//
+// Privacy by construction: `enableFileOutput()` is never called, so the
+// recorder can't write audio to disk, and nothing here touches the network.
+// Buffers are analyzed in memory and discarded.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AudioManager, AudioRecorder } from 'react-native-audio-api'
+import { stringReading, type StringReading, type TunerString } from './notes'
+import { createYinDetector, decimate, rmsLevel } from './yin'
+import { createCentsSmoother } from './smoothing'
+import { createInTuneHold, type HoldState } from './hold'
+
+const CAPTURE_RATE = 48000
+const CALLBACK_LENGTH = 1024
+const DECIMATION = 2
+const ANALYSIS_RATE = CAPTURE_RATE / DECIMATION
+const WINDOW = 2048
+const RMS_GATE = 0.008
+/** Keep showing the last reading through short detection dropouts (note decay). */
+const DROPOUT_MS = 400
+
+export type TunerPermission = 'unknown' | 'undetermined' | 'granted' | 'denied'
+
+export interface TunerReading {
+  frequency: number
+  /** Smoothed cents vs the resolved string — what the needle shows. */
+  cents: number
+  string: StringReading['string']
+  hold: HoldState
+}
+
+export interface TunerFrame {
+  reading: TunerReading | null
+}
+
+export interface UseTunerOptions {
+  /**
+   * Full-rate (~47/s) frame callback for driving the needle without React
+   * re-renders (e.g. writing a Reanimated shared value). Optional; the
+   * throttled `reading` state below is enough for text.
+   */
+  onFrame?: (frame: TunerFrame) => void
+}
+
+export interface Tuner {
+  permission: TunerPermission
+  /** Asks for mic access (first-use prompt). Resolves to the new state. */
+  requestPermission: () => Promise<TunerPermission>
+  running: boolean
+  start: () => Promise<void>
+  stop: () => void
+  /** Manual string lock; null = auto-detect. Changing it re-anchors live. */
+  lockedString: TunerString | null
+  setLockedString: (s: TunerString | null) => void
+  /** Throttled (~10/s) reading for text displays; null while silent. */
+  reading: TunerReading | null
+}
+
+function toPermission(status: string): TunerPermission {
+  if (status === 'Granted') return 'granted'
+  if (status === 'Denied') return 'denied'
+  return 'undetermined'
+}
+
+export function useTuner(options: UseTunerOptions = {}): Tuner {
+  const [permission, setPermission] = useState<TunerPermission>('unknown')
+  const [running, setRunning] = useState(false)
+  const [reading, setReading] = useState<TunerReading | null>(null)
+  const [lockedString, setLockedStringState] = useState<TunerString | null>(null)
+
+  const recorderRef = useRef<AudioRecorder | null>(null)
+  const lockRef = useRef<TunerString | null>(null)
+  const onFrameRef = useRef<UseTunerOptions['onFrame']>(options.onFrame)
+  onFrameRef.current = options.onFrame
+  const lastTextPushRef = useRef(0)
+
+  useEffect(() => {
+    let alive = true
+    AudioManager.checkRecordingPermissions()
+      .then((status) => {
+        if (alive) setPermission(toPermission(status))
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const stop = useCallback(() => {
+    const recorder = recorderRef.current
+    recorderRef.current = null
+    if (recorder) {
+      recorder.stop().catch(() => {})
+      recorder.clearOnAudioReady()
+      recorder.clearOnError()
+      AudioManager.setAudioSessionActivity(false).catch(() => {})
+    }
+    setRunning(false)
+    setReading(null)
+    onFrameRef.current?.({ reading: null })
+  }, [])
+
+  useEffect(() => stop, [stop])
+
+  const requestPermission = useCallback(async (): Promise<TunerPermission> => {
+    const status = toPermission(await AudioManager.requestRecordingPermissions())
+    setPermission(status)
+    return status
+  }, [])
+
+  const publish = useCallback((next: TunerReading | null, force: boolean) => {
+    onFrameRef.current?.({ reading: next })
+    // Text (note letter / Hz / cents digits) re-renders at ~10 Hz — the
+    // needle gets every frame via onFrame instead.
+    const now = Date.now()
+    if (force || now - lastTextPushRef.current >= 100) {
+      lastTextPushRef.current = now
+      setReading(next)
+    }
+  }, [])
+
+  const start = useCallback(async () => {
+    if (recorderRef.current) return
+    if ((await requestPermission()) !== 'granted') return
+
+    // 'measurement' disables system input processing (AGC / voice isolation)
+    // that would otherwise mangle the tuner's view of the raw signal.
+    AudioManager.setAudioSessionOptions({ iosCategory: 'record', iosMode: 'measurement' })
+    await AudioManager.setAudioSessionActivity(true)
+
+    const detector = createYinDetector({ sampleRate: ANALYSIS_RATE, windowSize: WINDOW })
+    const smoother = createCentsSmoother()
+    const hold = createInTuneHold()
+    const ring = new Float32Array(WINDOW)
+    let filled = 0
+    let lastReading: TunerReading | null = null
+    let lastReadingAt = 0
+
+    const clear = () => {
+      smoother.reset()
+      hold.reset()
+      lastReading = null
+      // Always force: a throttled null could be skipped and never re-sent,
+      // leaving stale text on screen through the silence.
+      publish(null, true)
+    }
+
+    const recorder = new AudioRecorder()
+    recorderRef.current = recorder
+    recorder.onAudioReady(
+      { sampleRate: CAPTURE_RATE, bufferLength: CALLBACK_LENGTH, channelCount: 1 },
+      (event) => {
+        const chunk = decimate(event.buffer.getChannelData(0), DECIMATION)
+        ring.copyWithin(0, chunk.length)
+        ring.set(chunk, WINDOW - chunk.length)
+        filled = Math.min(WINDOW, filled + chunk.length)
+        if (filled < WINDOW) return
+
+        const now = Date.now()
+        if (rmsLevel(ring) < RMS_GATE) {
+          if (lastReading) clear()
+          return
+        }
+
+        const detected = detector.detect(ring)
+        const resolved = detected ? stringReading(detected.frequency, lockRef.current) : null
+        if (!resolved) {
+          // Single-frame YIN misses happen mid-decay; hold the display briefly
+          // instead of blanking, then clear on a real dropout.
+          if (lastReading && now - lastReadingAt > DROPOUT_MS) clear()
+          else if (lastReading) publish(lastReading, false)
+          return
+        }
+
+        // A new string (auto mode) or a re-anchored lock restarts smoothing so
+        // the needle doesn't glide across from the previous target.
+        if (lastReading && lastReading.string.name !== resolved.string.name) {
+          smoother.reset()
+          hold.reset()
+        }
+        const cents = smoother.push(resolved.cents)
+        lastReading = {
+          frequency: detected!.frequency,
+          cents,
+          string: resolved.string,
+          hold: hold.push(cents, now),
+        }
+        lastReadingAt = now
+        publish(lastReading, false)
+      }
+    )
+    recorder.onError(() => {
+      clear()
+    })
+    await recorder.start()
+    setRunning(true)
+  }, [publish, requestPermission])
+
+  const setLockedString = useCallback(
+    (s: TunerString | null) => {
+      lockRef.current = s
+      setLockedStringState(s)
+      // Re-anchor immediately: cents against a new target are a different
+      // quantity, so continuing the old smoothing window would be wrong.
+      setReading(null)
+      onFrameRef.current?.({ reading: null })
+    },
+    []
+  )
+
+  return {
+    permission,
+    requestPermission,
+    running,
+    start,
+    stop,
+    lockedString,
+    setLockedString,
+    reading,
+  }
+}

--- a/apps/mobile/src/lib/tuner/yin.ts
+++ b/apps/mobile/src/lib/tuner/yin.ts
@@ -1,0 +1,121 @@
+// YIN pitch detection (de Cheveigné & Kawahara 2002), tuned for a guitar
+// tuner: cumulative-mean-normalized difference + absolute threshold +
+// parabolic interpolation. Pure TS, RN-free, no allocations per call after
+// construction — safe to run per audio callback.
+
+export interface YinOptions {
+  sampleRate: number
+  /** Analysis window length in samples (power of two not required). */
+  windowSize: number
+  /** Lowest detectable fundamental, Hz. Guitar low E is 82.4. */
+  fMin?: number
+  /** Highest detectable fundamental, Hz. High E is 329.6. */
+  fMax?: number
+  /** CMNDF acceptance threshold; lower = stricter (fewer, cleaner readings). */
+  threshold?: number
+}
+
+export interface PitchReading {
+  frequency: number
+  /** 1 - CMNDF minimum: rough periodicity confidence in [0, 1]. */
+  clarity: number
+}
+
+export interface YinDetector {
+  readonly windowSize: number
+  /** Returns null when no periodic pitch is found in the frame. */
+  detect(frame: Float32Array): PitchReading | null
+}
+
+export function createYinDetector(options: YinOptions): YinDetector {
+  const { sampleRate, windowSize } = options
+  const fMin = options.fMin ?? 70
+  const fMax = options.fMax ?? 400
+  const threshold = options.threshold ?? 0.12
+
+  const tauMax = Math.floor(sampleRate / fMin)
+  const tauMin = Math.max(2, Math.floor(sampleRate / fMax))
+  if (windowSize <= tauMax + 8) {
+    throw new Error(
+      `windowSize ${windowSize} too small for fMin ${fMin} at ${sampleRate} Hz (needs > ${tauMax + 8})`
+    )
+  }
+  // Integration window: what remains of the frame after the largest lag.
+  const integration = windowSize - tauMax
+
+  const cmndf = new Float32Array(tauMax + 1)
+
+  function detect(frame: Float32Array): PitchReading | null {
+    if (frame.length < windowSize) return null
+
+    // Difference function + cumulative mean normalization in one pass.
+    cmndf[0] = 1
+    let runningSum = 0
+    for (let tau = 1; tau <= tauMax; tau++) {
+      let diff = 0
+      for (let i = 0; i < integration; i++) {
+        const delta = frame[i] - frame[i + tau]
+        diff += delta * delta
+      }
+      runningSum += diff
+      cmndf[tau] = runningSum === 0 ? 1 : (diff * tau) / runningSum
+    }
+
+    // Absolute threshold: first dip under threshold, then slide to its local
+    // minimum. Falling back to the global minimum when nothing dips under
+    // would invite octave errors, so we simply report "no pitch".
+    let tau = -1
+    for (let t = tauMin; t <= tauMax; t++) {
+      if (cmndf[t] < threshold) {
+        while (t + 1 <= tauMax && cmndf[t + 1] < cmndf[t]) t++
+        tau = t
+        break
+      }
+    }
+    if (tau === -1) return null
+
+    // Parabolic interpolation around the minimum for sub-sample precision.
+    let betterTau = tau
+    if (tau > tauMin && tau < tauMax) {
+      const s0 = cmndf[tau - 1]
+      const s1 = cmndf[tau]
+      const s2 = cmndf[tau + 1]
+      const denom = 2 * (2 * s1 - s2 - s0)
+      if (denom !== 0) {
+        const adjustment = (s2 - s0) / denom
+        if (Math.abs(adjustment) < 1) betterTau = tau + adjustment
+      }
+    }
+
+    return {
+      frequency: sampleRate / betterTau,
+      clarity: 1 - cmndf[tau],
+    }
+  }
+
+  return { windowSize, detect }
+}
+
+/** RMS level of a frame — used to gate detection below the noise floor. */
+export function rmsLevel(frame: Float32Array): number {
+  let sum = 0
+  for (let i = 0; i < frame.length; i++) sum += frame[i] * frame[i]
+  return Math.sqrt(sum / frame.length)
+}
+
+/**
+ * Decimates by an integer factor with a simple box-average pre-filter.
+ * Good enough anti-aliasing for pitch tracking (energy above the new Nyquist
+ * is mostly high harmonics we don't need); production quality would use a
+ * proper FIR if we keep decimation at all.
+ */
+export function decimate(input: Float32Array, factor: number): Float32Array {
+  const out = new Float32Array(Math.floor(input.length / factor))
+  for (let i = 0; i < out.length; i++) {
+    let sum = 0
+    const base = i * factor
+    for (let j = 0; j < factor; j++) sum += input[base + j]
+    out[i] = sum / factor
+  }
+  return out
+}

--- a/apps/mobile/src/screens/TunerScreen.tsx
+++ b/apps/mobile/src/screens/TunerScreen.tsx
@@ -1,0 +1,365 @@
+import { useCallback, useState } from 'react'
+import { Linking, Pressable, Text, View, useWindowDimensions } from 'react-native'
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
+import { router, useFocusEffect } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Screen from '../components/Screen'
+import Button from '../components/Button'
+import GlassSurface from '../components/GlassSurface'
+import SymbolIcon from '../components/SymbolIcon'
+import { useTheme } from '../theme/ThemeProvider'
+import type { Tokens } from '@gracechords/tokens/native'
+import { STANDARD_TUNING, type TunerString } from '../lib/tuner/notes'
+import { useTuner, type TunerFrame, type TunerReading } from '../lib/tuner/useTuner'
+
+// The guitar tuner (Utilities → Tuner). Auto-detects the nearest
+// standard-tuning string; tapping a string in the row locks detection to it
+// (tap again to release). The needle is driven at full pipeline rate (~47/s)
+// through a Reanimated shared value — no React re-render per frame; text
+// updates are throttled in useTuner. See src/lib/tuner/ for the detection
+// core and spike/tuner/RESULTS.md for the parameter provenance.
+
+const METER_RANGE_CENTS = 50
+const METER_SWEEP_DEG = 45 // needle angle at full scale (±)
+
+function MeterTicks({ radius, t }: { radius: number; t: Tokens }) {
+  const ticks = []
+  for (let cents = -METER_RANGE_CENTS; cents <= METER_RANGE_CENTS; cents += 10) {
+    const major = cents === 0 || Math.abs(cents) === METER_RANGE_CENTS
+    ticks.push(
+      <View
+        key={cents}
+        style={{
+          position: 'absolute',
+          left: '50%',
+          bottom: 0,
+          marginLeft: -1,
+          width: 2,
+          height: radius,
+          transformOrigin: 'bottom center',
+          transform: [{ rotate: `${(cents / METER_RANGE_CENTS) * METER_SWEEP_DEG}deg` }],
+        }}
+      >
+        <View
+          style={{
+            width: 2,
+            height: major ? 18 : 10,
+            borderRadius: 1,
+            backgroundColor: cents === 0 ? t.colors.accent : t.colors.off,
+          }}
+        />
+      </View>
+    )
+  }
+  return <>{ticks}</>
+}
+
+function holdColor(reading: TunerReading | null, t: Tokens): string {
+  if (!reading) return t.colors.muted
+  if (reading.hold === 'inTune') return t.colors.success
+  if (reading.hold === 'settling') return t.colors.accent
+  return t.colors.ink
+}
+
+function StringKey({
+  string,
+  state,
+  onPress,
+  t,
+}: {
+  string: TunerString
+  state: 'idle' | 'active' | 'locked'
+  onPress: () => void
+  t: Tokens
+}) {
+  const bg =
+    state === 'locked' ? t.colors.accent : state === 'active' ? t.colors.accentSoft : t.colors.surfaceAlt
+  const fg = state === 'locked' ? t.colors.onAccent : state === 'active' ? t.colors.textAccent : t.colors.ink
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityState={{ selected: state === 'locked' }}
+      accessibilityLabel={`${string.name}${state === 'locked' ? ' — locked, tap for auto' : ''}`}
+      style={({ pressed }) => ({
+        flex: 1,
+        alignItems: 'center',
+        paddingVertical: t.spacing.md,
+        borderRadius: t.radii.md,
+        backgroundColor: bg,
+        borderWidth: 1,
+        borderColor: state === 'idle' ? t.colors.border : 'transparent',
+        opacity: pressed ? 0.85 : 1,
+      })}
+    >
+      <Text style={{ fontSize: 17, fontWeight: '700', color: fg }}>{string.label}</Text>
+      <Text style={{ fontSize: 10, fontWeight: '600', color: fg, opacity: 0.7 }}>
+        {string.name.slice(-1)}
+      </Text>
+    </Pressable>
+  )
+}
+
+export default function TunerScreen() {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const { width } = useWindowDimensions()
+  const [barH, setBarH] = useState(0)
+
+  const needleCents = useSharedValue(0)
+  const needleActive = useSharedValue(0)
+
+  const onFrame = useCallback(
+    (frame: TunerFrame) => {
+      if (frame.reading) {
+        const clamped = Math.max(
+          -METER_RANGE_CENTS,
+          Math.min(METER_RANGE_CENTS, frame.reading.cents)
+        )
+        needleCents.value = withTiming(clamped, { duration: 80, easing: Easing.linear })
+        needleActive.value = withTiming(1, { duration: 120 })
+      } else {
+        needleCents.value = withTiming(0, { duration: 250 })
+        needleActive.value = withTiming(0, { duration: 250 })
+      }
+    },
+    [needleCents, needleActive]
+  )
+
+  const tuner = useTuner({ onFrame })
+  const { permission, running, start, stop, lockedString, setLockedString, reading } = tuner
+
+  useFocusEffect(
+    useCallback(() => {
+      // Ask-on-first-use lives here: opening the tuner is the first use.
+      // start() requests permission and no-ops unless it's granted.
+      void start()
+      return stop
+    }, [start, stop])
+  )
+
+  const meterWidth = Math.min(width - t.spacing.lg * 2, 420)
+  const radius = meterWidth * 0.44
+
+  const needleStyle = useAnimatedStyle(() => ({
+    opacity: 0.35 + 0.65 * needleActive.value,
+    transform: [{ rotate: `${(needleCents.value / METER_RANGE_CENTS) * METER_SWEEP_DEG}deg` }],
+  }))
+
+  const stateColor = holdColor(reading, t)
+  const inTune = reading?.hold === 'inTune'
+  const centsText = !reading
+    ? '—'
+    : inTune
+      ? 'In tune'
+      : `${reading.cents > 0 ? '+' : '−'}${Math.abs(reading.cents).toFixed(0)}¢`
+
+  return (
+    <Screen edges={['left', 'right']}>
+      <View
+        style={{
+          flex: 1,
+          paddingTop: barH + t.spacing.lg,
+          paddingHorizontal: t.spacing.lg,
+          paddingBottom: insets.bottom + t.spacing.xl,
+        }}
+      >
+        {permission === 'denied' ? (
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: t.spacing.lg }}>
+            <SymbolIcon name="mic.slash" size={40} color={t.colors.muted} />
+            <Text
+              style={{
+                fontSize: t.typography.body.fontSize,
+                color: t.colors.sec,
+                textAlign: 'center',
+                maxWidth: 300,
+              }}
+            >
+              The tuner needs microphone access to hear your guitar. Audio is analyzed on this
+              device only — never recorded or sent anywhere.
+            </Text>
+            <Button
+              title="Enable in Settings"
+              fullWidth={false}
+              style={{ alignSelf: 'center' }}
+              onPress={() => Linking.openSettings()}
+            />
+          </View>
+        ) : (
+          <>
+            {/* Meter */}
+            <View style={{ alignItems: 'center' }}>
+              <View style={{ width: meterWidth, height: radius + 24, alignItems: 'center' }}>
+                <View style={{ position: 'absolute', bottom: 0, width: meterWidth, height: radius }}>
+                  <MeterTicks radius={radius} t={t} />
+                  <Animated.View
+                    style={[
+                      {
+                        position: 'absolute',
+                        left: '50%',
+                        bottom: 0,
+                        marginLeft: -1.5,
+                        width: 3,
+                        height: radius - 26,
+                        borderRadius: 1.5,
+                        backgroundColor: stateColor,
+                        transformOrigin: 'bottom center',
+                      },
+                      needleStyle,
+                    ]}
+                  />
+                  {/* Pivot */}
+                  <View
+                    style={{
+                      position: 'absolute',
+                      left: '50%',
+                      bottom: -7,
+                      marginLeft: -7,
+                      width: 14,
+                      height: 14,
+                      borderRadius: 7,
+                      backgroundColor: stateColor,
+                    }}
+                  />
+                </View>
+                <Text
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    bottom: 0,
+                    fontSize: 20,
+                    color: t.colors.muted,
+                  }}
+                >
+                  ♭
+                </Text>
+                <Text
+                  style={{
+                    position: 'absolute',
+                    right: 0,
+                    bottom: 0,
+                    fontSize: 20,
+                    color: t.colors.muted,
+                  }}
+                >
+                  ♯
+                </Text>
+              </View>
+            </View>
+
+            {/* Note + numbers */}
+            <View style={{ alignItems: 'center', marginTop: t.spacing.xl, gap: t.spacing.xs }}>
+              <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 4 }}>
+                <Text
+                  style={{
+                    fontSize: 84,
+                    fontWeight: '700',
+                    letterSpacing: -2,
+                    color: stateColor,
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {reading ? reading.string.label : '–'}
+                </Text>
+                <Text style={{ fontSize: 28, fontWeight: '600', color: t.colors.muted }}>
+                  {reading ? reading.string.name.slice(-1) : ''}
+                </Text>
+              </View>
+              <Text
+                style={{
+                  fontSize: 22,
+                  fontWeight: '600',
+                  color: inTune ? t.colors.success : t.colors.ink,
+                  fontVariant: ['tabular-nums'],
+                }}
+              >
+                {centsText}
+              </Text>
+              <Text
+                style={{
+                  fontSize: t.typography.rowSubtitle.fontSize,
+                  color: t.colors.sec,
+                  fontVariant: ['tabular-nums'],
+                }}
+              >
+                {reading ? `${reading.frequency.toFixed(1)} Hz` : running ? 'Play a string…' : ' '}
+              </Text>
+            </View>
+
+            <View style={{ flex: 1 }} />
+
+            {/* String row + mode caption */}
+            <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+              {STANDARD_TUNING.map((s) => {
+                const state =
+                  lockedString?.name === s.name
+                    ? 'locked'
+                    : !lockedString && reading?.string.name === s.name
+                      ? 'active'
+                      : 'idle'
+                return (
+                  <StringKey
+                    key={s.name}
+                    string={s}
+                    state={state}
+                    onPress={() => setLockedString(lockedString?.name === s.name ? null : s)}
+                    t={t}
+                  />
+                )
+              })}
+            </View>
+            <Text
+              style={{
+                marginTop: t.spacing.md,
+                textAlign: 'center',
+                fontSize: t.typography.rowMeta.fontSize,
+                color: t.colors.muted,
+              }}
+            >
+              {lockedString
+                ? `Locked to ${lockedString.name} — tap it again for auto-detect`
+                : 'Auto-detecting — tap a string to lock it'}
+            </Text>
+          </>
+        )}
+      </View>
+
+      {/* Scroll-behind top bar, same pattern as Settings/About. */}
+      <GlassSurface
+        fallbackColor={t.colors.bg}
+        onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          paddingTop: insets.top,
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+        >
+          <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>Utilities</Text>
+        </Pressable>
+        <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>Tuner</Text>
+        <View style={{ width: 70 }} />
+      </GlassSurface>
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/UtilitiesScreen.tsx
+++ b/apps/mobile/src/screens/UtilitiesScreen.tsx
@@ -9,12 +9,12 @@ import SymbolIcon from '../components/SymbolIcon'
 import { useTheme } from '../theme/ThemeProvider'
 import type { Tokens } from '@gracechords/tokens/native'
 
-// The Utilities tab landing page. This is a STUB: it establishes the navigation
-// slot and lists the planned musician's tools as non-functional "Coming soon"
-// rows. No feature logic lives here yet (pitch detection, metronome timing, capo
-// math, tone generation are all separate, later tasks). Built entirely from the
-// shared primitives (Screen / SectionHeader / Card / ListRow / SymbolIcon) and
-// theme tokens, mirroring the grouped-list layout used by Settings.
+// The Utilities tab landing page: musician's tools as a grouped list. Rows
+// with a `route` are live features (Tuner → /tuner); the rest are "Coming
+// soon" stubs for separate, later tasks (metronome timing, capo math, tone
+// generation). Built entirely from the shared primitives (Screen /
+// SectionHeader / Card / ListRow / SymbolIcon) and theme tokens, mirroring
+// the grouped-list layout used by Settings.
 
 /** Rounded leading icon chip, mirroring the Settings grouped-row pattern. */
 function RowIcon({ name, t }: { name: Parameters<typeof SymbolIcon>[0]['name']; t: Tokens }) {
@@ -34,8 +34,13 @@ function RowIcon({ name, t }: { name: Parameters<typeof SymbolIcon>[0]['name']; 
   )
 }
 
-const UTILITIES: { icon: Parameters<typeof SymbolIcon>[0]['name']; title: string }[] = [
-  { icon: 'tuningfork', title: 'Tuner' },
+const UTILITIES: {
+  icon: Parameters<typeof SymbolIcon>[0]['name']
+  title: string
+  /** Route to push; rows without one render as "Coming soon" stubs. */
+  route?: '/tuner'
+}[] = [
+  { icon: 'tuningfork', title: 'Tuner', route: '/tuner' },
   { icon: 'metronome', title: 'Tap Tempo / Metronome' },
   { icon: 'guitars', title: 'Capo Calculator' },
   { icon: 'pianokeys', title: 'Pitch Pipe' },
@@ -70,23 +75,39 @@ export default function UtilitiesScreen() {
         <SectionHeader label="TOOLS" />
         <Card>
           {UTILITIES.map((u, i) => {
-            // Dev-only doorway to the tuner pipeline spike harness
-            // (spike/tuner/) — production builds still show "Coming soon".
-            const spikeLink = __DEV__ && u.title === 'Tuner'
+            const live = u.route != null
             return (
               <ListRow
                 key={u.title}
                 title={u.title}
                 leading={<RowIcon name={u.icon} t={t} />}
-                value={spikeLink ? 'Spike harness' : 'Coming soon'}
-                chevron={spikeLink}
-                onPress={spikeLink ? () => router.push('/dev/tuner-spike') : undefined}
+                value={live ? undefined : 'Coming soon'}
+                chevron={live}
+                onPress={live ? () => router.push(u.route!) : undefined}
                 isLast={i === UTILITIES.length - 1}
-                accessibilityLabel={spikeLink ? 'Tuner — spike harness' : `${u.title} — coming soon`}
+                accessibilityLabel={live ? u.title : `${u.title} — coming soon`}
               />
             )
           })}
         </Card>
+
+        {__DEV__ ? (
+          // Dev-only doorway to the tuner pipeline spike harness
+          // (spike/tuner/), kept until the device-verify pass is done.
+          <>
+            <SectionHeader label="DEV" />
+            <Card>
+              <ListRow
+                title="Tuner spike harness"
+                leading={<RowIcon name="waveform" t={t} />}
+                chevron
+                onPress={() => router.push('/dev/tuner-spike')}
+                isLast
+                accessibilityLabel="Tuner spike harness (dev only)"
+              />
+            </Card>
+          </>
+        ) : null}
       </ScrollView>
     </Screen>
   )

--- a/apps/mobile/src/screens/UtilitiesScreen.tsx
+++ b/apps/mobile/src/screens/UtilitiesScreen.tsx
@@ -1,3 +1,4 @@
+import { router } from 'expo-router'
 import { ScrollView, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Screen from '../components/Screen'
@@ -68,16 +69,23 @@ export default function UtilitiesScreen() {
 
         <SectionHeader label="TOOLS" />
         <Card>
-          {UTILITIES.map((u, i) => (
-            <ListRow
-              key={u.title}
-              title={u.title}
-              leading={<RowIcon name={u.icon} t={t} />}
-              value="Coming soon"
-              isLast={i === UTILITIES.length - 1}
-              accessibilityLabel={`${u.title} — coming soon`}
-            />
-          ))}
+          {UTILITIES.map((u, i) => {
+            // Dev-only doorway to the tuner pipeline spike harness
+            // (spike/tuner/) — production builds still show "Coming soon".
+            const spikeLink = __DEV__ && u.title === 'Tuner'
+            return (
+              <ListRow
+                key={u.title}
+                title={u.title}
+                leading={<RowIcon name={u.icon} t={t} />}
+                value={spikeLink ? 'Spike harness' : 'Coming soon'}
+                chevron={spikeLink}
+                onPress={spikeLink ? () => router.push('/dev/tuner-spike') : undefined}
+                isLast={i === UTILITIES.length - 1}
+                accessibilityLabel={spikeLink ? 'Tuner — spike harness' : `${u.title} — coming soon`}
+              />
+            )
+          })}
         </Card>
       </ScrollView>
     </Screen>

--- a/apps/web/src/content/privacy-policy.md
+++ b/apps/web/src/content/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Effective date:** July 3rd, 2026
+**Effective date:** July 4th, 2026
 **Applies to:** the GraceChords website ([https://gracechords.com](https://gracechords.com)) and the GraceChords mobile app (collectively, the "Service").
 
 GraceChords ("GraceChords," "we," "us," or "our") is a free, non-commercial worship tool operated by Ryan Moore, an individual based in the U.S. state of Georgia. We take your privacy seriously and collect as little information as the Service needs to work. This policy explains what we collect, why, and the choices and rights you have.
@@ -22,6 +22,8 @@ You may create an account directly (email + password) or through **Sign in with 
 
 **Technical information (infrastructure).** We do not run analytics or tracking. However, like any online service, our hosting and infrastructure providers automatically process limited technical data — such as your IP address and standard request logs — to deliver content, keep the Service secure, and prevent abuse. This is not used to profile or track you, and we do not build advertising or behavioral profiles from it.
 
+**Microphone (instrument tuner).** The mobile app includes a guitar tuner that uses your device's microphone **solely for real-time, on-device pitch detection**. The audio is analyzed in memory on your device and immediately discarded — it is **never recorded, stored, or transmitted**, and no audio ever leaves your device. The microphone is active only while the tuner screen is open, and the app asks for microphone permission only when you first use the tuner. You can revoke this permission at any time in your device settings; the rest of the app works without it.
+
 **Essential storage / cookies.**
 
 - On the **website**, we use a strictly necessary cookie to keep you signed in. It is not used for tracking or advertising.
@@ -39,6 +41,7 @@ To be clear about our practices, we do **not**:
 - Show advertising of any kind
 - Use remarketing or retargeting services
 - Sell, rent, or share your personal information
+- Record, store, or transmit audio from your microphone (the tuner analyzes audio on-device only)
 - Send marketing, newsletter, or promotional emails
 - Knowingly collect information from children under 13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "expo-web-browser": "~55.0.17",
         "react": "19.2.0",
         "react-native": "0.83.6",
+        "react-native-audio-api": "^0.13.1",
         "react-native-gesture-handler": "~2.30.0",
         "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.2",
@@ -1689,6 +1690,28 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "apps/mobile/node_modules/react-native-audio-api": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/react-native-audio-api/-/react-native-audio-api-0.13.1.tgz",
+      "integrity": "sha512-FuUcj/flfWImRFQkxpJVJe0HueQxwliCjeI+kVcWQPOj46mkpsbEhvNF0IPRNwWiDl1GaiYka8oLShZ+Y7Y9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.3"
+      },
+      "bin": {
+        "setup-rn-audio-api-web": "scripts/setup-rn-audio-api-web.js"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": ">= 0.6.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-worklets": {
           "optional": true
         }
       }

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -50,6 +50,8 @@ export type ThemeColors = {
   onDanger: string
   /** Favorite/star fill (gold). */
   star: string
+  /** Positive/confirmed state (e.g. tuner in-tune). */
+  success: string
   /** Dimmed color for inactive scrubber letters. */
   off: string
   /**
@@ -76,6 +78,7 @@ export const lightColors: ThemeColors = {
   danger: '#C43D38',
   onDanger: '#FFFFFF',
   star: '#F0B000',
+  success: '#34C759',
   off: 'rgba(138,146,155,0.45)',
   heroGradient: {
     colors: ['#BFD3E3', '#CFE0EA', '#E3EDF2', '#F5F7F9'],
@@ -99,6 +102,7 @@ export const darkColors: ThemeColors = {
   danger: '#F0736A',
   onDanger: '#14171A',
   star: '#FFCC00',
+  success: '#30D158',
   off: 'rgba(124,133,142,0.5)',
   heroGradient: {
     colors: ['#1C2A36', '#18222A', '#15191D', '#14171A'],


### PR DESCRIPTION
## Summary

Implements a fully functional guitar tuner in the Utilities tab, featuring real-time pitch detection via the YIN algorithm, a needle-based meter UI, and per-string lock controls. The tuner captures audio at 48 kHz, decimates to 24 kHz for analysis, and drives the needle at full pipeline rate (~47 fps) using Reanimated shared values to avoid React re-renders per frame.

## Key Changes

**Core tuner pipeline** (`src/lib/tuner/`)
- `yin.ts`: YIN pitch detector (CMNDF + absolute threshold + parabolic interpolation) tuned for guitar frequencies (70–400 Hz)
- `notes.ts`: Note math (cents calculation, string matching, standard tuning definition)
- `smoothing.ts`: Median-5 + EMA-0.35 cents smoother to reduce jitter
- `hold.ts`: In-tune hold state machine (settles for 500 ms before locking green)
- `useTuner.ts`: React hook wrapping `react-native-audio-api` with privacy-by-construction (no file output, no network)

**UI** (`src/screens/TunerScreen.tsx`)
- Animated needle meter (±50 cents range, ±45° sweep) with tick marks
- Large note display (E–E) + frequency + cents readout
- String row with tap-to-lock controls (auto-detect when unlocked)
- Permission denial screen with Settings link
- Throttled text updates (~10 Hz) while needle runs at full frame rate

**Spike/validation** (`spike/tuner/`)
- `bench.ts`: Headless benchmark (270 synthetic plucks per config) measuring latency, accuracy, jitter, and gross-error rates
- `signals.ts`: Synthetic pluck generator modeling inharmonicity, per-partial decay, weak low-E fundamental, and noise
- `TunerSpikeScreen.tsx`: On-device harness for validating pipeline numbers on real hardware
- `RESULTS.md`: Gate report confirming `react-native-audio-api` viability and recommended parameters

**Tests** (`src/lib/tuner/__tests__/tuner.test.ts`)
- Unit tests for note math, string detection, hold state machine, and smoothing

**Integration**
- Added `react-native-audio-api` (v0.13.1) dependency with Expo config plugin
- Registered `/tuner` route in app navigation
- Added `success` color token for in-tune state
- Updated Utilities screen to link to tuner (live feature, not stub)
- Updated privacy policy effective date

## Notable Implementation Details

- **Privacy**: Audio is analyzed on-device only; `enableFileOutput()` is never called, so no recording occurs by construction
- **Performance**: Needle driven via Reanimated shared value at full pipeline rate; text updates throttled to ~10 Hz to avoid React overhead
- **Ask-on-first-use**: Permission request happens when the tuner screen opens (via `useFocusEffect`)
- **Session control**: iOS audio session set to `measurement` mode to disable AGC/voice isolation that would mangle the signal
- **Spike-proven parameters**: All pipeline settings (48 kHz capture, ×2 decimation, 2048-sample window, 1024-frame hop, 0.12 threshold, median-5 + EMA-0.35 smoothing) validated against synthetic benchmarks
- **String lock**: Tapping a string in the row locks detection to it; tap again to release and return to auto-detect

https://claude.ai/code/session_01DrQoAAEnsLL1Pkhzwyyseg