### PR TITLE
Replace logo text with icon image in Auth and Home screens

### DIFF
--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -103,20 +103,11 @@ export default function AuthScreen() {
           end={{ x: 0, y: 1 }}
           style={{ alignItems: 'center', paddingTop: insets.top + t.spacing.xxl, paddingBottom: t.spacing.xl }}
         >
-          <View
-            style={{
-              width: 64,
-              height: 64,
-              borderRadius: t.radii.card,
-              backgroundColor: t.colors.accent,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Text style={{ fontSize: 22, fontWeight: '700', letterSpacing: 0.5, color: t.colors.onAccent }}>
-              GC
-            </Text>
-          </View>
+          <Image
+            source={require('../../assets/icon.png')}
+            accessibilityLabel="GraceChords"
+            style={{ width: 64, height: 64, borderRadius: t.radii.card }}
+          />
           <Text
             style={{
               marginTop: t.spacing.lg,

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -123,20 +123,11 @@ export default function HomeScreen() {
               }}
             >
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 9 }}>
-                <View
-                  style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: 8,
-                    backgroundColor: t.colors.accent,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Text style={{ fontSize: 12, fontWeight: '700', letterSpacing: 0.3, color: t.colors.onAccent }}>
-                    GC
-                  </Text>
-                </View>
+                <Image
+                  source={require('../../assets/icon.png')}
+                  accessibilityLabel="GraceChords"
+                  style={{ width: 28, height: 28, borderRadius: 8 }}
+                />
                 <Text style={{ fontSize: 20, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
                   GraceChords
                 </Text>


### PR DESCRIPTION
## Summary
Replace hardcoded "GC" text logos with actual icon image assets in the mobile app's authentication and home screens.

## Changes
- **AuthScreen**: Replaced styled View with "GC" text (64x64px) with Image component loading `icon.png`
- **HomeScreen**: Replaced styled View with "GC" text (28x28px) with Image component loading `icon.png`
- Both implementations now use the same icon asset with appropriate accessibility labels
- Removed inline styling for background color, text styling, and layout (now handled by the image asset itself)

## Implementation Details
- Image components maintain the same dimensions and border radius as the previous text-based logos
- Added `accessibilityLabel="GraceChords"` to both Image components for accessibility
- The icon asset is sourced from `apps/mobile/assets/icon.png`

https://claude.ai/code/session_01WKNr6QUbdsao62GpoM9KV7