### PR TITLE
Fix "Invalid Refresh Token" error logged on iOS launch

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -12,6 +12,7 @@ import {
   supabase,
   supabaseConfigError,
 } from '../src/lib/supabase'
+import { resolveInitialSession } from '../src/lib/authSession'
 import { flushPendingSprite } from '../src/lib/profile'
 import { hydrateDefaults } from '../src/lib/defaults'
 import { prefetchToday } from '../src/lib/bibleSource'
@@ -120,14 +121,10 @@ export default function RootLayout() {
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
-    if (supabaseConfigError) return
-    return registerAuthAutoRefresh()
-  }, [])
-
-  useEffect(() => {
     // Missing public config: skip the session read entirely (the supabase client
     // is null here) and let the ConfigErrorScreen below take over.
     if (supabaseConfigError) return
+    let stopAutoRefresh: (() => void) | undefined
     // Load app-wide defaults (theme/chord style) before the splash lifts so the
     // resolved theme is applied on first paint — no light→dark flash. Runs in
     // parallel with the session read; both must resolve before `ready`.
@@ -136,13 +133,19 @@ export default function RootLayout() {
     // the first paint has the resolved theme, offline reads know what's
     // downloaded, and Home's "Continue" card can render synchronously.
     Promise.all([
-      supabase.auth.getSession(),
+      resolveInitialSession(supabase.auth),
       hydrateDefaults(AsyncStorage),
       hydrateDownloads(AsyncStorage),
       hydrateRecents(AsyncStorage),
-    ]).then(([{ data }]) => {
-      setSession(data.session)
+    ]).then(([session]) => {
+      setSession(session)
       setReady(true)
+      // Start AppState-driven token auto-refresh only AFTER the persisted
+      // session is resolved. resolveInitialSession has already purged any
+      // stale/revoked refresh token from storage, so the immediate refresh tick
+      // can't fire against a dead token and log "Invalid Refresh Token: Refresh
+      // Token Not Found" on launch.
+      stopAutoRefresh = registerAuthAutoRefresh()
     })
     const { data: sub } = supabase.auth.onAuthStateChange((event, next) => {
       setSession(next)
@@ -153,7 +156,10 @@ export default function RootLayout() {
         void flushPendingSprite(supabase, AsyncStorage, next.user.id)
       }
     })
-    return () => sub.subscription.unsubscribe()
+    return () => {
+      sub.subscription.unsubscribe()
+      stopAutoRefresh?.()
+    }
   }, [])
 
   // Warm today's Daily Word passages on open so the reader is instant even if

--- a/apps/mobile/src/lib/__tests__/authSession.test.ts
+++ b/apps/mobile/src/lib/__tests__/authSession.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isInvalidRefreshTokenError, resolveInitialSession } from '../authSession'
+
+type BootAuth = Parameters<typeof resolveInitialSession>[0]
+
+function fakeAuth(overrides: Partial<BootAuth> = {}): BootAuth {
+  return {
+    getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+    signOut: vi.fn().mockResolvedValue({ error: null }),
+    ...overrides,
+  } as unknown as BootAuth
+}
+
+describe('isInvalidRefreshTokenError', () => {
+  it('matches the refresh_token_not_found error code', () => {
+    expect(
+      isInvalidRefreshTokenError({
+        code: 'refresh_token_not_found',
+        message: 'Invalid Refresh Token: Refresh Token Not Found',
+      }),
+    ).toBe(true)
+  })
+
+  it('matches by message when only the message is present', () => {
+    expect(
+      isInvalidRefreshTokenError({ message: 'Invalid Refresh Token: Refresh Token Not Found' }),
+    ).toBe(true)
+    expect(isInvalidRefreshTokenError({ message: 'invalid refresh token' })).toBe(true)
+  })
+
+  it('ignores unrelated errors and non-objects', () => {
+    expect(isInvalidRefreshTokenError({ code: 'over_email_send_rate_limit' })).toBe(false)
+    expect(isInvalidRefreshTokenError({ message: 'Network request failed' })).toBe(false)
+    expect(isInvalidRefreshTokenError(null)).toBe(false)
+    expect(isInvalidRefreshTokenError('boom')).toBe(false)
+    expect(isInvalidRefreshTokenError(undefined)).toBe(false)
+  })
+})
+
+describe('resolveInitialSession', () => {
+  it('returns the persisted session and never signs out', async () => {
+    const session = { user: { id: 'u1' } }
+    const auth = fakeAuth({
+      getSession: vi.fn().mockResolvedValue({ data: { session }, error: null }),
+    })
+
+    await expect(resolveInitialSession(auth)).resolves.toBe(session)
+    expect(auth.signOut).not.toHaveBeenCalled()
+  })
+
+  it('returns null with no session and no error (signed out / fresh install)', async () => {
+    const auth = fakeAuth()
+    await expect(resolveInitialSession(auth)).resolves.toBeNull()
+    expect(auth.signOut).not.toHaveBeenCalled()
+  })
+
+  it('purges the stale token locally and resolves null on a dead refresh token', async () => {
+    const auth = fakeAuth({
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: { code: 'refresh_token_not_found', message: 'Refresh Token Not Found' },
+      }),
+    })
+
+    await expect(resolveInitialSession(auth)).resolves.toBeNull()
+    expect(auth.signOut).toHaveBeenCalledWith({ scope: 'local' })
+  })
+
+  it('does not sign out on unrelated getSession errors', async () => {
+    const auth = fakeAuth({
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Network request failed' },
+      }),
+    })
+
+    await expect(resolveInitialSession(auth)).resolves.toBeNull()
+    expect(auth.signOut).not.toHaveBeenCalled()
+  })
+
+  it('still resolves null even if the local sign-out itself fails', async () => {
+    const auth = fakeAuth({
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: { code: 'refresh_token_not_found' },
+      }),
+      signOut: vi.fn().mockRejectedValue(new Error('storage unavailable')),
+    })
+
+    await expect(resolveInitialSession(auth)).resolves.toBeNull()
+  })
+})

--- a/apps/mobile/src/lib/authSession.ts
+++ b/apps/mobile/src/lib/authSession.ts
@@ -1,0 +1,36 @@
+// Boot-time session resolution, kept RN-free (no react-native / AsyncStorage
+// imports) so it unit-tests headless under vitest — the supabase client is an
+// injected dep, like authFlows.ts. Type-only supabase imports erase at compile
+// time.
+import type { Session, SupabaseClient } from '@supabase/supabase-js'
+
+type BootAuth = Pick<SupabaseClient['auth'], 'getSession' | 'signOut'>
+
+// A persisted session whose refresh token has been revoked or rotated (signed
+// out on another device, session deleted in the dashboard, token reuse) surfaces
+// as an AuthApiError with this code / message on the next refresh. We treat it
+// as "signed out" rather than a real failure.
+export function isInvalidRefreshTokenError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const e = error as { code?: string; message?: string }
+  if (e.code === 'refresh_token_not_found') return true
+  const msg = typeof e.message === 'string' ? e.message.toLowerCase() : ''
+  return msg.includes('refresh token') && (msg.includes('not found') || msg.includes('invalid'))
+}
+
+// Resolve the persisted session at launch. getSession() already refreshes an
+// expired token internally and returns { session: null, error } when the stored
+// refresh token is dead — but it leaves the caller to react. If we hit a dead
+// token we purge the local session so (a) the app routes cleanly to /login and
+// (b) the AppState auto-refresh tick has nothing to refresh, so it can never log
+// the "Invalid Refresh Token: Refresh Token Not Found" error on launch. scope
+// 'local' only clears the device — no network round-trip against a token the
+// server has already forgotten.
+export async function resolveInitialSession(auth: BootAuth): Promise<Session | null> {
+  const { data, error } = await auth.getSession()
+  if (error && isInvalidRefreshTokenError(error)) {
+    await auth.signOut({ scope: 'local' }).catch(() => {})
+    return null
+  }
+  return data.session ?? null
+}


### PR DESCRIPTION
A persisted session whose refresh token has been revoked or rotated
(signed out on another device, session deleted, token reuse) surfaced on
launch as an uncaught `AuthApiError: Invalid Refresh Token: Refresh Token
Not Found`.

The cause was a race at boot: `registerAuthAutoRefresh()` ran in its own
effect and fired an auto-refresh tick against the stale session in
AsyncStorage before the session had been resolved. `getSession()` handles a
dead token silently (returns a null session), but the racing tick logged the
error.

Fix:
- Add `resolveInitialSession()` (RN-free, dependency-injected, unit-tested):
  reads the persisted session and, on a dead refresh token, purges it locally
  (`signOut({ scope: 'local' })`) and resolves to null so the app routes
  cleanly to /login.
- Start AppState-driven auto-refresh only AFTER the persisted session is
  resolved, so the refresh tick can never run against a dead token.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015QMDiAY5B8sR5wwvmnuNhK