### PR TITLE
refactor(mobile): polish utilities UI per device feedback

### DIFF
--- a/apps/mobile/src/lib/pitchpipe/__tests__/notes.test.ts
+++ b/apps/mobile/src/lib/pitchpipe/__tests__/notes.test.ts
@@ -39,14 +39,16 @@ describe('pitch pipe notes', () => {
     }
   })
 
-  it('spans the vocal-centered C3–B5 range around a C4 default', () => {
+  it('spans the vocal-centered C2–B6 range around a C4 default', () => {
     expect(DEFAULT_OCTAVE).toBe(4)
-    expect(noteFrequency(C, MIN_OCTAVE)).toBeCloseTo(130.8128, 3) // C3
-    expect(noteFrequency(B, MAX_OCTAVE)).toBeCloseTo(987.7666, 3) // B5
+    expect(MIN_OCTAVE).toBe(2)
+    expect(MAX_OCTAVE).toBe(6)
+    expect(noteFrequency(C, MIN_OCTAVE)).toBeCloseTo(65.4064, 3) // C2
+    expect(noteFrequency(B, MAX_OCTAVE)).toBeCloseTo(1975.5332, 3) // B6
   })
 
   it('clamps octaves to the supported range', () => {
-    expect(clampOctave(2)).toBe(MIN_OCTAVE)
+    expect(clampOctave(1)).toBe(MIN_OCTAVE)
     expect(clampOctave(9)).toBe(MAX_OCTAVE)
     expect(clampOctave(4)).toBe(4)
     expect(clampOctave(Number.NaN)).toBe(DEFAULT_OCTAVE)

--- a/apps/mobile/src/lib/pitchpipe/notes.ts
+++ b/apps/mobile/src/lib/pitchpipe/notes.ts
@@ -1,6 +1,7 @@
 // Pure pitch-pipe math — RN-free so it unit-tests headless. Equal temperament
-// at A4 = 440 Hz over a 3-octave vocal-centered span: C3 (130.81 Hz) through
-// B5 (987.77 Hz), defaulting to the middle-C octave (C4–B4).
+// at A4 = 440 Hz over a vocal-centered span two octaves either side of the
+// middle-C octave: C2 (65.41 Hz) through B6 (1975.53 Hz), defaulting to the
+// middle-C octave (C4–B4, shown as offset 0).
 
 export const CHROMATIC_NOTES = [
   'C',
@@ -17,8 +18,8 @@ export const CHROMATIC_NOTES = [
   'B',
 ] as const
 
-export const MIN_OCTAVE = 3
-export const MAX_OCTAVE = 5
+export const MIN_OCTAVE = 2
+export const MAX_OCTAVE = 6
 export const DEFAULT_OCTAVE = 4
 
 export function clampOctave(octave: number): number {

--- a/apps/mobile/src/lib/tuner/useTuner.ts
+++ b/apps/mobile/src/lib/tuner/useTuner.ts
@@ -20,9 +20,11 @@ const CALLBACK_LENGTH = 1024
 const DECIMATION = 2
 const ANALYSIS_RATE = CAPTURE_RATE / DECIMATION
 const WINDOW = 2048
-const RMS_GATE = 0.008
+// Opened slightly from the spike's 0.008 so a decaying string is still tracked
+// into its tail instead of the gate slamming shut early.
+const RMS_GATE = 0.006
 /** Keep showing the last reading through short detection dropouts (note decay). */
-const DROPOUT_MS = 400
+const DROPOUT_MS = 650
 
 export type TunerPermission = 'unknown' | 'undetermined' | 'granted' | 'denied'
 
@@ -163,7 +165,11 @@ export function useTuner(options: UseTunerOptions = {}): Tuner {
 
         const now = Date.now()
         if (rmsLevel(ring) < RMS_GATE) {
-          if (lastReading) clear()
+          // Same decay grace as a detection miss: hold the last reading for
+          // DROPOUT_MS after the level dips rather than blanking instantly, so
+          // the display lingers through the tail of a ringing string.
+          if (lastReading && now - lastReadingAt > DROPOUT_MS) clear()
+          else if (lastReading) publish(lastReading, false)
           return
         }
 

--- a/apps/mobile/src/screens/MetronomeScreen.tsx
+++ b/apps/mobile/src/screens/MetronomeScreen.tsx
@@ -205,9 +205,6 @@ export default function MetronomeScreen() {
         >
           <SymbolIcon name="hand.tap" size={30} color={t.colors.accent} />
           <Text style={{ fontSize: 17, fontWeight: '600', color: t.colors.ink }}>Tap tempo</Text>
-          <Text style={{ fontSize: t.typography.rowMeta.fontSize, color: t.colors.muted }}>
-            Tap along anywhere in this box
-          </Text>
         </Pressable>
 
         {/* Time signature */}

--- a/apps/mobile/src/screens/PitchPipeScreen.tsx
+++ b/apps/mobile/src/screens/PitchPipeScreen.tsx
@@ -14,7 +14,6 @@ import {
   MAX_OCTAVE,
   MIN_OCTAVE,
   clampOctave,
-  noteFrequency,
 } from '../lib/pitchpipe/notes'
 import { usePitchPipe } from '../lib/pitchpipe/usePitchPipe'
 
@@ -117,6 +116,8 @@ export default function PitchPipeScreen() {
 
   const ringSize = Math.min(width - t.spacing.lg * 2, 340)
   const activeLabel = activeNote ? CHROMATIC_NOTES[activeNote.noteIndex] : null
+  const octaveOffset = octave - DEFAULT_OCTAVE
+  const octaveOffsetLabel = octaveOffset === 0 ? '0' : octaveOffset > 0 ? `+${octaveOffset}` : `${octaveOffset}`
   const octaveButtonStyle = ({ pressed }: { pressed: boolean }) => ({
     width: 44,
     height: 44,
@@ -140,8 +141,10 @@ export default function PitchPipeScreen() {
           alignItems: 'center',
         }}
       >
-        {/* The pipe: 12 chromatic notes on a ring, C at the top. */}
-        <View style={{ width: ringSize, height: ringSize, marginTop: t.spacing.md }}>
+        {/* The pipe: 12 chromatic notes on a ring, C at the top — vertically
+            centered in the space above the octave/hold controls. */}
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+        <View style={{ width: ringSize, height: ringSize }}>
           <View
             pointerEvents="none"
             style={{
@@ -155,7 +158,7 @@ export default function PitchPipeScreen() {
               borderColor: t.colors.border,
             }}
           />
-          {/* Center readout */}
+          {/* Center readout: a dash when silent, the sounding note otherwise. */}
           <View
             pointerEvents="none"
             style={{
@@ -166,32 +169,18 @@ export default function PitchPipeScreen() {
               bottom: 0,
               alignItems: 'center',
               justifyContent: 'center',
-              gap: 2,
             }}
           >
             <Text
               style={{
-                fontSize: 44,
+                fontSize: 52,
                 fontWeight: '700',
                 letterSpacing: -1,
                 color: activeNote ? t.colors.accent : t.colors.muted,
                 fontVariant: ['tabular-nums'],
               }}
             >
-              {activeLabel ? `${activeLabel}${activeNote!.octave}` : `C${octave}–B${octave}`}
-            </Text>
-            <Text
-              style={{
-                fontSize: t.typography.rowSubtitle.fontSize,
-                color: t.colors.sec,
-                fontVariant: ['tabular-nums'],
-              }}
-            >
-              {activeNote
-                ? `${noteFrequency(activeNote.noteIndex, activeNote.octave).toFixed(1)} Hz`
-                : hold
-                  ? 'Tap a note to sustain it'
-                  : 'Hold a note to sound it'}
+              {activeLabel ? `${activeLabel}${activeNote!.octave}` : '–'}
             </Text>
           </View>
           {CHROMATIC_NOTES.map((label, i) => (
@@ -207,10 +196,9 @@ export default function PitchPipeScreen() {
             />
           ))}
         </View>
+        </View>
 
-        <View style={{ flex: 1 }} />
-
-        {/* Octave ± (C3–B5, vocal-centered around middle C) */}
+        {/* Octave ± (C2–B6, shown as an offset from the middle-C octave) */}
         <View
           style={{
             flexDirection: 'row',
@@ -229,11 +217,25 @@ export default function PitchPipeScreen() {
             <SymbolIcon name="minus" size={18} color={t.colors.accent} weight="semibold" />
           </Pressable>
           <View style={{ alignItems: 'center', minWidth: 96 }}>
-            <Text style={{ fontSize: 20, fontWeight: '700', color: t.colors.ink }}>
-              Octave {octave}
+            <Text
+              style={{
+                fontSize: 28,
+                fontWeight: '700',
+                color: t.colors.ink,
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {octaveOffsetLabel}
             </Text>
-            <Text style={{ fontSize: t.typography.rowMeta.fontSize, color: t.colors.muted }}>
-              C{MIN_OCTAVE}–B{MAX_OCTAVE} range
+            <Text
+              style={{
+                fontSize: t.typography.overline.fontSize,
+                fontWeight: t.typography.overline.fontWeight,
+                letterSpacing: t.typography.overline.letterSpacing,
+                color: t.colors.muted,
+              }}
+            >
+              OCTAVE
             </Text>
           </View>
           <Pressable
@@ -258,14 +260,9 @@ export default function PitchPipeScreen() {
               paddingVertical: t.spacing.sm,
             }}
           >
-            <View style={{ flexShrink: 1, paddingRight: t.spacing.md }}>
-              <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.ink }}>
-                Hold
-              </Text>
-              <Text style={{ fontSize: t.typography.rowMeta.fontSize, color: t.colors.muted }}>
-                {hold ? 'Notes sustain until tapped again' : 'Notes sound while pressed'}
-              </Text>
-            </View>
+            <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.ink }}>
+              Hold note
+            </Text>
             <Switch
               value={hold}
               onValueChange={(on) => {
@@ -273,7 +270,7 @@ export default function PitchPipeScreen() {
                 if (!on) stop()
               }}
               trackColor={{ true: t.colors.accent }}
-              accessibilityLabel="Hold notes"
+              accessibilityLabel="Hold note"
             />
           </View>
         </Card>

--- a/apps/mobile/src/screens/TunerScreen.tsx
+++ b/apps/mobile/src/screens/TunerScreen.tsx
@@ -97,10 +97,7 @@ function StringKey({
         opacity: pressed ? 0.85 : 1,
       })}
     >
-      <Text style={{ fontSize: 17, fontWeight: '700', color: fg }}>{string.label}</Text>
-      <Text style={{ fontSize: 10, fontWeight: '600', color: fg, opacity: 0.7 }}>
-        {string.name.slice(-1)}
-      </Text>
+      <Text style={{ fontSize: 24, fontWeight: '700', color: fg }}>{string.label}</Text>
     </Pressable>
   )
 }
@@ -121,7 +118,8 @@ export default function TunerScreen() {
           -METER_RANGE_CENTS,
           Math.min(METER_RANGE_CENTS, frame.reading.cents)
         )
-        needleCents.value = withTiming(clamped, { duration: 80, easing: Easing.linear })
+        // ~10% longer glide than the original 80 ms for a smoother needle.
+        needleCents.value = withTiming(clamped, { duration: 88, easing: Easing.linear })
         needleActive.value = withTiming(1, { duration: 120 })
       } else {
         needleCents.value = withTiming(0, { duration: 250 })
@@ -192,6 +190,9 @@ export default function TunerScreen() {
           </View>
         ) : (
           <>
+            {/* Balances the spacer below the readout so the meter + note block
+                sits vertically centered above the string row. */}
+            <View style={{ flex: 1 }} />
             {/* Meter */}
             <View style={{ alignItems: 'center' }}>
               <View style={{ width: meterWidth, height: radius + 24, alignItems: 'center' }}>
@@ -321,9 +322,7 @@ export default function TunerScreen() {
                 color: t.colors.muted,
               }}
             >
-              {lockedString
-                ? `Locked to ${lockedString.name} — tap it again for auto-detect`
-                : 'Auto-detecting — tap a string to lock it'}
+              {lockedString ? 'Auto-mode off' : 'Auto-mode on'}
             </Text>
           </>
         )}


### PR DESCRIPTION
Pitch Pipe:
- center the note ring vertically in the view
- center readout shows a dash when silent, the sounding note when playing (dropped the octave-range label, per-note Hz, and instruction subtext)
- octave control reads as a signed offset from middle C (0, +1, +2, -1, -2); range widened to C2-B6 so +/-2 are reachable
- toggle relabeled "Hold note" with the subtext removed

Metronome:
- drop the "Tap along anywhere in this box" explainer ("Tap tempo" is enough)

Tuner:
- string keys: larger, centered letters; octave digits removed
- mode caption simplified to "Auto-mode on" / "Auto-mode off"
- meter moved toward vertical center
- needle glide ~10% smoother (80 -> 88 ms)
- noise gate opened slightly (RMS 0.008 -> 0.006) and the last reading now holds through the note's decay tail on both the detection-miss and level-dip paths (DROPOUT 400 -> 650 ms), so the reading no longer blanks the instant a string starts to fade


Claude-Session: https://claude.ai/code/session_01Euhirt2TogM4iqc9qTMyyz