### PR TITLE
Silence benign "Invalid Refresh Token" logs from GoTrue init

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -85,6 +85,17 @@ step to core to make mobile work — fix Metro config instead.
   `persistSession`/`autoRefreshToken` keep the factory defaults (`true`).
 - Token refresh is driven by `AppState` (`registerAuthAutoRefresh` in
   `src/lib/supabase.ts`), called once at the app root.
+- A **dead persisted refresh token** (signed out elsewhere, token rotated,
+  session deleted) is benign and self-healing: `resolveInitialSession`
+  (`src/lib/authSession.ts`) purges it locally at launch and the gate routes to
+  `/login`. But GoTrue also logs it to `console.error` from inside its own
+  automatic init (`_recoverAndRefresh`, run when the client is constructed) —
+  before any of our code can react, and with no config hook to disable that one
+  call. `silenceInvalidRefreshTokenLogs` wraps `console.error` once (installed in
+  `src/lib/supabase.ts` **before** the client is created) to drop exactly that
+  self-healing error; everything else passes through. Don't "fix" this by
+  flipping `autoRefreshToken` off — that changes real refresh behavior and
+  relies on GoTrue internals.
 - Env: `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` from
   `apps/mobile/.env` (the **public anon** key — same as the web client, never the
   service-role key). Mirror any new `EXPO_PUBLIC_*` var into `.env.example`.

--- a/apps/mobile/src/lib/__tests__/authSession.test.ts
+++ b/apps/mobile/src/lib/__tests__/authSession.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { isInvalidRefreshTokenError, resolveInitialSession } from '../authSession'
+import {
+  isInvalidRefreshTokenError,
+  resolveInitialSession,
+  silenceInvalidRefreshTokenLogs,
+} from '../authSession'
 
 type BootAuth = Parameters<typeof resolveInitialSession>[0]
 
@@ -34,6 +38,96 @@ describe('isInvalidRefreshTokenError', () => {
     expect(isInvalidRefreshTokenError(null)).toBe(false)
     expect(isInvalidRefreshTokenError('boom')).toBe(false)
     expect(isInvalidRefreshTokenError(undefined)).toBe(false)
+  })
+})
+
+describe('silenceInvalidRefreshTokenLogs', () => {
+  function fakeConsole() {
+    return { error: vi.fn() as unknown as (...args: unknown[]) => void }
+  }
+
+  it('drops the benign invalid-refresh-token error', () => {
+    const original = vi.fn()
+    const target = { error: original as unknown as (...args: unknown[]) => void }
+    silenceInvalidRefreshTokenLogs(target)
+
+    target.error({
+      __isAuthError: true,
+      name: 'AuthApiError',
+      status: 400,
+      code: 'refresh_token_not_found',
+      message: 'Invalid Refresh Token: Refresh Token Not Found',
+    })
+
+    expect(original).not.toHaveBeenCalled()
+  })
+
+  it('passes unrelated console.error calls through untouched', () => {
+    const original = vi.fn()
+    const target = { error: original as unknown as (...args: unknown[]) => void }
+    silenceInvalidRefreshTokenLogs(target)
+
+    target.error('a real problem', { detail: 1 })
+    target.error(new Error('boom'))
+
+    expect(original).toHaveBeenCalledTimes(2)
+    expect(original).toHaveBeenNthCalledWith(1, 'a real problem', { detail: 1 })
+  })
+
+  it('suppresses when the error is passed alongside a message (auto-refresh tick shape)', () => {
+    const original = vi.fn()
+    const target = { error: original as unknown as (...args: unknown[]) => void }
+    silenceInvalidRefreshTokenLogs(target)
+
+    target.error('Auto refresh tick failed with error. This is likely a transient error.', {
+      code: 'refresh_token_not_found',
+    })
+
+    expect(original).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: a second install does not double-wrap and its restore is a no-op', () => {
+    const original = vi.fn() as unknown as (...args: unknown[]) => void
+    const target = { error: original }
+    silenceInvalidRefreshTokenLogs(target)
+    const wrapped = target.error
+    const restoreSecond = silenceInvalidRefreshTokenLogs(target)
+
+    expect(target.error).toBe(wrapped)
+    restoreSecond()
+    // the no-op restore must not tear the filter off
+    expect(target.error).toBe(wrapped)
+  })
+
+  it('restore puts the original console.error back', () => {
+    const original = vi.fn() as unknown as (...args: unknown[]) => void
+    const target = { error: original }
+    const restore = silenceInvalidRefreshTokenLogs(target)
+
+    expect(target.error).not.toBe(original)
+    restore()
+    expect(target.error).toBe(original)
+  })
+
+  it('defaults to the global console when no target is given', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const restore = silenceInvalidRefreshTokenLogs()
+      console.error({ code: 'refresh_token_not_found' })
+      expect(spy).not.toHaveBeenCalled()
+      console.error('still works')
+      expect(spy).toHaveBeenCalledWith('still works')
+      restore()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('leaves the passthrough available for callers that inject a stub', () => {
+    const target = fakeConsole()
+    const restore = silenceInvalidRefreshTokenLogs(target)
+    restore()
+    expect(typeof target.error).toBe('function')
   })
 })
 

--- a/apps/mobile/src/lib/authSession.ts
+++ b/apps/mobile/src/lib/authSession.ts
@@ -18,6 +18,45 @@ export function isInvalidRefreshTokenError(error: unknown): boolean {
   return msg.includes('refresh token') && (msg.includes('not found') || msg.includes('invalid'))
 }
 
+// GoTrue's automatic init runs `_recoverAndRefresh` the moment the client is
+// constructed (synchronously, at module import) and, when the persisted refresh
+// token is dead, refreshes it and logs the AuthApiError straight to
+// `console.error` itself — see @supabase/auth-js GoTrueClient `_recoverAndRefresh`.
+// That fires BEFORE resolveInitialSession() (or the AppState auto-refresh tick)
+// can react, so purging the token after the fact can't prevent the log. The log
+// is benign: GoTrue removes the dead session immediately and the app routes to
+// /login. But on a dev build it surfaces as a red LogBox screen ("Console
+// Error: Invalid Refresh Token: Refresh Token Not Found") and in production it
+// pollutes crash/log reporters with a non-actionable error. There is no config
+// or API hook to silence that one call, so wrap `console.error` once and drop
+// exactly this self-healing error (everything else passes through untouched).
+//
+// Idempotent per target (marks the wrapper so a second call is a no-op) and
+// returns a restore function. `target` is injectable so it unit-tests without
+// mutating the real global console.
+const REFRESH_LOG_SILENCED = '__gcRefreshTokenLogSilenced'
+
+type ConsoleErrorTarget = { error: (...args: unknown[]) => void }
+
+export function silenceInvalidRefreshTokenLogs(
+  target: ConsoleErrorTarget = console,
+): () => void {
+  const original = target.error
+  if ((original as { [REFRESH_LOG_SILENCED]?: boolean })[REFRESH_LOG_SILENCED]) {
+    return () => {}
+  }
+  const patched = (...args: unknown[]) => {
+    if (args.some(isInvalidRefreshTokenError)) return
+    original.apply(target, args)
+  }
+  ;(patched as { [REFRESH_LOG_SILENCED]?: boolean })[REFRESH_LOG_SILENCED] = true
+  target.error = patched as ConsoleErrorTarget['error']
+  return () => {
+    // Only restore if nothing else re-wrapped console.error after us.
+    if (target.error === patched) target.error = original
+  }
+}
+
 // Resolve the persisted session at launch. getSession() already refreshes an
 // expired token internally and returns { session: null, error } when the stored
 // refresh token is dead — but it leaves the caller to react. If we hit a dead

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { AppState } from 'react-native'
 import { createGcSupabase } from '@gracechords/core'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import { silenceInvalidRefreshTokenLogs } from './authSession'
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL
 const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
@@ -23,6 +24,15 @@ export const supabaseConfigError: string | null =
       'cloud build — set these as EAS environment variables ' +
       '(eas env:create --environment production ...).'
     : null
+
+// Drop GoTrue's benign, self-healing "Invalid Refresh Token" console.error
+// before the client is created. That log is emitted from inside GoTrue's own
+// automatic init (`_recoverAndRefresh`), which kicks off when createGcSupabase()
+// constructs the client below — so the filter must be installed FIRST to be in
+// place when init runs. See silenceInvalidRefreshTokenLogs for the full why.
+if (!supabaseConfigError) {
+  silenceInvalidRefreshTokenLogs()
+}
 
 // Consume the SAME core factory the web app uses. We inject AsyncStorage as the
 // native session store; persistSession + autoRefreshToken default to true in


### PR DESCRIPTION
## Summary
Wraps `console.error` to suppress GoTrue's benign "Invalid Refresh Token" error that fires during automatic client initialization when a persisted refresh token is dead. The error is self-healing (the app routes to login), but pollutes logs and causes red LogBox screens in dev builds.

## Changes
- **`authSession.ts`**: Added `silenceInvalidRefreshTokenLogs()` function that wraps `console.error` to filter out invalid refresh token errors while passing all other logs through. The wrapper is idempotent (safe to call multiple times on the same target) and returns a restore function.
- **`supabase.ts`**: Installed the console wrapper **before** creating the Supabase client, ensuring it's in place when GoTrue's `_recoverAndRefresh` runs during client construction.
- **`authSession.test.ts`**: Added comprehensive test suite covering:
  - Filtering the benign error by error object shape
  - Filtering when the error is passed alongside a message (auto-refresh tick shape)
  - Passing through unrelated console.error calls
  - Idempotency (second install doesn't double-wrap)
  - Restore function behavior
  - Default to global console when no target provided
- **`AGENTS.md`**: Documented the pattern and rationale to prevent future "fixes" that would break the solution.

## Implementation Details
- Uses a symbol (`__gcRefreshTokenLogSilenced`) to mark wrapped functions, preventing double-wrapping if the function is called multiple times on the same target.
- The restore function only restores if nothing else has re-wrapped `console.error` after this wrapper, maintaining safety in complex initialization scenarios.
- Injection of a `target` parameter enables unit testing without mutating the real global console.

https://claude.ai/code/session_01XxwtmZ9zmJctzaynRnu4NR