### PR TITLE
Add two-column tablet layout for song charts

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -176,11 +176,21 @@ duplicate logic here and never edit core internals to suit mobile.
   over lyrics, per-symbol transpose + chord style at render, `RawFallback` when a
   parse yields nothing. Controls: floating `TransposeBar` (±1 semitone, haptic),
   `ViewOptionsSheet` (chords/lyrics · section labels · font scale 80–160% · chord
-  style Letters/Solfège · sharp/flat accidentals · "Hide controls when idle"),
+  style Letters/Solfège · sharp/flat accidentals · columns 1│2 on tablet widths ·
+  "Hide controls when idle"),
   `StarButton`, and `ExportSheet`. Transpose/accidentals/chord-style are
-  **ephemeral** per open; only "Hide controls when idle" persists (separately, in
-  `src/lib/autoHideChrome.ts`). Opening from a setlist seeds transpose via the
-  `initialKey` route param.
+  **ephemeral** per open; "Hide controls when idle" persists (separately, in
+  `src/lib/autoHideChrome.ts`) and the column mode persists **per song**
+  (device-local, `src/lib/viewerPrefs.ts`). Opening from a setlist seeds
+  transpose via the `initialKey` route param.
+- **Two-column mode** (`src/components/TwoColumnChart.tsx` +
+  `src/lib/columnLayout.ts`): tablet-only (`src/lib/useIsTabletWidth.ts`, min
+  window dimension ≥ 600 — phones never see the toggle), fill-first packing
+  (never balanced), sections atomic (never split), single-column rendering is
+  the untouched baseline, and double only engages when a single column would
+  overflow the viewport. Section heights are measured offscreen and memoized
+  per width/font/transpose/chord-style/accidental/visibility inputs; the
+  partition + persistence logic is unit-tested headless (`npm run test`).
 - **Performer** (`app/perform/[id].tsx` → `PerformerScreen`) runs a set one song
   at a time (Prev/Next, swipe, tappable progress rail), prefetches every song
   body, and reuses the same chart/transpose/view-options. Its

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -18,6 +18,7 @@ import { hydrateDefaults } from '../src/lib/defaults'
 import { prefetchToday } from '../src/lib/bibleSource'
 import { hydrateDownloads } from '../src/lib/downloads/manifest'
 import { hydrateRecents } from '../src/lib/recents'
+import { hydrateViewerPrefs } from '../src/lib/viewerPrefs'
 
 // Keep the native splash up past first render so we can resolve the persisted
 // session and route to the right screen before anything is shown — the app is
@@ -137,6 +138,7 @@ export default function RootLayout() {
       hydrateDefaults(AsyncStorage),
       hydrateDownloads(AsyncStorage),
       hydrateRecents(AsyncStorage),
+      hydrateViewerPrefs(AsyncStorage),
     ]).then(([session]) => {
       setSession(session)
       setReady(true)

--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -25,6 +25,7 @@ import Screen from '../../src/components/Screen'
 import StarButton from '../../src/components/StarButton'
 import SymbolIcon from '../../src/components/SymbolIcon'
 import TransposeBar from '../../src/components/TransposeBar'
+import TwoColumnChart from '../../src/components/TwoColumnChart'
 import ViewOptionsSheet, {
   type Accidental,
   defaultAccidental,
@@ -38,15 +39,18 @@ import { recordSongOpened } from '../../src/lib/recents'
 import { useAutoHideChrome, useAutoHidePref } from '../../src/lib/autoHideChrome'
 import { getDefaultsSnapshot, setDefaultKeepAwake, useAppDefaults } from '../../src/lib/defaults'
 import { useKeepAwakeWhileFocused } from '../../src/lib/keepAwake'
+import { useIsTabletWidth } from '../../src/lib/useIsTabletWidth'
+import { setColumnMode, useColumnMode } from '../../src/lib/viewerPrefs'
 import { useTheme } from '../../src/theme/ThemeProvider'
 
 // Song Viewer. Pass 1 built the static monospaced chart; pass 2 adds the live
 // view controls (floating transpose bar, View-options sheet) and the Export &
 // share sheet (server-rendered PDF/JPG via the web app's /api/export/song
-// Pages Function, system share, Telegram push). ALL
-// view state here is session-ephemeral useState — discarded on unmount, never
-// persisted. The optional `initialKey` param seeds the transpose so a setlist
-// can open the Viewer at its own key with no refactor.
+// Pages Function, system share, Telegram push). View state here is
+// session-ephemeral useState — discarded on unmount, never persisted — except
+// the tablet-only column mode, which persists per song (src/lib/viewerPrefs).
+// The optional `initialKey` param seeds the transpose so a setlist can open
+// the Viewer at its own key with no refactor.
 
 // Extra scroll room so the last lines clear the floating transpose bar.
 const TRANSPOSE_BAR_CLEARANCE = 96
@@ -112,6 +116,12 @@ export default function ViewerScreen() {
   // height seeds the chart's top inset, so the first line starts where the
   // header sits and the user can scroll up into that space.
   const [headerH, setHeaderH] = useState(0)
+  // Two-column mode: tablet widths only. Persisted PER SONG (device-local);
+  // phones never see the toggle and always take the baseline single path.
+  const isTablet = useIsTabletWidth()
+  const columnMode = useColumnMode(slug)
+  const [chartAreaH, setChartAreaH] = useState(0)
+  const twoColumns = isTablet && columnMode === 'double'
 
   const nativeKey = doc?.meta?.key || song?.default_key || songKey || ''
   const seedSteps = initialKey ? stepsBetween(nativeKey, initialKey) : 0
@@ -347,7 +357,7 @@ export default function ViewerScreen() {
           </Text>
         </View>
       ) : doc ? (
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1 }} onLayout={(e) => setChartAreaH(e.nativeEvent.layout.height)}>
           <GestureDetector gesture={tapReveal}>
             <ScrollView
               style={{ flex: 1 }}
@@ -357,15 +367,28 @@ export default function ViewerScreen() {
                 paddingBottom: t.spacing.xxl * 2 + TRANSPOSE_BAR_CLEARANCE,
               }}
             >
-              <ChordChart
-                doc={doc}
-                steps={steps}
-                preferFlat={preferFlat}
-                showChords={showChords}
-                showSections={showSections}
-                fontScale={fontScale}
-                chordStyle={chordStyle}
-              />
+              {twoColumns ? (
+                <TwoColumnChart
+                  doc={doc}
+                  steps={steps}
+                  preferFlat={preferFlat}
+                  showChords={showChords}
+                  showSections={showSections}
+                  fontScale={fontScale}
+                  chordStyle={chordStyle}
+                  viewportHeight={Math.max(0, chartAreaH - headerH - t.spacing.sm)}
+                />
+              ) : (
+                <ChordChart
+                  doc={doc}
+                  steps={steps}
+                  preferFlat={preferFlat}
+                  showChords={showChords}
+                  showSections={showSections}
+                  fontScale={fontScale}
+                  chordStyle={chordStyle}
+                />
+              )}
             </ScrollView>
           </GestureDetector>
           {keyLabel ? (
@@ -421,6 +444,8 @@ export default function ViewerScreen() {
         onChordStyle={setChordStyle}
         accidental={accidental}
         onAccidental={setAccidentalManual}
+        columnMode={isTablet ? columnMode : undefined}
+        onColumnMode={isTablet ? (m) => setColumnMode(slug, m) : undefined}
         autoHide={autoHide}
         onAutoHide={setAutoHide}
         keepAwake={keepAwake}

--- a/apps/mobile/src/components/ChordChart.tsx
+++ b/apps/mobile/src/components/ChordChart.tsx
@@ -69,7 +69,7 @@ export default function ChordChart({
   )
 }
 
-type RenderOpts = {
+export type RenderOpts = {
   steps: number
   preferFlat: boolean
   showChords: boolean
@@ -78,7 +78,9 @@ type RenderOpts = {
   chordStyle: ChordStyle
 }
 
-function ChartSection({ section, first, ...opts }: RenderOpts & { section: SongSection; first: boolean }) {
+// Exported for TwoColumnChart, which renders the same sections one column at a
+// time (and offscreen for measurement). `first` gates the inter-section gap.
+export function ChartSection({ section, first, ...opts }: RenderOpts & { section: SongSection; first: boolean }) {
   const t = useTheme()
   return (
     <View style={{ marginTop: first ? 0 : t.spacing.md }}>

--- a/apps/mobile/src/components/TwoColumnChart.tsx
+++ b/apps/mobile/src/components/TwoColumnChart.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useRef, useState } from 'react'
+import { View } from 'react-native'
+import type { SongDoc, SongSection } from '@gracechords/core'
+import ChordChart, { ChartSection, type ChordStyle } from './ChordChart'
+import { columnMeasureKey, partitionSections } from '../lib/columnLayout'
+import { useTheme } from '../theme/ThemeProvider'
+
+// Tablet two-column mode for the chord chart. Wraps ChordChart without
+// touching it: sections are measured OFFSCREEN (opacity 0, position absolute,
+// no pointer events) at column width, plus one full-width single-column
+// measurement, then the fill-first partition in lib/columnLayout decides the
+// split. When the song fits one viewport — or the partition keeps everything
+// in column 1 — this renders the exact same single <ChordChart> as ever, so
+// double never shows a near-empty second column.
+//
+// Measured heights are memoized per (width, font scale, transpose, accidental,
+// chord style, show-chords, section-labels) — every input that changes
+// wrapping. Transpose is the critical one: chord widths change line wrapping
+// and therefore section heights. While a re-measure is in flight the previous
+// partition (or the single-column render) stays visible, so there's no flicker
+// or blank frame — the layout swaps in one state flip when heights land.
+//
+// A song taller than two viewports scrolls as a single unit (column tops stay
+// aligned); a single section taller than the viewport still scrolls. Accepted —
+// two columns delay overflow, they don't eliminate it.
+
+const CACHE_MAX = 8
+
+type Measured = { singleH: number; heights: number[] }
+
+type Props = {
+  doc: SongDoc
+  steps: number
+  preferFlat: boolean
+  showChords?: boolean
+  showSections?: boolean
+  fontScale?: number
+  chordStyle?: ChordStyle
+  /** Visible height available to the chart (chart area minus the header inset). */
+  viewportHeight: number
+}
+
+export default function TwoColumnChart({
+  doc,
+  steps,
+  preferFlat,
+  showChords = true,
+  showSections = true,
+  fontScale = 1,
+  chordStyle = 'letters',
+  viewportHeight,
+}: Props) {
+  const t = useTheme()
+  const [width, setWidth] = useState(0)
+
+  // Same renderable-section filter ChordChart applies, so indices line up.
+  const sections = useMemo(
+    () => doc.sections.filter((section) => section.lines.length > 0),
+    [doc],
+  )
+
+  // Vertical gap between stacked sections = ChartSection's non-first marginTop.
+  const sectionGap = t.spacing.md
+  const columnGap = t.spacing.lg
+  const colWidth = width > 0 ? (width - columnGap) / 2 : 0
+
+  const measureKey =
+    width > 0
+      ? columnMeasureKey({ width, fontScale, steps, preferFlat, chordStyle, showChords, showSections })
+      : ''
+
+  // Height cache, scoped to the current doc (a new song starts fresh).
+  const cacheRef = useRef<{ doc: SongDoc; entries: Map<string, Measured> } | null>(null)
+  if (!cacheRef.current || cacheRef.current.doc !== doc) {
+    cacheRef.current = { doc, entries: new Map() }
+  }
+  const cache = cacheRef.current.entries
+  const measured = measureKey ? cache.get(measureKey) : undefined
+
+  // In-flight measurement pass: -1 marks a section not yet reported. The
+  // single-column total occupies one extra slot semantically (singleH < 0).
+  const passRef = useRef<{ key: string; singleH: number; heights: number[] } | null>(null)
+  const [, setDone] = useState(0)
+
+  const needMeasure = !!measureKey && !measured && sections.length > 0
+  if (needMeasure && passRef.current?.key !== measureKey) {
+    passRef.current = { key: measureKey, singleH: -1, heights: new Array<number>(sections.length).fill(-1) }
+  }
+
+  const finishIfComplete = () => {
+    const pass = passRef.current
+    if (!pass || pass.singleH < 0 || pass.heights.some((h) => h < 0)) return
+    if (cache.size >= CACHE_MAX) {
+      const oldest = cache.keys().next().value
+      if (oldest !== undefined) cache.delete(oldest)
+    }
+    cache.set(pass.key, { singleH: pass.singleH, heights: pass.heights })
+    passRef.current = null
+    setDone((n) => n + 1)
+  }
+
+  const onSingleLayout = (h: number) => {
+    const pass = passRef.current
+    if (!pass || pass.key !== measureKey) return
+    pass.singleH = h
+    finishIfComplete()
+  }
+
+  const onSectionLayout = (i: number, h: number) => {
+    const pass = passRef.current
+    if (!pass || pass.key !== measureKey) return
+    pass.heights[i] = h
+    finishIfComplete()
+  }
+
+  const chartOpts = { steps, preferFlat, showChords, showSections, fontScale, chordStyle }
+
+  const partition = measured
+    ? partitionSections(measured.heights, viewportHeight, sectionGap, measured.singleH)
+    : null
+
+  const renderColumn = (colSections: SongSection[], indexOffset: number) => (
+    <View style={{ flex: 1 }}>
+      {colSections.map((section, j) => (
+        <ChartSection key={indexOffset + j} section={section} first={j === 0} {...chartOpts} />
+      ))}
+    </View>
+  )
+
+  return (
+    <View onLayout={(e) => setWidth(e.nativeEvent.layout.width)}>
+      {partition?.mode === 'double' ? (
+        <View style={{ flexDirection: 'row', alignItems: 'flex-start', columnGap }}>
+          {renderColumn(sections.slice(0, partition.col2Start), 0)}
+          {renderColumn(sections.slice(partition.col2Start), partition.col2Start)}
+        </View>
+      ) : (
+        // No partition yet (still measuring) or the song fits: the untouched
+        // single-column chart, byte-for-byte the baseline render.
+        <ChordChart doc={doc} {...chartOpts} />
+      )}
+
+      {needMeasure && colWidth > 0 ? (
+        // Keyed by measureKey so any input change REMOUNTS the pass — onLayout
+        // only fires on size changes, so a remount guarantees every section
+        // reports even when its height is identical under the new inputs.
+        <View
+          key={measureKey}
+          pointerEvents="none"
+          collapsable={false}
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, opacity: 0 }}
+        >
+          <View collapsable={false} onLayout={(e) => onSingleLayout(e.nativeEvent.layout.height)}>
+            <ChordChart doc={doc} {...chartOpts} />
+          </View>
+          <View collapsable={false} style={{ width: colWidth }}>
+            {sections.map((section, i) => (
+              <View
+                key={i}
+                collapsable={false}
+                onLayout={(e) => onSectionLayout(i, e.nativeEvent.layout.height)}
+              >
+                <ChartSection section={section} first {...chartOpts} />
+              </View>
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </View>
+  )
+}

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -3,6 +3,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import BottomSheet from './BottomSheet'
 import AccidentalToggle, { type Accidental } from './AccidentalToggle'
 import type { ChordStyle } from './ChordChart'
+import type { ColumnMode } from '../lib/viewerPrefs'
 import { useTheme } from '../theme/ThemeProvider'
 
 // Re-export so existing screen imports (`from './ViewOptionsSheet'`) keep working.
@@ -100,6 +101,8 @@ export default function ViewOptionsSheet({
   onChordStyle,
   accidental,
   onAccidental,
+  columnMode,
+  onColumnMode,
   autoHide,
   onAutoHide,
   keepAwake,
@@ -118,6 +121,10 @@ export default function ViewOptionsSheet({
   // Accidental spelling (session-scoped). Optional — rendered only when wired.
   accidental?: Accidental
   onAccidental?: (v: Accidental) => void
+  // Column layout (persisted per song). Optional — the screens wire it only at
+  // tablet widths, so phones never see the toggle.
+  columnMode?: ColumnMode
+  onColumnMode?: (v: ColumnMode) => void
   // Optional "hide controls when idle" toggle — rendered only when the screen
   // wires it (Song Viewer + Setlist Performer).
   autoHide?: boolean
@@ -264,6 +271,22 @@ export default function ViewOptionsSheet({
             <Text style={{ fontSize: 16, color: t.colors.ink }}>Accidentals</Text>
             <AccidentalToggle value={accidental} onChange={onAccidental} />
           </View>
+        ) : null}
+
+        {/* Columns — tablet-only 1 │ 2 layout toggle, persisted per song.
+            Rendered only when the screen wires it. */}
+        {onColumnMode && columnMode ? (
+          <>
+            <OverlineLabel>Columns</OverlineLabel>
+            <Segmented
+              options={[
+                { value: 'single', label: '1' },
+                { value: 'double', label: '2' },
+              ]}
+              value={columnMode}
+              onChange={onColumnMode}
+            />
+          </>
         ) : null}
 
         {/* Screen preferences — persist across launches (unlike the options

--- a/apps/mobile/src/lib/__tests__/columnLayout.test.ts
+++ b/apps/mobile/src/lib/__tests__/columnLayout.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { columnMeasureKey, partitionSections, type MeasureInputs } from '../columnLayout'
+
+const VIEWPORT = 1000
+const GAP = 10
+
+/** Stacked single-column height at column width (what a naive consumer sums). */
+function stacked(heights: number[], gap: number): number {
+  return heights.reduce((a, b) => a + b, 0) + gap * Math.max(0, heights.length - 1)
+}
+
+describe('partitionSections (fill-first, never balanced)', () => {
+  it('stays single when the whole song fits one viewport', () => {
+    const heights = [200, 200, 200]
+    expect(partitionSections(heights, VIEWPORT, GAP, 620)).toEqual({ mode: 'single' })
+  })
+
+  it('stays single even when double is selected but the song fits (no near-empty column)', () => {
+    // singleHeight (full-width render) fits exactly at the viewport.
+    expect(partitionSections([500, 480], VIEWPORT, GAP, VIEWPORT)).toEqual({ mode: 'single' })
+  })
+
+  it('splits a classic 1.x-viewport song: full column 1, remainder in column 2', () => {
+    const heights = [300, 300, 300, 300, 300]
+    // col1: 300 + 10+300 + 10+300 = 920; next (10+300) would hit 1230 > 1000.
+    expect(partitionSections(heights, VIEWPORT, GAP, stacked(heights, GAP))).toEqual({
+      mode: 'double',
+      col2Start: 3,
+    })
+  })
+
+  it('is greedy fill-first, not balanced: column 1 packs to the brim', () => {
+    const heights = [900, 100, 100, 100]
+    // Balanced packing would move sections left/right; fill-first keeps 900 in
+    // col 1 and only adds what still fits under the viewport.
+    expect(partitionSections(heights, VIEWPORT, GAP, stacked(heights, GAP))).toEqual({
+      mode: 'double',
+      col2Start: 1,
+    })
+  })
+
+  it('an oversized single section still anchors column 1 (it scrolls; never split)', () => {
+    const heights = [2400, 300, 300]
+    expect(partitionSections(heights, VIEWPORT, GAP, stacked(heights, GAP))).toEqual({
+      mode: 'double',
+      col2Start: 1,
+    })
+  })
+
+  it('empty and one-section songs stay single', () => {
+    expect(partitionSections([], VIEWPORT, GAP, 0)).toEqual({ mode: 'single' })
+    expect(partitionSections([5000], VIEWPORT, GAP, 5000)).toEqual({ mode: 'single' })
+  })
+
+  it('stays single when the viewport is unmeasurable', () => {
+    expect(partitionSections([300, 300, 300], 0, GAP, 900)).toEqual({ mode: 'single' })
+    expect(partitionSections([300, 300, 300], -1, GAP, 900)).toEqual({ mode: 'single' })
+  })
+
+  it('accounts for the inter-section gap when packing column 1', () => {
+    // Without the gap both fit (500+500 = 1000); with it the second overflows.
+    expect(partitionSections([500, 500], VIEWPORT, GAP, 1010)).toEqual({
+      mode: 'double',
+      col2Start: 1,
+    })
+  })
+
+  it('stays single when overflow was width-induced only (all fit one column at column width)', () => {
+    // singleHeight overflows, but the measured column heights all fit stacked —
+    // degenerate, keep single rather than an empty second column.
+    expect(partitionSections([400, 400], VIEWPORT, GAP, 1200)).toEqual({ mode: 'single' })
+  })
+})
+
+describe('columnMeasureKey (height-cache invalidation)', () => {
+  const base: MeasureInputs = {
+    width: 800,
+    fontScale: 1,
+    steps: 0,
+    preferFlat: false,
+    chordStyle: 'letters',
+    showChords: true,
+    showSections: true,
+  }
+
+  it('is stable for identical inputs', () => {
+    expect(columnMeasureKey({ ...base })).toBe(columnMeasureKey({ ...base }))
+  })
+
+  it('invalidates on transpose — the critical dependency', () => {
+    expect(columnMeasureKey({ ...base, steps: 2 })).not.toBe(columnMeasureKey(base))
+  })
+
+  it('invalidates on width, font size, and every other layout-affecting option', () => {
+    const variants: MeasureInputs[] = [
+      { ...base, width: 700 },
+      { ...base, fontScale: 1.2 },
+      { ...base, preferFlat: true },
+      { ...base, chordStyle: 'solfege' },
+      { ...base, showChords: false },
+      { ...base, showSections: false },
+    ]
+    const keys = new Set([columnMeasureKey(base), ...variants.map(columnMeasureKey)])
+    expect(keys.size).toBe(variants.length + 1)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/viewerPrefs.test.ts
+++ b/apps/mobile/src/lib/__tests__/viewerPrefs.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  __resetViewerPrefsForTest,
+  getColumnMode,
+  getDefaultColumnMode,
+  hydrateViewerPrefs,
+  setColumnMode,
+  setDefaultColumnMode,
+} from '../viewerPrefs'
+import type { KVStorage as KV } from '../defaults'
+
+const KEY = 'gc.viewer.columnMode.v1'
+
+function memoryStorage(initial: Record<string, string> = {}): KV & { store: Map<string, string> } {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    getItem: async (k) => store.get(k) ?? null,
+    setItem: async (k, v) => void store.set(k, v),
+    removeItem: async (k) => void store.delete(k),
+  }
+}
+
+// Writes are fire-and-forget; let the microtask queue drain before asserting
+// on the backing store.
+const flush = () => new Promise<void>((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  __resetViewerPrefsForTest()
+})
+
+describe('viewerPrefs column mode', () => {
+  it('resolves to single when nothing is stored (app-wide default)', async () => {
+    await hydrateViewerPrefs(memoryStorage())
+    expect(getDefaultColumnMode()).toBe('single')
+    expect(getColumnMode('amazing-grace')).toBe('single')
+    expect(getColumnMode(undefined)).toBe('single')
+  })
+
+  it('persists per song and is isolated between songs', async () => {
+    const s = memoryStorage()
+    await hydrateViewerPrefs(s)
+    setColumnMode('song-a', 'double')
+    await flush()
+
+    expect(getColumnMode('song-a')).toBe('double')
+    expect(getColumnMode('song-b')).toBe('single')
+    expect(JSON.parse(s.store.get(KEY)!)).toEqual({ songs: { 'song-a': 'double' } })
+  })
+
+  it('survives a simulated reload (reopen a song set to double → still double)', async () => {
+    const s = memoryStorage()
+    await hydrateViewerPrefs(s)
+    setColumnMode('song-a', 'double')
+    await flush()
+
+    await hydrateViewerPrefs(memoryStorage()) // fresh empty hydrate = relaunch reset
+    expect(getColumnMode('song-a')).toBe('single')
+
+    await hydrateViewerPrefs(s) // reload from the original storage
+    expect(getColumnMode('song-a')).toBe('double')
+    expect(getColumnMode('song-b')).toBe('single')
+  })
+
+  it('does not bloat storage: flipping back to single removes the entry and the key', async () => {
+    const s = memoryStorage()
+    await hydrateViewerPrefs(s)
+    setColumnMode('song-a', 'double')
+    await flush()
+    expect(s.store.has(KEY)).toBe(true)
+
+    setColumnMode('song-a', 'single')
+    await flush()
+    expect(getColumnMode('song-a')).toBe('single')
+    expect(s.store.has(KEY)).toBe(false)
+  })
+
+  it('setting a mode a song already resolves to writes nothing', async () => {
+    const s = memoryStorage()
+    await hydrateViewerPrefs(s)
+    setColumnMode('song-a', 'single') // already the default
+    await flush()
+    expect(s.store.has(KEY)).toBe(false)
+  })
+
+  it('app-wide default seam: overrides resolve against it and prune to it', async () => {
+    const s = memoryStorage()
+    await hydrateViewerPrefs(s)
+    setDefaultColumnMode('double')
+    await flush()
+
+    expect(getColumnMode('untouched-song')).toBe('double')
+    // A per-song 'single' now differs from the default → stored as an override.
+    setColumnMode('song-a', 'single')
+    await flush()
+    expect(getColumnMode('song-a')).toBe('single')
+    expect(JSON.parse(s.store.get(KEY)!)).toEqual({
+      default: 'double',
+      songs: { 'song-a': 'single' },
+    })
+
+    // Restoring the default prunes overrides that became redundant.
+    setDefaultColumnMode('single')
+    await flush()
+    expect(getColumnMode('song-a')).toBe('single')
+    expect(s.store.has(KEY)).toBe(false)
+  })
+
+  it('ignores corrupt or invalid stored data', async () => {
+    await hydrateViewerPrefs(memoryStorage({ [KEY]: '{ not json' }))
+    expect(getColumnMode('song-a')).toBe('single')
+
+    await hydrateViewerPrefs(
+      memoryStorage({ [KEY]: JSON.stringify({ default: 'triple', songs: { 'song-a': 'wide', 'song-b': 'double' } }) }),
+    )
+    expect(getColumnMode('song-a')).toBe('single')
+    expect(getColumnMode('song-b')).toBe('double')
+  })
+})

--- a/apps/mobile/src/lib/columnLayout.ts
+++ b/apps/mobile/src/lib/columnLayout.ts
@@ -1,0 +1,80 @@
+// Two-column layout math for the Song Viewer / Performer tablet mode. Pure and
+// RN-free so the partition rules are unit-testable headless.
+//
+// Fill-first, NOT balanced: whole sections pack into column 1 until the next
+// one would exceed the viewport, then everything remaining flows to column 2.
+// Columns are top-aligned and intentionally unequal — no balancing, no
+// bin-packing. Sections are atomic (the parser's section boundary is the unit)
+// and are never split.
+
+export type ColumnPartition =
+  | { mode: 'single' }
+  /** Sections [0, col2Start) render in column 1; [col2Start, n) in column 2. */
+  | { mode: 'double'; col2Start: number }
+
+/**
+ * Greedy O(n) fill-first partition over measured section heights.
+ *
+ * `singleHeight` is the song's total height rendered single-column at full
+ * width: double only engages when that overflows the viewport, so a song that
+ * fits in one screen stays single even with double selected (never a
+ * near-empty second column). `heights` are the per-section heights measured at
+ * COLUMN width (narrower → taller, so they can't be reused from the
+ * single-column render). `gap` is the vertical space between stacked sections.
+ */
+export function partitionSections(
+  heights: number[],
+  viewportHeight: number,
+  gap: number,
+  singleHeight: number,
+): ColumnPartition {
+  const n = heights.length
+  // Nothing to split, an unmeasurable viewport, or a song that fits in one
+  // viewport as-is: stay single.
+  if (n <= 1 || viewportHeight <= 0) return { mode: 'single' }
+  if (singleHeight <= viewportHeight) return { mode: 'single' }
+
+  let colH = 0
+  for (let i = 0; i < n; i++) {
+    const add = i === 0 ? heights[i] : gap + heights[i]
+    // An oversized first section still anchors column 1 (it scrolls; two
+    // columns delay overflow, they don't eliminate it) — only break once
+    // column 1 has at least one section.
+    if (i > 0 && colH + add > viewportHeight) {
+      return { mode: 'double', col2Start: i }
+    }
+    colH += add
+  }
+  // Everything fit in one column at column width.
+  return { mode: 'single' }
+}
+
+export type MeasureInputs = {
+  /** Available content width (drives wrapping, and column width with it). */
+  width: number
+  fontScale: number
+  /** Transpose steps — chord widths change wrapping, so heights must invalidate. */
+  steps: number
+  preferFlat: boolean
+  chordStyle: string
+  showChords: boolean
+  showSections: boolean
+}
+
+/**
+ * Cache key for measured section heights. Every input that can change a
+ * section's rendered height is included — transpose, chord style, accidentals,
+ * and the show-chords/show-sections toggles all alter wrapping or remove rows,
+ * not just the (width, fontSize) pair.
+ */
+export function columnMeasureKey(i: MeasureInputs): string {
+  return [
+    i.width,
+    i.fontScale,
+    i.steps,
+    i.preferFlat ? 1 : 0,
+    i.chordStyle,
+    i.showChords ? 1 : 0,
+    i.showSections ? 1 : 0,
+  ].join('|')
+}

--- a/apps/mobile/src/lib/useIsTabletWidth.ts
+++ b/apps/mobile/src/lib/useIsTabletWidth.ts
@@ -1,0 +1,12 @@
+import { useWindowDimensions } from 'react-native'
+
+// Tablet-width gate for the two-column chart mode. Uses the SMALLER window
+// dimension so the answer is orientation-independent: iPads (min dimension
+// ≥ 744pt, down to the mini) qualify in both orientations, while phones —
+// including a landscape Pro Max (min dimension ~440pt) — never do.
+export const TABLET_MIN_DIMENSION = 600
+
+export function useIsTabletWidth(): boolean {
+  const { width, height } = useWindowDimensions()
+  return Math.min(width, height) >= TABLET_MIN_DIMENSION
+}

--- a/apps/mobile/src/lib/viewerPrefs.ts
+++ b/apps/mobile/src/lib/viewerPrefs.ts
@@ -1,0 +1,143 @@
+import { useSyncExternalStore } from 'react'
+import type { KVStorage } from './defaults'
+
+// Per-song viewer preferences — today just the column mode (1 or 2 columns on
+// tablet widths). Device-local (AsyncStorage), NOT Supabase-synced.
+//
+// Resolution is per-song override → app-wide default → 'single'. The app-wide
+// default is a storage seam only: nothing in the UI writes it in v1 (no
+// Settings surface), it just keeps the fallback in one place.
+//
+// Follows the defaults.ts pattern: storage is INJECTED so the module is RN-free
+// and unit-testable headless; the app root hydrates once during the splash
+// hold, after which reads are synchronous. Storage stays lean — only overrides
+// that differ from the resolved default are kept, and the key is removed
+// entirely when nothing remains.
+
+export type ColumnMode = 'single' | 'double'
+
+export const DEFAULT_COLUMN_MODE: ColumnMode = 'single'
+
+const STORAGE_KEY = 'gc.viewer.columnMode.v1'
+
+type ViewerPrefs = {
+  default: ColumnMode
+  songs: Record<string, ColumnMode>
+}
+
+const EMPTY: ViewerPrefs = { default: DEFAULT_COLUMN_MODE, songs: {} }
+
+let cache: ViewerPrefs = EMPTY
+let storage: KVStorage | null = null
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function isColumnMode(v: unknown): v is ColumnMode {
+  return v === 'single' || v === 'double'
+}
+
+function parse(raw: string | null): ViewerPrefs {
+  if (!raw) return EMPTY
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return EMPTY
+    const rec = parsed as Record<string, unknown>
+    const def = isColumnMode(rec.default) ? rec.default : DEFAULT_COLUMN_MODE
+    const songs: Record<string, ColumnMode> = {}
+    if (rec.songs && typeof rec.songs === 'object') {
+      for (const [slug, mode] of Object.entries(rec.songs as Record<string, unknown>)) {
+        if (isColumnMode(mode) && mode !== def) songs[slug] = mode
+      }
+    }
+    return { default: def, songs }
+  } catch {
+    return EMPTY
+  }
+}
+
+function persist(): void {
+  if (!storage) return
+  const hasOverrides = Object.keys(cache.songs).length > 0
+  if (!hasOverrides && cache.default === DEFAULT_COLUMN_MODE) {
+    storage.removeItem(STORAGE_KEY).catch(() => {})
+    return
+  }
+  const payload: Record<string, unknown> = { songs: cache.songs }
+  if (cache.default !== DEFAULT_COLUMN_MODE) payload.default = cache.default
+  storage.setItem(STORAGE_KEY, JSON.stringify(payload)).catch(() => {})
+}
+
+/**
+ * Load stored prefs into the cache and remember `store` for write-through. A
+ * bad read never crashes the app. Safe to call again to re-read from the same
+ * storage (used to simulate a reload in tests).
+ */
+export async function hydrateViewerPrefs(store: KVStorage): Promise<void> {
+  storage = store
+  try {
+    cache = parse(await store.getItem(STORAGE_KEY))
+  } catch {
+    cache = EMPTY
+  }
+  emit()
+}
+
+/** Resolved column mode for a song: per-song override → app default → single. */
+export function getColumnMode(slug: string | undefined): ColumnMode {
+  if (!slug) return cache.default
+  return cache.songs[slug] ?? cache.default
+}
+
+/**
+ * Persist a song's column mode. Setting a song back to the resolved default
+ * removes its override instead of storing a redundant entry.
+ */
+export function setColumnMode(slug: string, mode: ColumnMode): void {
+  if (!slug || getColumnMode(slug) === mode) return
+  const songs = { ...cache.songs }
+  if (mode === cache.default) delete songs[slug]
+  else songs[slug] = mode
+  cache = { ...cache, songs }
+  emit()
+  persist()
+}
+
+/** The app-wide default (storage seam only — no UI writes it in v1). */
+export function getDefaultColumnMode(): ColumnMode {
+  return cache.default
+}
+
+export function setDefaultColumnMode(mode: ColumnMode): void {
+  if (cache.default === mode) return
+  // Overrides equal to the new default become redundant; prune them.
+  const songs: Record<string, ColumnMode> = {}
+  for (const [slug, m] of Object.entries(cache.songs)) {
+    if (m !== mode) songs[slug] = m
+  }
+  cache = { default: mode, songs }
+  emit()
+  persist()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Subscribing hook — the resolved mode for `slug`, re-rendering on change. */
+export function useColumnMode(slug: string | undefined): ColumnMode {
+  return useSyncExternalStore(
+    subscribe,
+    () => getColumnMode(slug),
+    () => getColumnMode(slug),
+  )
+}
+
+/** Test-only reset so each test starts from a clean module state. */
+export function __resetViewerPrefsForTest(): void {
+  cache = EMPTY
+  storage = null
+}

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -29,6 +29,7 @@ import {
   transposeSymPrefer,
 } from '@gracechords/core'
 import ChordChart, { type ChordStyle } from '../components/ChordChart'
+import TwoColumnChart from '../components/TwoColumnChart'
 import Screen from '../components/Screen'
 import StarButton from '../components/StarButton'
 import SymbolIcon from '../components/SymbolIcon'
@@ -47,6 +48,8 @@ import { prefetchSong, useSong } from '../lib/useSong'
 import { useAutoHideChrome, useAutoHidePref } from '../lib/autoHideChrome'
 import { getDefaultsSnapshot, setDefaultKeepAwake, useAppDefaults } from '../lib/defaults'
 import { useKeepAwakeWhileFocused } from '../lib/keepAwake'
+import { useIsTabletWidth } from '../lib/useIsTabletWidth'
+import { setColumnMode, useColumnMode } from '../lib/viewerPrefs'
 import { exportSetlist, exportSong } from '../lib/exportSong'
 import { buildSetlistShareUrl } from '../lib/setlistShare'
 import {
@@ -122,6 +125,14 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
   const [sheet, setSheet] = useState<null | 'options' | 'share'>(null)
   // Floating-overlay header height → chart top inset (edge-to-edge).
   const [headerH, setHeaderH] = useState(0)
+  // Two-column mode: tablet widths only, persisted PER SONG (the current
+  // entry's song), exactly as in the Song Viewer. One song at a time — the
+  // columns split the current song's sections, never tile multiple songs.
+  const isTablet = useIsTabletWidth()
+  const currentSlug = entry?.song.slug
+  const columnMode = useColumnMode(currentSlug)
+  const [chartAreaH, setChartAreaH] = useState(0)
+  const twoColumns = isTablet && columnMode === 'double'
 
   const nativeKey = doc?.meta?.key || entry?.song.default_key || ''
   const targetKey = entryKeys[index] || nativeKey
@@ -474,7 +485,10 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         </View>
       ) : (
         <GestureDetector gesture={chartGesture}>
-          <Animated.View style={[{ flex: 1 }, chartAnim]}>
+          <Animated.View
+            style={[{ flex: 1 }, chartAnim]}
+            onLayout={(e) => setChartAreaH(e.nativeEvent.layout.height)}
+          >
             {doc ? (
               <ScrollView
                 style={{ flex: 1 }}
@@ -484,15 +498,28 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
                   paddingBottom: t.spacing.xxl * 2 + TRANSPOSE_BAR_CLEARANCE,
                 }}
               >
-                <ChordChart
-                  doc={doc}
-                  steps={steps}
-                  preferFlat={preferFlat}
-                  showChords={showChords}
-                  showSections={showSections}
-                  fontScale={fontScale}
-                  chordStyle={chordStyle}
-                />
+                {twoColumns ? (
+                  <TwoColumnChart
+                    doc={doc}
+                    steps={steps}
+                    preferFlat={preferFlat}
+                    showChords={showChords}
+                    showSections={showSections}
+                    fontScale={fontScale}
+                    chordStyle={chordStyle}
+                    viewportHeight={Math.max(0, chartAreaH - headerH - t.spacing.sm)}
+                  />
+                ) : (
+                  <ChordChart
+                    doc={doc}
+                    steps={steps}
+                    preferFlat={preferFlat}
+                    showChords={showChords}
+                    showSections={showSections}
+                    fontScale={fontScale}
+                    chordStyle={chordStyle}
+                  />
+                )}
               </ScrollView>
             ) : (
               <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl, paddingTop: headerH }}>
@@ -571,6 +598,10 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
         onChordStyle={setChordStyle}
         accidental={accidental}
         onAccidental={setAccidentalManual}
+        columnMode={isTablet && currentSlug ? columnMode : undefined}
+        onColumnMode={
+          isTablet && currentSlug ? (m) => setColumnMode(currentSlug, m) : undefined
+        }
         autoHide={autoHide}
         onAutoHide={setAutoHide}
         keepAwake={keepAwake}


### PR DESCRIPTION
## Summary

Adds optional two-column layout mode for tablet widths in the Song Viewer and Performer screens. When enabled on tablets, song sections are intelligently partitioned across two columns using a fill-first algorithm, reducing vertical scrolling while keeping the layout responsive and never creating near-empty columns.

## Key Changes

- **TwoColumnChart component** (`src/components/TwoColumnChart.tsx`): New wrapper around ChordChart that measures section heights off-screen at column width, then uses a fill-first partition algorithm to split sections across two columns. Includes height caching keyed by all layout-affecting inputs (width, font scale, transpose, chord style, etc.) to avoid redundant measurements.

- **Column layout math** (`src/lib/columnLayout.ts`): Pure, testable partition logic that greedily fills column 1 until the next section would exceed the viewport, then flows remaining sections to column 2. Stays single-column if the song fits in one viewport or has ≤1 section.

- **Viewer preferences** (`src/lib/viewerPrefs.ts`): New per-song, device-local storage for column mode (single/double). Follows the existing defaults.ts pattern with injected storage, synchronous reads after hydration, and automatic cleanup of redundant entries. Includes a subscribing hook for reactive updates.

- **Tablet width detection** (`src/lib/useIsTabletWidth.ts`): Hook that gates two-column mode to tablets (min dimension ≥600pt), orientation-independent.

- **Screen integration**: Updated Song Viewer (`app/viewer/[slug].tsx`) and Performer (`src/screens/PerformerScreen.tsx`) to conditionally render TwoColumnChart on tablets when column mode is 'double', with a new toggle in ViewOptionsSheet (tablet-only).

- **Tests**: Full unit test coverage for partition logic and viewer preferences (hydration, persistence, override resolution, storage cleanup).

## Notable Implementation Details

- **No flicker during measurement**: While heights are being measured, the previous partition (or single-column render) stays visible; the layout swaps in one state flip when all measurements complete.
- **Transpose invalidates cache**: Chord widths change line wrapping, so transpose steps are a critical cache key—changing transpose remeasures all sections.
- **Fill-first, not balanced**: Intentionally unequal columns; no bin-packing or rebalancing. Sections are atomic and never split.
- **Graceful degradation**: Phones never see the toggle; single-column is always the baseline. Tablets with double selected still render single if the song fits one viewport.

https://claude.ai/code/session_01KQ29cPrphBjJrukiqbv8B7