### PR TITLE
Tighten section spacing in lyrics layout

### DIFF
--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -284,8 +284,8 @@ select{
 }
 .section {
   font-weight: 700;          /* bold */
-  margin-top: 0.85em;        /* just shy of a line */
-  margin-bottom: 0.25em;     /* small gap before the first lyric line */
+  margin-top: 0.45em;        /* tighter gap between sections */
+  margin-bottom: 0.05em;     /* minimal gap before the first lyric line */
   letter-spacing: 0.02em;    /* subtle readability boost (optional) */
 }
 .comment {


### PR DESCRIPTION
## Summary
Adjusted margin values for `.section` class to create tighter spacing between lyric sections and reduce gaps before the first lyric line.

## Changes
- Reduced `margin-top` from `0.85em` to `0.45em` for more compact spacing between sections
- Reduced `margin-bottom` from `0.25em` to `0.05em` for minimal gap before lyric lines
- Updated comments to reflect the new spacing intent

## Details
These changes improve the visual density of lyric layouts by reducing whitespace while maintaining readability. The tighter margins create a more cohesive section grouping without sacrificing clarity.

https://claude.ai/code/session_01KmBPBFgZjApdogRMbVq4cY