### PR TITLE
fix(mobile): add expo-dev-client so physical-device runs find Metro

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -38,8 +38,9 @@ the visual rather than porting the HTML/CSS.
   transpose gestures), `expo-file-system` / `expo-sharing` / `expo-clipboard`
   (export + share sheet), `@react-native-google-signin/google-signin` +
   `expo-apple-authentication` (native auth), `expo-network` (Wi-Fi-only gate for
-  offline downloads), and `expo-build-properties` (`useFrameworks: static`,
-  required by google-signin). Add Expo deps with
+  offline downloads), `expo-build-properties` (`useFrameworks: static`,
+  required by google-signin), and `expo-dev-client` (dev launcher — see the
+  device note under Commands). Add Expo deps with
   `npx expo install <pkg>`; if the Expo API is unreachable, pin the SDK-correct
   version from `node_modules/expo/bundledNativeModules.json` and `npm install`.
 
@@ -47,6 +48,14 @@ the visual rather than porting the HTML/CSS.
 
 - `npx expo run:ios` — prebuild + build + launch on the iOS simulator (needs
   macOS + Xcode).
+- `npx expo run:ios --device` — build + launch on a physical device. Because
+  `expo-dev-client` is installed, this produces a **dev client** whose launcher
+  auto-discovers the Metro server on the LAN. This is the supported path for
+  device runs: a bare (no dev-client) debug build has no reliable way to learn
+  the Mac's address on a physical device and boots with
+  `No script URL provided … unsanitizedScriptURLString = (null)`. Keep the phone
+  and Mac on the same Wi-Fi (no Guest SSID / VPN) so the launcher can reach
+  `http://<mac-ip>:8081`.
 - `npm run start` — Metro dev server.
 - `npm run export:ios` — `expo export --platform ios`; a Metro-only bundle that
   works on any OS. Use it to verify resolution/transpile without a simulator.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -26,6 +26,7 @@
     "expo-clipboard": "~55.0.14",
     "expo-constants": "~55.0.16",
     "expo-crypto": "~55.0.16",
+    "expo-dev-client": "~55.0.36",
     "expo-file-system": "~55.0.23",
     "expo-glass-effect": "55.0.11",
     "expo-haptics": "~55.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "expo-clipboard": "~55.0.14",
         "expo-constants": "~55.0.16",
         "expo-crypto": "~55.0.16",
+        "expo-dev-client": "~55.0.36",
         "expo-file-system": "~55.0.23",
         "expo-glass-effect": "55.0.11",
         "expo-haptics": "~55.0.15",
@@ -838,6 +839,57 @@
         "expo": "*"
       }
     },
+    "apps/mobile/node_modules/expo-dev-client": {
+      "version": "55.0.36",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-55.0.36.tgz",
+      "integrity": "sha512-Fq/Jx4YVMeR8hup1YK0omlmRwqgMW5FoAWrzwl0BdBygy8oixENLxsEp1p/CuaDhrNw38Kr9E4a1M3p6Gy/Q0w==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "55.0.37",
+        "expo-dev-menu": "55.0.31",
+        "expo-dev-menu-interface": "55.0.2",
+        "expo-manifests": "~55.0.18",
+        "expo-updates-interface": "~55.1.6"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-dev-launcher": {
+      "version": "55.0.37",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-55.0.37.tgz",
+      "integrity": "sha512-Cwj/pvVEAftixQEV7Nj+XFDO3Kp/NOKxRCMY2n4lwb8sAHL0gBOFxwTjloZTyJDfwmxZagIJGANXnD8kdb+yog==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.4",
+        "expo-dev-menu": "55.0.31",
+        "expo-manifests": "~55.0.18"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-dev-menu": {
+      "version": "55.0.31",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-55.0.31.tgz",
+      "integrity": "sha512-GCHID6veeHL7P1D2w6bhuwqil7mo6+0Yh3/6O1cDaCCCNfF10K0Gm/GJgtv1wlHYz7ygevc+pbS0ErzqQQFhPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "55.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-dev-menu-interface": {
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-55.0.2.tgz",
+      "integrity": "sha512-DomUNvGzY/xliwnMdbAYY780sCv19N7zIbifc0ClcoCzJZpNSCkvJ2qGIFRPyM/7DmqmlHGCKi8di7kYYLKNEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "apps/mobile/node_modules/expo-file-system": {
       "version": "55.0.23",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.23.tgz",
@@ -916,6 +968,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-manifests": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.18.tgz",
+      "integrity": "sha512-8zIjEZ7x+aSj4NwvQuKwaghjd2835yjF5LDzSV0s0vP1KAa6fZ7LwPyjXBjmPAwfd9UFxlMeHbNGp+qAqu7hSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-json-utils": "~55.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "apps/mobile/node_modules/expo-network": {
@@ -1260,6 +1324,15 @@
         "expo-font": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-updates-interface": {
+      "version": "55.1.6",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-55.1.6.tgz",
+      "integrity": "sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "apps/mobile/node_modules/expo-web-browser": {
@@ -11875,6 +11948,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/expo-json-utils": {
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-55.0.2.tgz",
+      "integrity": "sha512-QJMOZOPOG7CTnKcrdVaiummn2va1MCO56z++eyWkDv3GBRODldM6MFMDf/jTREWthFc2Nxo6TuyWRrEV9S6n/Q==",
+      "license": "MIT"
     },
     "node_modules/expo-modules-autolinking": {
       "version": "55.0.24",


### PR DESCRIPTION
`expo run:ios --device` on a physical device previously built a bare debug app with no reliable way to learn the dev machine's LAN address, so it booted with:

  No script URL provided. Make sure the packager is running or you have
  embedded a JS bundle in your application bundle.
  unsanitizedScriptURLString = (null)

On a device `localhost` is the phone itself, and without expo-dev-client the bundle URL falls back to the fragile embedded-IP mechanism, which yields a nil URL over Wi-Fi in this monorepo. Adding expo-dev-client (SDK-55 pin ~55.0.36) makes `--device` builds a dev client whose launcher auto-discovers the Metro server on the LAN. No effect on release builds.

Docs: note the --device workflow and the same-Wi-Fi requirement in the mobile AGENTS.md.


Claude-Session: https://claude.ai/code/session_017EuuB9aB95AGTJ694KvqNY