### PR TITLE
fix(mobile): make song library A–Z scrubber actually scroll on iOS

### DIFF
--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -189,8 +189,14 @@ export default function SongLibraryScreen() {
     if (index < 0) return
     pendingSection.current = index
     // Non-animated so continuous scrubbing tracks the finger without lag; the
-    // failure fallback still animates a single recovery scroll.
-    listRef.current?.scrollToLocation({ sectionIndex: index, itemIndex: 0, animated: false })
+    // failure fallback (onScrollToIndexFailed) recovers when the target section
+    // is outside the render window.
+    listRef.current?.scrollToLocation({
+      sectionIndex: index,
+      itemIndex: 0,
+      animated: false,
+      viewPosition: 0,
+    })
   }
 
   const rowMeta = (song: Song) => ({
@@ -389,12 +395,20 @@ export default function SongLibraryScreen() {
               onPress={() => openSong(item)}
             />
           )}
-          onScrollToIndexFailed={() => {
+          onScrollToIndexFailed={(info) => {
+            // scrollToLocation can't reach a section outside the render window
+            // without getItemLayout — it fires this and scrolls nowhere. Nudge
+            // the list to an approximate offset so the target renders, then
+            // retry the precise scroll. Repeats (advancing each time) converge
+            // on far jumps instead of looping in place.
+            const approxOffset = info.averageItemLength * info.index
+            listRef.current?.getScrollResponder()?.scrollTo({ y: approxOffset, animated: false })
             setTimeout(() => {
               listRef.current?.scrollToLocation({
                 sectionIndex: pendingSection.current,
                 itemIndex: 0,
                 animated: true,
+                viewPosition: 0,
               })
             }, 60)
           }}


### PR DESCRIPTION
The alphabet scrubber fired a haptic on each letter change but the list
never moved when jumping to a section outside the render window. Without
getItemLayout, SectionList.scrollToLocation can't compute the target
offset for an unrendered section, so it fires onScrollToIndexFailed and
scrolls nowhere. The old handler just re-called scrollToLocation after a
delay without moving the list first, so the target was never measured and
the retry looped in place.

Nudge the list to an approximate offset (averageItemLength * index) so the
target section renders, then retry the precise scroll — repeats advance the
measured window and converge on far jumps. Also pin the landing to the top
(viewPosition: 0).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ARjiGosgvEzDiqtrbkn3HS