### PR TITLE
fix(mobile): lift Daily Word Copy FAB above the native tab bar

### DIFF
--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -20,6 +20,7 @@ import {
   type BibleTranslation,
   type Passage,
 } from '@gracechords/core'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Screen from '../components/Screen'
 import SymbolIcon from '../components/SymbolIcon'
 import GlassSurface from '../components/GlassSurface'
@@ -61,6 +62,9 @@ function chipLabel(passage: Passage) {
 
 export default function DailyWordScreen() {
   const t = useTheme()
+  // Native tabs float over the screen; this bottom inset includes the tab bar
+  // height so the Copy FAB clears it (see FAB position below).
+  const insets = useSafeAreaInsets()
   const { translations, groups, defaultTranslationId } = useBibleTranslations()
 
   const [date, setDate] = useState(() => new Date())
@@ -364,7 +368,7 @@ export default function DailyWordScreen() {
           <Animated.View
             style={{
               position: 'absolute',
-              bottom: t.spacing.xl,
+              bottom: insets.bottom + t.spacing.xl,
               [rtl ? 'left' : 'right']: t.spacing.lg,
               opacity: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.85] }),
               transform: [


### PR DESCRIPTION
The Copy FAB was positioned at bottom: t.spacing.xl relative to a flex:1 container that runs under the OS-rendered native tab bar (the screen omits the bottom safe-area edge), so after the native-tabs migration it rendered behind the floating Liquid Glass bar.

Offset it by the safe-area bottom inset — react-native-screens wraps each native-tab screen in a SafeAreaProvider whose bottom inset includes the tab bar height — so bottom: insets.bottom + t.spacing.xl restores the original 24pt gap above the bar and adapts across iOS 18 / iOS 26 and notch / non-notch devices without any (unavailable) tab-bar-height hook.


Claude-Session: https://claude.ai/code/session_01NJCaVsrs94A4U8ydjjkT2t