### PR TITLE
Document Google Sign-In nonce requirement for iOS

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -26,6 +26,11 @@ EXPO_PUBLIC_R2_PUBLIC_URL=https://assets.gracechords.com
 #    validates (also add it to Supabase -> Auth -> Providers -> Google ->
 #    Authorized Client IDs, alongside the iOS client id).
 #  - an "iOS" client bound to bundle id com.gracechords.app.
+# ALSO enable Supabase -> Auth -> Providers -> Google -> "Skip nonce checks".
+# On iOS the native Google SDK embeds a nonce in the id_token, but the free
+# google-signin library cannot supply the matching raw nonce (custom nonce is a
+# paid feature), so without this toggle Supabase rejects the token with
+# "Passed nonce and nonce in id_token should either both exist or not."
 # The REVERSED iOS client id (com.googleusercontent.apps.<id>) must also
 # replace the placeholder in app.json -> @react-native-google-signin/
 # google-signin -> iosUrlScheme, then rebuild the dev client.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -176,7 +176,11 @@ duplicate logic here and never edit core internals to suit mobile.
   `src/lib/authDeps.ts`. Google client ids come from
   `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` / `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID`, and the
   reversed iOS client id must be set in `app.json` → google-signin plugin
-  `iosUrlScheme`. The sprite pick is written to `users.preferences.sprite`
+  `iosUrlScheme`. Supabase's Google provider must have **"Skip nonce checks"**
+  enabled: iOS embeds a nonce in the id-token that the free google-signin lib
+  can't reproduce, so otherwise `signInWithIdToken` rejects it ("Passed nonce and
+  nonce in id_token should either both exist or not"). Apple is unaffected — it
+  drives the raw/hashed nonce pair itself (see `appleSignIn`). The sprite pick is written to `users.preferences.sprite`
   (`src/lib/profile.ts`) — the same JSONB shape the web Profile page writes; ids in
   `src/lib/sprites.ts` must stay in sync with web's `SpritePicker.jsx`.
 

--- a/apps/mobile/src/lib/authFlows.ts
+++ b/apps/mobile/src/lib/authFlows.ts
@@ -95,6 +95,13 @@ export async function googleSignIn(deps: GoogleDeps): Promise<AuthResult> {
     return { ok: false, error: 'Google did not return a credential.' }
   }
 
+  // No nonce is passed here — unlike Apple. On iOS the native Google SDK embeds
+  // its own nonce claim in the id_token, but the FREE @react-native-google-signin
+  // cannot supply/read a matching raw nonce (custom nonce is a paid feature). So
+  // the Google provider MUST have "Skip nonce checks" enabled in the Supabase
+  // dashboard (Auth -> Providers -> Google); otherwise Supabase rejects the token
+  // with "Passed nonce and nonce in id_token should either both exist or not."
+  // Do not add a `nonce` here expecting parity with appleSignIn — it would not match.
   const { error } = await deps.supabase.auth.signInWithIdToken({
     provider: 'google',
     token: result.idToken,


### PR DESCRIPTION
## Summary
Added documentation clarifying that Supabase's Google provider must have "Skip nonce checks" enabled for iOS Google Sign-In to work correctly with the free `@react-native-google-signin` library.

## Changes
- **authFlows.ts**: Added detailed inline comment explaining why no nonce is passed to `signInWithIdToken` for Google, and why the Supabase Google provider configuration requires "Skip nonce checks" to be enabled
- **AGENTS.md**: Updated Google Sign-In setup documentation to include the nonce check requirement and explain the technical reason (iOS native SDK embeds a nonce that the free library cannot reproduce)
- **.env.example**: Added setup instructions noting the "Skip nonce checks" toggle requirement and the underlying constraint

## Implementation Details
The iOS native Google SDK automatically embeds a nonce claim in the id_token, but the free `@react-native-google-signin` library cannot supply or read a matching raw nonce (custom nonce support is a paid feature). Without "Skip nonce checks" enabled in Supabase, `signInWithIdToken` rejects the token with "Passed nonce and nonce in id_token should either both exist or not." This is distinct from Apple Sign-In, which drives the raw/hashed nonce pair itself and does not have this constraint.

https://claude.ai/code/session_01NiTkWyyQyTy6qsKDaNcyXE