### PR TITLE
Add tablet UI: library grid, split builder, form sheets

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -127,6 +127,12 @@ duplicate logic here and never edit core internals to suit mobile.
   `layout.maxWidth`). It passes through untouched at compact (phone) width and
   caps + centers at regular (tablet) width (`useIsTabletWidth`). Applied to
   Auth (form), Home and the Setlists index (content).
+- **Song Library tablet grid:** at regular width the library's SectionList
+  chunks each letter section's songs into rows of N `ListRow` cells
+  (`src/lib/gridRows.ts`; N from tokens `layout.libraryColumns` — 2 portrait,
+  3 landscape). Presentation-only: sections, sticky full-width headers, the
+  A–Z scrubber's section-index jumps, and search/sort logic are unchanged, and
+  phones keep the unchunked single-column list.
 - **Setlist Builder tablet split:** at regular width the builder becomes a
   list-detail split (ratio from tokens `layout.split`, ~1/3 · 2/3): a
   searchable `LibraryPane` (`src/components/setlist/LibraryPane.tsx` — its own

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -127,6 +127,13 @@ duplicate logic here and never edit core internals to suit mobile.
   `layout.maxWidth`). It passes through untouched at compact (phone) width and
   caps + centers at regular (tablet) width (`useIsTabletWidth`). Applied to
   Auth (form), Home and the Setlists index (content).
+- **Setlist Builder tablet split:** at regular width the builder becomes a
+  list-detail split (ratio from tokens `layout.split`, ~1/3 · 2/3): a
+  searchable `LibraryPane` (`src/components/setlist/LibraryPane.tsx` — its own
+  list instance, not shared with the Songs tab) on the left with the same
+  tap-to-toggle add semantics as `AddSongsModal` (`toggleSong` — one write
+  path, autosave applies), the unchanged builder column on the right. Phones
+  render the single-column builder untouched.
 - **Option sheets:** `ViewOptionsSheet` and `FilterSortSheet` present through
   the native `formSheet` route (`app/sheet.tsx` + `src/lib/formSheetHost.ts` —
   screens keep owning state/callbacks; the host bridges the render into the

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -120,7 +120,19 @@ duplicate logic here and never edit core internals to suit mobile.
 ## Primitives & UI conventions
 
 - Reusable primitives live in `src/components/`: `Screen`, `Button`, `Card`,
-  `ListRow`, `Chip`, `SectionHeader`. Prefer them over bespoke views.
+  `ListRow`, `Chip`, `SectionHeader`, `ConstrainedContent`. Prefer them over
+  bespoke views.
+- **Tablet content width:** wrap screen content in `ConstrainedContent`
+  (`tier="form"` ≈ 440 / `tier="content"` ≈ 700, values in tokens
+  `layout.maxWidth`). It passes through untouched at compact (phone) width and
+  caps + centers at regular (tablet) width (`useIsTabletWidth`). Applied to
+  Auth (form), Home and the Setlists index (content).
+- **Option sheets:** `ViewOptionsSheet` and `FilterSortSheet` present through
+  the native `formSheet` route (`app/sheet.tsx` + `src/lib/formSheetHost.ts` —
+  screens keep owning state/callbacks; the host bridges the render into the
+  route). Phones get a native bottom sheet with grabber/detents, iPads a
+  centered narrow form sheet. The remaining sheets still use the hand-rolled
+  `BottomSheet` Modal shell.
 - **Icons are SF Symbols only**, via `src/components/SymbolIcon.tsx` (wraps
   `expo-symbols`) — no hand-drawn/SVG glyphs. SF Symbols render on iOS/iPadOS only
   (the current target).

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import * as SplashScreen from 'expo-splash-screen'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import type { Session } from '@supabase/supabase-js'
+import { radii } from '@gracechords/tokens/native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { ThemeProvider, ThemedStatusBar } from '../src/theme/ThemeProvider'
 import {
@@ -196,6 +197,19 @@ export default function RootLayout() {
             <Stack.Screen name="tuner" />
             <Stack.Screen name="metronome" />
             <Stack.Screen name="pitch-pipe" />
+            {/* Shared option-sheet route (src/lib/formSheetHost.ts): native
+                formSheet so phones keep a bottom sheet with grabber/detents
+                while tablets get the centered, naturally-narrow form sheet. */}
+            <Stack.Screen
+              name="sheet"
+              options={{
+                presentation: 'formSheet',
+                sheetAllowedDetents: 'fitToContents',
+                sheetGrabberVisible: true,
+                sheetCornerRadius: radii.sheet,
+                contentStyle: { backgroundColor: 'transparent' },
+              }}
+            />
           </Stack>
         </SafeAreaProvider>
       </ThemeProvider>

--- a/apps/mobile/app/sheet.tsx
+++ b/apps/mobile/app/sheet.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+import { View } from 'react-native'
+import { notifyFormSheetRouteClosed, useFormSheetContent } from '../src/lib/formSheetHost'
+import { useTheme } from '../src/theme/ThemeProvider'
+
+// The shared native-sheet route: presented as `formSheet` (see app/_layout.tsx)
+// so phones get a native bottom sheet with detents/grabber and iPads get the
+// centered, naturally-narrow form sheet. Content comes from the formSheetHost
+// bridge — the owning screen keeps its state and callbacks.
+
+export default function SheetRoute() {
+  const t = useTheme()
+  const content = useFormSheetContent()
+
+  useEffect(() => () => notifyFormSheetRouteClosed(), [])
+
+  return <View style={{ backgroundColor: t.colors.surface }}>{content}</View>
+}

--- a/apps/mobile/src/components/ConstrainedContent.tsx
+++ b/apps/mobile/src/components/ConstrainedContent.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+import { View, type StyleProp, type ViewStyle } from 'react-native'
+import { useTheme } from '../theme/ThemeProvider'
+import { useIsTabletWidth } from '../lib/useIsTabletWidth'
+
+// The content-width constraint primitive. On compact (phone) width it renders
+// its children untouched — a literal pass-through, so phone layouts are
+// byte-identical to a build without it. On regular (tablet) width it caps the
+// content to the tier's max width (tokens `layout.maxWidth`) and centers it.
+//
+// `style` is applied only to the regular-width wrapper — use it when the
+// constrained region must also flex (e.g. wrapping a screen-filling list).
+
+export default function ConstrainedContent({
+  tier,
+  style,
+  children,
+}: {
+  tier: 'form' | 'content'
+  style?: StyleProp<ViewStyle>
+  children: ReactNode
+}) {
+  const t = useTheme()
+  const isRegular = useIsTabletWidth()
+  if (!isRegular) return <>{children}</>
+  return (
+    <View
+      style={[
+        { width: '100%', maxWidth: t.layout.maxWidth[tier], alignSelf: 'center' },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  )
+}

--- a/apps/mobile/src/components/FilterSortSheet.tsx
+++ b/apps/mobile/src/components/FilterSortSheet.tsx
@@ -2,10 +2,12 @@ import {
   Pressable,
   ScrollView,
   Text,
+  useWindowDimensions,
   View,
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import BottomSheet from './BottomSheet'
+import FormSheetShell from './FormSheetShell'
+import { useFormSheet } from '../lib/formSheetHost'
 import Button from './Button'
 import Card from './Card'
 import Chip from './Chip'
@@ -23,23 +25,14 @@ const SORT_OPTIONS: { key: SortKey; label: string }[] = [
   { key: 'tempo', label: 'Tempo' },
 ]
 
-// The Filter & sort bottom sheet (the design's single filter control — no
-// segment bar). Sort-by rows show an up/down chevron on the active option;
-// tapping it again flips direction. Tags come from the real library and toggle
-// the tag filter. The footer button just closes the sheet — the list behind it
-// already reflects every change live.
-export default function FilterSortSheet({
-  visible,
-  onClose,
-  sortKey,
-  sortDir,
-  onToggleSort,
-  availableTags,
-  selectedTags,
-  onToggleTag,
-  onReset,
-  resultCount,
-}: {
+// The Filter & sort sheet (the design's single filter control — no segment
+// bar), presented via the native formSheet route (src/lib/formSheetHost.ts):
+// a bottom sheet on phones, a centered narrow form sheet on tablets. Sort-by
+// rows show an up/down chevron on the active option; tapping it again flips
+// direction. Tags come from the real library and toggle the tag filter. The
+// footer button just closes the sheet — the list behind it already reflects
+// every change live.
+type FilterSortProps = {
   visible: boolean
   onClose: () => void
   sortKey: SortKey
@@ -50,21 +43,35 @@ export default function FilterSortSheet({
   onToggleTag: (tag: string) => void
   onReset: () => void
   resultCount: number
-}) {
+}
+
+export default function FilterSortSheet(props: FilterSortProps) {
+  useFormSheet(props.visible, () => <FilterSortContent {...props} />, props.onClose)
+  return null
+}
+
+function FilterSortContent({
+  onClose,
+  sortKey,
+  sortDir,
+  onToggleSort,
+  availableTags,
+  selectedTags,
+  onToggleTag,
+  onReset,
+  resultCount,
+}: FilterSortProps) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
+  const { height } = useWindowDimensions()
 
   return (
-    <BottomSheet
-      visible={visible}
-      onClose={onClose}
-      title="Filter & sort"
-      actionLabel="Reset"
-      onAction={onReset}
-      closeAccessibilityLabel="Close filter and sort"
-    >
+    <FormSheetShell title="Filter & sort" actionLabel="Reset" onAction={onReset}>
       <ScrollView
-        style={{ flexGrow: 0 }}
+        // The fitToContents detent doesn't bound over-tall content the way the
+        // old Modal's maxHeight did, so cap the scroll area ourselves — long
+        // tag lists scroll here instead of pushing the footer off screen.
+        style={{ flexGrow: 0, maxHeight: Math.round(height * 0.6) }}
         contentContainerStyle={{ padding: t.spacing.lg }}
       >
         {/* Sort by */}
@@ -158,6 +165,6 @@ export default function FilterSortSheet({
           onPress={onClose}
         />
       </View>
-    </BottomSheet>
+    </FormSheetShell>
   )
 }

--- a/apps/mobile/src/components/FormSheetShell.tsx
+++ b/apps/mobile/src/components/FormSheetShell.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { useTheme } from '../theme/ThemeProvider'
+
+// Chrome for sheets hosted in the native formSheet route (app/sheet.tsx): the
+// same title/action header as BottomSheet, minus the Modal, backdrop, slide
+// animation, and grabber — presentation, dismissal, and the grabber are native.
+
+export default function FormSheetShell({
+  title,
+  actionLabel = 'Done',
+  onAction,
+  children,
+}: {
+  title: string
+  actionLabel?: string
+  /** Header action; pass the sheet's close/reset handler. */
+  onAction: () => void
+  children: ReactNode
+}) {
+  const t = useTheme()
+  return (
+    <View style={{ backgroundColor: t.colors.surface }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: t.spacing.lg,
+          paddingTop: t.spacing.lg,
+          paddingBottom: t.spacing.md,
+          borderBottomWidth: 1,
+          borderBottomColor: t.colors.border,
+        }}
+      >
+        <Text style={{ fontSize: 18, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
+          {title}
+        </Text>
+        <Pressable onPress={onAction} accessibilityRole="button" hitSlop={8}>
+          <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.textAccent }}>
+            {actionLabel}
+          </Text>
+        </Pressable>
+      </View>
+      {children}
+    </View>
+  )
+}

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -1,16 +1,19 @@
 import { Pressable, Switch, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import BottomSheet from './BottomSheet'
+import FormSheetShell from './FormSheetShell'
 import AccidentalToggle, { type Accidental } from './AccidentalToggle'
 import type { ChordStyle } from './ChordChart'
 import type { ColumnMode } from '../lib/viewerPrefs'
+import { useFormSheet } from '../lib/formSheetHost'
 import { useTheme } from '../theme/ThemeProvider'
 
 // Re-export so existing screen imports (`from './ViewOptionsSheet'`) keep working.
 export { type Accidental, defaultAccidental, resolvePreferFlat } from './AccidentalToggle'
 
-// The viewer's "View options" bottom sheet (••• button). Everything is
+// The viewer's "View options" sheet (••• button). Everything is
 // controlled/ephemeral — the screen owns the state, nothing persists.
+// Presented via the native formSheet route (src/lib/formSheetHost.ts): a
+// bottom sheet on phones, a centered narrow form sheet on tablets.
 // CHORD STYLE has no Numbers segment: no Nashville conversion exists in core
 // yet (flagged for a future pass).
 
@@ -88,26 +91,7 @@ function OverlineLabel({ children, first }: { children: string; first?: boolean 
   )
 }
 
-export default function ViewOptionsSheet({
-  visible,
-  onClose,
-  showChords,
-  onShowChords,
-  showSections,
-  onShowSections,
-  fontScale,
-  onFontScale,
-  chordStyle,
-  onChordStyle,
-  accidental,
-  onAccidental,
-  columnMode,
-  onColumnMode,
-  autoHide,
-  onAutoHide,
-  keepAwake,
-  onKeepAwake,
-}: {
+type ViewOptionsProps = {
   visible: boolean
   onClose: () => void
   showChords: boolean
@@ -133,7 +117,32 @@ export default function ViewOptionsSheet({
   // only when the screen wires it (Song Viewer + Setlist Performer).
   keepAwake?: boolean
   onKeepAwake?: (v: boolean) => void
-}) {
+}
+
+export default function ViewOptionsSheet(props: ViewOptionsProps) {
+  useFormSheet(props.visible, () => <ViewOptionsContent {...props} />, props.onClose)
+  return null
+}
+
+function ViewOptionsContent({
+  onClose,
+  showChords,
+  onShowChords,
+  showSections,
+  onShowSections,
+  fontScale,
+  onFontScale,
+  chordStyle,
+  onChordStyle,
+  accidental,
+  onAccidental,
+  columnMode,
+  onColumnMode,
+  autoHide,
+  onAutoHide,
+  keepAwake,
+  onKeepAwake,
+}: ViewOptionsProps) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
 
@@ -145,7 +154,7 @@ export default function ViewOptionsSheet({
   const atMax = fontScale >= FONT_SCALE_MAX
 
   return (
-    <BottomSheet visible={visible} onClose={onClose} title="View options">
+    <FormSheetShell title="View options" onAction={onClose}>
       <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom }}>
         {/* Show chords */}
         <View
@@ -324,6 +333,6 @@ export default function ViewOptionsSheet({
           </View>
         ) : null}
       </View>
-    </BottomSheet>
+    </FormSheetShell>
   )
 }

--- a/apps/mobile/src/components/setlist/LibraryPane.tsx
+++ b/apps/mobile/src/components/setlist/LibraryPane.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react'
+import { ActivityIndicator, FlatList, Pressable, Text, TextInput, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import ListRow from '../ListRow'
+import SymbolIcon from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+import { useKeyboardHeight } from '../../lib/useKeyboardHeight'
+import type { Song } from '../../lib/useSongList'
+
+// The tablet Setlist Builder's left pane: a searchable, single-column library
+// list with the same rows and toggle semantics as AddSongsModal — tap appends
+// the song to the end of the set, tapping a song already in the set removes
+// its last entry, and the trailing badge flips + / ✓. Its own list instance,
+// deliberately NOT shared with the Songs tab (no sections, scrubber, or tag
+// filter — search covers lookup at pane width).
+
+export default function LibraryPane({
+  songs,
+  addedSongIds,
+  onToggle,
+  loading,
+}: {
+  songs: Song[]
+  addedSongIds: Set<string>
+  onToggle: (song: Song) => void
+  loading: boolean
+}) {
+  const t = useTheme()
+  const insets = useSafeAreaInsets()
+  const keyboardHeight = useKeyboardHeight()
+  const [query, setQuery] = useState('')
+
+  const trimmed = query.trim().toLowerCase()
+  const results = useMemo(() => {
+    const base = trimmed
+      ? songs.filter(
+          (s) =>
+            s.title.toLowerCase().includes(trimmed) ||
+            (s.artist ?? '').toLowerCase().includes(trimmed),
+        )
+      : songs
+    return base.slice().sort((a, b) => a.title.localeCompare(b.title))
+  }, [songs, trimmed])
+
+  return (
+    <View style={{ flex: 1 }}>
+      {/* Search field — same pattern as AddSongsModal. */}
+      <View style={{ paddingHorizontal: t.spacing.lg, paddingVertical: t.spacing.sm }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 8,
+            backgroundColor: t.colors.surfaceAlt,
+            borderRadius: t.radii.sm,
+            paddingHorizontal: 12,
+            height: 44,
+          }}
+        >
+          <SymbolIcon name="magnifyingglass" size={18} color={t.colors.muted} />
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Search songs…"
+            placeholderTextColor={t.colors.muted}
+            returnKeyType="search"
+            autoCorrect={false}
+            accessibilityLabel="Search library"
+            style={{ flex: 1, fontSize: 16, color: t.colors.ink, padding: 0 }}
+          />
+          {query ? (
+            <Pressable
+              onPress={() => setQuery('')}
+              accessibilityRole="button"
+              accessibilityLabel="Clear search"
+              hitSlop={8}
+            >
+              <SymbolIcon name="xmark.circle.fill" size={17} color={t.colors.muted} />
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+
+      {loading && songs.length === 0 ? (
+        <ActivityIndicator color={t.colors.accent} style={{ marginTop: t.spacing.xl }} />
+      ) : (
+        <FlatList
+          data={results}
+          keyExtractor={(item) => item.id}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+          ListEmptyComponent={
+            <View style={{ alignItems: 'center', padding: t.spacing.xl }}>
+              <Text
+                style={{
+                  fontSize: t.typography.body.fontSize,
+                  color: t.colors.muted,
+                  textAlign: 'center',
+                }}
+              >
+                {trimmed ? `No songs match “${query.trim()}”.` : 'Your library is empty.'}
+              </Text>
+            </View>
+          }
+          renderItem={({ item }) => {
+            const added = addedSongIds.has(item.id)
+            return (
+              <ListRow
+                title={item.title}
+                subtitle={item.artist}
+                trailingTop={item.default_key}
+                accessibilityLabel={added ? `Remove ${item.title} from set` : `Add ${item.title} to set`}
+                onPress={() => onToggle(item)}
+                trailing={
+                  <View
+                    style={{
+                      width: 30,
+                      height: 30,
+                      borderRadius: t.radii.pill,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: added ? t.colors.accent : t.colors.accentSoft,
+                    }}
+                  >
+                    <SymbolIcon
+                      name={added ? 'checkmark' : 'plus'}
+                      size={15}
+                      weight="semibold"
+                      color={added ? t.colors.onAccent : t.colors.textAccent}
+                    />
+                  </View>
+                }
+              />
+            )
+          }}
+          contentContainerStyle={{
+            paddingBottom: Math.max(keyboardHeight, insets.bottom) + t.spacing.lg,
+            flexGrow: 1,
+          }}
+        />
+      )}
+    </View>
+  )
+}

--- a/apps/mobile/src/lib/__tests__/gridRows.test.ts
+++ b/apps/mobile/src/lib/__tests__/gridRows.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { chunkRows } from '../gridRows'
+
+describe('chunkRows', () => {
+  it('chunks row-major into full rows of N', () => {
+    expect(chunkRows([1, 2, 3, 4, 5, 6], 3)).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ])
+  })
+
+  it('keeps the remainder as a shorter final row', () => {
+    expect(chunkRows([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+  })
+
+  it('returns no rows for an empty section', () => {
+    expect(chunkRows([], 3)).toEqual([])
+  })
+
+  it('puts everything in one row when columns exceed the item count', () => {
+    expect(chunkRows([1, 2], 5)).toEqual([[1, 2]])
+  })
+
+  it('clamps degenerate column counts to single-item rows', () => {
+    expect(chunkRows([1, 2], 0)).toEqual([[1], [2]])
+  })
+
+  it('preserves item order across rows', () => {
+    const items = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    expect(chunkRows(items, 3).flat()).toEqual(items)
+  })
+})

--- a/apps/mobile/src/lib/formSheetHost.ts
+++ b/apps/mobile/src/lib/formSheetHost.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useSyncExternalStore, type ReactNode } from 'react'
+import { router } from 'expo-router'
+
+// Host for sheets presented via the native `formSheet` route (app/sheet.tsx).
+//
+// Router screens can't receive function props, but our sheets are controlled
+// components whose state/callbacks live in the owning screen. The bridge: the
+// screen registers a render function (closing over its live state) here and
+// pushes the /sheet route; the route renders whatever is registered. While the
+// sheet is open the owner re-publishes on every render, so toggles/segments
+// inside the sheet stay live.
+//
+// Only one sheet can be hosted at a time — matches the app's one-sheet-at-a-
+// time UX (iOS can't present two sheets anyway).
+
+type Entry = {
+  render: () => ReactNode
+  /** Fires when the route unmounts (native swipe-dismiss or programmatic close). */
+  onRouteClosed: () => void
+}
+
+let entry: Entry | null = null
+let version = 0
+const listeners = new Set<() => void>()
+
+function emit() {
+  version++
+  listeners.forEach((l) => l())
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Route-side: the currently hosted sheet content (null when none). */
+export function useFormSheetContent(): ReactNode {
+  useSyncExternalStore(subscribe, () => version)
+  return entry ? entry.render() : null
+}
+
+/** Route-side: called when the sheet route unmounts. */
+export function notifyFormSheetRouteClosed() {
+  const closed = entry
+  entry = null
+  emit()
+  closed?.onRouteClosed()
+}
+
+/**
+ * Screen-side: present `render()` in the native formSheet route while
+ * `visible` is true. `onDismissed` fires when the sheet is dismissed natively
+ * (swipe/scrim) so the owner can sync its `visible` state; owner-initiated
+ * closes (`visible` → false) dismiss the route without firing it.
+ */
+export function useFormSheet(visible: boolean, render: () => ReactNode, onDismissed: () => void) {
+  const renderRef = useRef(render)
+  renderRef.current = render
+  const dismissedRef = useRef(onDismissed)
+  dismissedRef.current = onDismissed
+  const openRef = useRef(false)
+
+  useEffect(() => {
+    if (visible && !openRef.current) {
+      openRef.current = true
+      entry = {
+        render: () => renderRef.current(),
+        onRouteClosed: () => {
+          if (openRef.current) {
+            openRef.current = false
+            dismissedRef.current()
+          }
+        },
+      }
+      emit()
+      router.push('/sheet')
+    } else if (!visible && openRef.current) {
+      // Owner-initiated close. Keep `entry` registered so the content stays
+      // visible through the exit animation; the route unmount clears it.
+      openRef.current = false
+      if (router.canGoBack()) router.back()
+    }
+  }, [visible])
+
+  // While open, re-publish on every owner render so the sheet reflects the
+  // owner's latest state (switch flips, segment changes, live counts).
+  useEffect(() => {
+    if (openRef.current) emit()
+  })
+
+  // Owner unmounting with the sheet still up: dismiss the route.
+  useEffect(
+    () => () => {
+      if (openRef.current) {
+        openRef.current = false
+        if (router.canGoBack()) router.back()
+      }
+    },
+    [],
+  )
+}

--- a/apps/mobile/src/lib/gridRows.ts
+++ b/apps/mobile/src/lib/gridRows.ts
@@ -1,0 +1,10 @@
+// Chunk a section's items into grid rows of `columns` cells, row-major (the
+// tablet Song Library grid: reading order flows left→right, then down, within
+// each letter section). The final row keeps its remainder — the renderer pads
+// it with empty flex cells. Never emits an empty row.
+export function chunkRows<T>(items: T[], columns: number): T[][] {
+  const size = Math.max(1, Math.floor(columns))
+  const rows: T[][] = []
+  for (let i = 0; i < items.length; i += size) rows.push(items.slice(i, i + size))
+  return rows
+}

--- a/apps/mobile/src/lib/useSetlistBuilder.ts
+++ b/apps/mobile/src/lib/useSetlistBuilder.ts
@@ -53,10 +53,10 @@ function toEntrySong(song: Song): EntrySong {
 // serialized: while one is in flight at most one trailing save is queued, and
 // pending work is flushed when the app backgrounds or the screen unmounts.
 export function useSetlistBuilder(setlistId: string) {
-  // The catalog is only needed for the Add-songs search; existing rows render
-  // from the setlist fetch's embedded song data, so we do NOT gate the screen
-  // on `songsLoading`.
-  const { songs, error: songsError } = useSongList()
+  // The catalog is only needed for the Add-songs search (modal + tablet
+  // library pane); existing rows render from the setlist fetch's embedded
+  // song data, so we do NOT gate the screen on `songsLoading`.
+  const { songs, loading: songsLoading, error: songsError } = useSongList()
   const [name, setNameState] = useState('')
   const [entries, setEntries] = useState<WorkingEntry[]>([])
   const [serviceDate, setServiceDate] = useState<string | null>(null)
@@ -297,6 +297,7 @@ export function useSetlistBuilder(setlistId: string) {
     name,
     items,
     songs,
+    songsLoading,
     updatedAt,
     // Gated on the setlist fetch only — rows render from embedded song data,
     // so the whole-catalog load never blocks the screen.

--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -14,6 +14,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import * as AppleAuthentication from 'expo-apple-authentication'
 import { useRouter } from 'expo-router'
 import { useTheme } from '../theme/ThemeProvider'
+import ConstrainedContent from '../components/ConstrainedContent'
 import TextField from '../components/TextField'
 import SymbolIcon from '../components/SymbolIcon'
 import { supabase } from '../lib/supabase'
@@ -121,6 +122,7 @@ export default function AuthScreen() {
           </Text>
         </LinearGradient>
 
+        <ConstrainedContent tier="form">
         <View style={{ paddingHorizontal: t.spacing.lg, gap: t.spacing.lg }}>
           {isSignup ? (
             <TextField
@@ -271,6 +273,7 @@ export default function AuthScreen() {
             </Pressable>
           </View>
         </View>
+        </ConstrainedContent>
       </ScrollView>
     </KeyboardAvoidingView>
   )

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient'
 import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import ConstrainedContent from '../components/ConstrainedContent'
 import ListRow from '../components/ListRow'
 import SymbolIcon from '../components/SymbolIcon'
 import { useTheme } from '../theme/ThemeProvider'
@@ -113,6 +114,7 @@ export default function HomeScreen() {
               style={StyleSheet.absoluteFill}
             />
 
+            <ConstrainedContent tier="content">
             {/* Brand row + avatar */}
             <View
               style={{
@@ -172,12 +174,14 @@ export default function HomeScreen() {
                 </Text>
               ) : null}
             </View>
+            </ConstrainedContent>
           </LinearGradient>
 
           {/* Continue where you left off — overlaps up into the hero. Shown only
               when there is recent history. */}
           {continueSong ? (
             <View style={{ paddingHorizontal: t.spacing.lg, marginTop: -66 }}>
+              <ConstrainedContent tier="content">
               <View style={cardStyle(t, true)}>
                 <Text style={{ fontSize: 13, fontWeight: '700', letterSpacing: 0.2, color: t.colors.ink, marginBottom: 13 }}>
                   Continue where you left off
@@ -230,6 +234,7 @@ export default function HomeScreen() {
                   </View>
                 </Pressable>
               </View>
+              </ConstrainedContent>
             </View>
           ) : null}
         </View>
@@ -237,6 +242,7 @@ export default function HomeScreen() {
         {/* ===== Last set — shown only if present ===== */}
         {lastSet ? (
           <View style={{ paddingHorizontal: t.spacing.lg, marginTop: 26 }}>
+            <ConstrainedContent tier="content">
             <View style={cardStyle(t)}>
               <Text
                 style={{
@@ -312,11 +318,13 @@ export default function HomeScreen() {
                 </Pressable>
               </View>
             </View>
+            </ConstrainedContent>
           </View>
         ) : null}
 
         {/* ===== Starred songs (real data) ===== */}
         <View style={{ marginTop: 28 }}>
+          <ConstrainedContent tier="content">
           <View style={{ paddingHorizontal: t.spacing.xl }}>
             <Text style={{ fontSize: 18, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
               Starred songs
@@ -347,6 +355,7 @@ export default function HomeScreen() {
               ))}
             </View>
           )}
+          </ConstrainedContent>
         </View>
       </ScrollView>
     </View>

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -24,11 +24,13 @@ import Button from '../components/Button'
 import SymbolIcon from '../components/SymbolIcon'
 import HeaderIconButton from '../components/HeaderIconButton'
 import SetlistTimeline, { type TimelineCallbacks } from '../components/setlist/SetlistTimeline'
+import LibraryPane from '../components/setlist/LibraryPane'
 import KeyPickerSheet from '../components/setlist/KeyPickerSheet'
 import SetOptionsSheet from '../components/setlist/SetOptionsSheet'
 import ShareSetSheet from '../components/setlist/ShareSetSheet'
 import AddSongsModal from '../components/setlist/AddSongsModal'
 import { useTheme } from '../theme/ThemeProvider'
+import { useIsTabletWidth } from '../lib/useIsTabletWidth'
 import { useSetlistBuilder } from '../lib/useSetlistBuilder'
 import { supabase } from '../lib/supabase'
 import { buildSetlistShareUrl } from '../lib/setlistShare'
@@ -48,10 +50,12 @@ const TOAST_MS = 1900
 export default function SetlistBuilderScreen({ setlistId }: { setlistId: string }) {
   const t = useTheme()
   const router = useRouter()
+  const isTablet = useIsTabletWidth()
   const {
     name,
     items,
     songs,
+    songsLoading,
     loading,
     notFound,
     error,
@@ -264,8 +268,11 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
     )
   }
 
-  return (
-    <Screen edges={['top', 'left', 'right', 'bottom']}>
+  // The full builder column (header → timeline → action bar → toast). Phones
+  // render it directly — the tree is unchanged from the single-column screen.
+  // Tablets place it as the right pane beside the library pane.
+  const builderPane = (
+    <>
       {/* Header: back + more + share. Plain bar on the page background — same
           chrome as the Viewer/Performer headers. (Glass here drew a visible
           material edge around the bar because it sits inside the safe area.) */}
@@ -471,6 +478,35 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
           <Text style={{ fontSize: 13.5, fontWeight: '600', color: t.colors.bg }}>{toast}</Text>
         </Animated.View>
       ) : null}
+    </>
+  )
+
+  return (
+    <Screen edges={['top', 'left', 'right', 'bottom']}>
+      {isTablet ? (
+        // Tablet list-detail split: searchable library pane (~1/3) with
+        // tap-to-add, the existing builder (~2/3) on the right. Ratio from
+        // tokens layout.split.
+        <View style={{ flex: 1, flexDirection: 'row' }}>
+          <View
+            style={{
+              flex: t.layout.split.library,
+              borderRightWidth: 1,
+              borderRightColor: t.colors.border,
+            }}
+          >
+            <LibraryPane
+              songs={songs}
+              addedSongIds={addedSongIds}
+              onToggle={toggleSong}
+              loading={songsLoading}
+            />
+          </View>
+          <View style={{ flex: t.layout.split.builder }}>{builderPane}</View>
+        </View>
+      ) : (
+        builderPane
+      )}
 
       {/* Sheets */}
       <KeyPickerSheet

--- a/apps/mobile/src/screens/SetlistsScreen.tsx
+++ b/apps/mobile/src/screens/SetlistsScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { Alert, FlatList, Pressable, RefreshControl, Text, View } from 'react-native'
 import { useFocusEffect, useRouter } from 'expo-router'
 import Screen from '../components/Screen'
+import ConstrainedContent from '../components/ConstrainedContent'
 import ListRow from '../components/ListRow'
 import EmptyState from '../components/EmptyState'
 import LoadingSkeleton from '../components/LoadingSkeleton'
@@ -122,6 +123,7 @@ export default function SetlistsScreen() {
 
   return (
     <Screen edges={['top', 'left', 'right']}>
+      <ConstrainedContent tier="content" style={{ flex: 1 }}>
       <View
         style={{
           flexDirection: 'row',
@@ -162,6 +164,7 @@ export default function SetlistsScreen() {
         </Pressable>
       </View>
       {renderBody()}
+      </ConstrainedContent>
     </Screen>
   )
 }

--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -5,6 +5,7 @@ import {
   SectionList,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } from 'react-native'
 import { useRouter } from 'expo-router'
@@ -15,9 +16,15 @@ import SymbolIcon from '../components/SymbolIcon'
 import AlphaScrubber from '../components/AlphaScrubber'
 import FilterSortSheet, { type SortDir, type SortKey } from '../components/FilterSortSheet'
 import { useTheme } from '../theme/ThemeProvider'
+import { useIsTabletWidth } from '../lib/useIsTabletWidth'
+import { chunkRows } from '../lib/gridRows'
 import { useSongList, type Song } from '../lib/useSongList'
 
-type Section = { key: string; title: string; letter: string | null; data: Song[] }
+// A list entry is one song (phone, single-column) or a grid row of songs
+// (tablet — sections are chunked N per row, so letter headers stay full-width
+// and sections never interleave across columns).
+type LibraryRow = Song | Song[]
+type Section = { key: string; title: string; letter: string | null; data: LibraryRow[] }
 
 // First-letter bucket for the A–Z index; anything not A–Z lands under "#".
 function bucketLetter(value: string | null | undefined): string {
@@ -93,6 +100,15 @@ export default function SongLibraryScreen() {
   const t = useTheme()
   const router = useRouter()
   const { songs, loading, error } = useSongList()
+  const isTablet = useIsTabletWidth()
+  const { width, height } = useWindowDimensions()
+  // Grid columns: tablet-only (tokens layout.libraryColumns), 1 on phones —
+  // the single-column path renders exactly as before (no chunking at all).
+  const columns = isTablet
+    ? width > height
+      ? t.layout.libraryColumns.landscape
+      : t.layout.libraryColumns.portrait
+    : 1
 
   const [query, setQuery] = useState('')
   const [searchActive, setSearchActive] = useState(false)
@@ -102,7 +118,7 @@ export default function SongLibraryScreen() {
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set())
 
   const inputRef = useRef<TextInput>(null)
-  const listRef = useRef<SectionList<Song, Section>>(null)
+  const listRef = useRef<SectionList<LibraryRow, Section>>(null)
   const pendingSection = useRef(0)
 
   const availableTags = useMemo(() => {
@@ -121,6 +137,18 @@ export default function SongLibraryScreen() {
     [tagFiltered, sortKey, sortDir],
   )
 
+  // Presentation-only chunking for the tablet grid: each section's songs
+  // become rows of N cells. Section count and order are untouched, so the
+  // scrubber's section-index jumps (and sticky full-width headers) work
+  // exactly as in the single-column list.
+  const displaySections = useMemo(
+    () =>
+      columns === 1
+        ? sections
+        : sections.map((s) => ({ ...s, data: chunkRows(s.data as Song[], columns) })),
+    [sections, columns],
+  )
+
   const trimmedQuery = query.trim().toLowerCase()
   const results = useMemo(() => {
     if (!trimmedQuery) return []
@@ -133,6 +161,11 @@ export default function SongLibraryScreen() {
       .slice()
       .sort(byTitle)
   }, [tagFiltered, trimmedQuery])
+
+  const resultRows: LibraryRow[] = useMemo(
+    () => (columns === 1 ? results : chunkRows(results, columns)),
+    [results, columns],
+  )
 
   const showScrubber = !searchActive && (sortKey === 'title' || sortKey === 'artist')
   const presentLetters = useMemo(() => {
@@ -203,6 +236,41 @@ export default function SongLibraryScreen() {
     trailingTop: song.default_key ?? undefined,
     trailingBottom: song.time_signature ?? undefined,
   })
+
+  const keyForRow = (item: LibraryRow) => (Array.isArray(item) ? item[0].id : item.id)
+
+  // One renderer for both lists: a single song renders the row exactly as the
+  // phone list always has; a chunk renders a full-width grid row of flex-equal
+  // cells, the last row padded with empty cells so columns stay aligned.
+  function renderRow({ item }: { item: LibraryRow }) {
+    if (Array.isArray(item)) {
+      return (
+        <View style={{ flexDirection: 'row' }}>
+          {item.map((song) => (
+            <View key={song.id} style={{ flex: 1 }}>
+              <ListRow
+                title={song.title}
+                subtitle={song.artist}
+                {...rowMeta(song)}
+                onPress={() => openSong(song)}
+              />
+            </View>
+          ))}
+          {Array.from({ length: columns - item.length }, (_, i) => (
+            <View key={`pad-${i}`} style={{ flex: 1 }} />
+          ))}
+        </View>
+      )
+    }
+    return (
+      <ListRow
+        title={item.title}
+        subtitle={item.artist}
+        {...rowMeta(item)}
+        onPress={() => openSong(item)}
+      />
+    )
+  }
 
   function renderHeader() {
     return (
@@ -345,8 +413,8 @@ export default function SongLibraryScreen() {
       if (results.length === 0) return centeredMessage(`No songs match “${query.trim()}”.`)
       return (
         <SectionList
-          sections={[{ key: '__results', title: '', letter: null, data: results }]}
-          keyExtractor={(item) => item.id}
+          sections={[{ key: '__results', title: '', letter: null, data: resultRows }]}
+          keyExtractor={keyForRow}
           keyboardShouldPersistTaps="handled"
           renderSectionHeader={() => (
             <View style={{ backgroundColor: t.colors.bg, paddingHorizontal: t.spacing.xl, paddingVertical: 6 }}>
@@ -363,14 +431,7 @@ export default function SongLibraryScreen() {
               </Text>
             </View>
           )}
-          renderItem={({ item }) => (
-            <ListRow
-              title={item.title}
-              subtitle={item.artist}
-              {...rowMeta(item)}
-              onPress={() => openSong(item)}
-            />
-          )}
+          renderItem={renderRow}
         />
       )
     }
@@ -381,20 +442,13 @@ export default function SongLibraryScreen() {
       <View style={{ flex: 1 }}>
         <SectionList
           ref={listRef}
-          sections={sections}
-          keyExtractor={(item) => item.id}
+          sections={displaySections}
+          keyExtractor={keyForRow}
           stickySectionHeadersEnabled
           renderSectionHeader={({ section }) =>
             section.title ? <SectionHeader label={section.title} /> : null
           }
-          renderItem={({ item }) => (
-            <ListRow
-              title={item.title}
-              subtitle={item.artist}
-              {...rowMeta(item)}
-              onPress={() => openSong(item)}
-            />
-          )}
+          renderItem={renderRow}
           onScrollToIndexFailed={(info) => {
             // scrollToLocation can't reach a section outside the render window
             // without getItemLayout — it fires this and scrolls nowhere. Nudge

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -121,6 +121,20 @@ export const spacing = {
   xxl: 32,
 } as const
 
+/**
+ * Content-width caps applied at regular (tablet) width via the mobile app's
+ * `ConstrainedContent` primitive. Compact (phone) layouts never read these —
+ * the primitive passes through untouched there.
+ */
+export const layout = {
+  maxWidth: {
+    /** Focused single-column forms (e.g. the auth screen). */
+    form: 440,
+    /** General content columns (Home, index lists). */
+    content: 700,
+  },
+} as const
+
 /** Corner radii (shared across modes). */
 export const radii = {
   sm: 10,
@@ -158,6 +172,7 @@ export type Tokens = {
   mode: ThemeMode
   colors: ThemeColors
   spacing: typeof spacing
+  layout: typeof layout
   radii: typeof radii
   typography: typeof typography
 }
@@ -166,6 +181,7 @@ export const lightTokens: Tokens = {
   mode: 'light',
   colors: lightColors,
   spacing,
+  layout,
   radii,
   typography,
 }
@@ -174,6 +190,7 @@ export const darkTokens: Tokens = {
   mode: 'dark',
   colors: darkColors,
   spacing,
+  layout,
   radii,
   typography,
 }

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -133,6 +133,14 @@ export const layout = {
     /** General content columns (Home, index lists). */
     content: 700,
   },
+  /**
+   * Flex weights for the tablet list-detail split (Setlist Builder): the
+   * library pane vs the builder pane, ~1/3 · 2/3.
+   */
+  split: {
+    library: 1,
+    builder: 2,
+  },
 } as const
 
 /** Corner radii (shared across modes). */

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -141,6 +141,14 @@ export const layout = {
     library: 1,
     builder: 2,
   },
+  /**
+   * Song Library grid columns at regular (tablet) width, by orientation.
+   * Compact (phone) width always renders single-column.
+   */
+  libraryColumns: {
+    portrait: 2,
+    landscape: 3,
+  },
 } as const
 
 /** Corner radii (shared across modes). */


### PR DESCRIPTION
## Summary

Introduces comprehensive tablet support to the mobile app, transforming single-column phone layouts into adaptive multi-column and split-pane designs. Adds a new native form-sheet routing system for option sheets, enabling bottom sheets on phones and centered form sheets on tablets.

## Key Changes

- **Tablet content-width constraint primitive** (`ConstrainedContent`): wraps screen content to cap width at 440px (forms) or 700px (general content) on tablets, passes through untouched on phones. Applied to Auth, Home, and Setlists screens.

- **Song Library tablet grid**: at regular width, each letter section chunks its songs into rows of 2–3 cells (portrait/landscape) via `chunkRows()`. Presentation-only—sections, sticky headers, A–Z scrubber, and search/sort logic unchanged. Phones keep single-column rendering.

- **Setlist Builder tablet split**: at regular width becomes a list-detail layout (~1/3 · 2/3 ratio). New `LibraryPane` component on the left provides a searchable, single-column library with tap-to-add semantics matching `AddSongsModal`. Right pane is the unchanged builder. Phones render single-column builder as before.

- **Native form-sheet routing system** (`formSheetHost.ts`, `sheet.tsx`): bridges state/callbacks from owning screens to a shared native route. Enables `ViewOptionsSheet` and `FilterSortSheet` to present as bottom sheets (phones) or centered form sheets (tablets) without modal wrappers. New `FormSheetShell` component provides consistent header chrome.

- **Layout tokens** (`packages/tokens/native.ts`): adds `layout` object with `maxWidth` (form/content), `split` (library/builder ratio), and `libraryColumns` (portrait/landscape grid columns).

- **Utility hooks**: `useIsTabletWidth()` detects regular (tablet) width; `gridRows.ts` chunks items row-major for grid rendering.

## Implementation Details

- The form-sheet host uses `useSyncExternalStore` to bridge route and screen state, allowing sheets to stay live while open by re-publishing on every owner render.
- Grid chunking is presentation-only; underlying data structures (sections, sort order) remain unchanged, so scrubber jumps and search work identically.
- `LibraryPane` is a separate list instance from the Songs tab—no shared state, deliberate design for the split-pane UX.
- All phone layouts are byte-identical to pre-tablet code; tablet features activate only at regular width via `useIsTabletWidth()`.

https://claude.ai/code/session_01Ac5rQtEBpYhYNzx52CTVxM