### PR TITLE
fix(mobile): let Daily Word reader scroll clear of the native tab bar

### DIFF
--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -303,7 +303,9 @@ export default function DailyWordScreen() {
             contentContainerStyle={{
               paddingHorizontal: 18,
               paddingTop: t.spacing.xs,
-              paddingBottom: t.spacing.xxl,
+              // Clear the floating native tab bar (insets.bottom includes its
+              // height under native tabs) so the last verse scrolls fully above it.
+              paddingBottom: insets.bottom + t.spacing.xl,
             }}
           >
               {settings.layout === 'prose' ? (


### PR DESCRIPTION
The verse ScrollView used a fixed paddingBottom (t.spacing.xxl) with no allowance for the floating native tab bar, so the last line couldn't be scrolled fully above it. Use insets.bottom + t.spacing.xl (the same tab-bar-inclusive bottom inset the FAB fix relies on) so the final verse plus a comfortable gap clears the bar.


Claude-Session: https://claude.ai/code/session_01NJCaVsrs94A4U8ydjjkT2t