### PR TITLE
feat(mobile): Home dashboard with Daily Word and Recent-songs cards

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -127,6 +127,12 @@ duplicate logic here and never edit core internals to suit mobile.
   `layout.maxWidth`). It passes through untouched at compact (phone) width and
   caps + centers at regular (tablet) width (`useIsTabletWidth`). Applied to
   Auth (form), Home and the Setlists index (content).
+- **Home dashboard:** Home is a card dashboard (`src/components/home/` —
+  `DailyWordCard`, `RecentSongsCard`, shared `cardStyle`): hero + Continue card
+  full-width (capped at tokens `layout.maxWidth.dashboard`), then Last set /
+  Starred / Daily Word / Recent songs — a 2-column grid at regular width, one
+  stack on phones (same components, only the arrangement differs). The
+  Recent-songs count comes from tokens `layout.recentSongs`.
 - **Song Library tablet grid:** at regular width the library's SectionList
   chunks each letter section's songs into rows of N `ListRow` cells
   (`src/lib/gridRows.ts`; N from tokens `layout.libraryColumns` — 2 portrait,
@@ -287,7 +293,16 @@ duplicate logic here and never edit core internals to suit mobile.
   once at splash, then `getRecentlyOpened()` is **synchronous** (Home reads it in
   render, no flash). The Viewer calls `recordSongOpened()` on load — it dedupes by
   slug, moves the entry to the front, and caps at 20 (`gc.recents.songs.v1` in
-  AsyncStorage, NOT Supabase-synced). Feeds Home's "Continue where you left off".
+  AsyncStorage, NOT Supabase-synced). Feeds Home's "Continue where you left off"
+  and its Recent-songs card. Each entry also stores `lastKey` — the key showing
+  in the viewer (`updateRecentKey` mirrors the effective key as it changes) —
+  and the Recent-songs card reopens the song in that key via the viewer's
+  existing `initialKey` param (Library opens still use the default key).
+- **Reading streak** (`src/lib/readingStreak.ts`, same injected-storage /
+  `useSyncExternalStore` pattern): OPT-IN, off by default — the toggle lives in
+  the Daily Word reader-settings sheet, and `DailyWordScreen` marks a day read
+  when one of TODAY's chapters renders. Home's Daily Word card shows the streak
+  only when enabled (`currentStreak` — 0 once a day is missed). Unit-tested.
   Editable greeting phrases live in `src/lib/greetings.ts` (`SUB_GREETINGS`).
 - **Daily Word / Reader** reads the day's M'Cheyne passages from Cloudflare R2.
   Shared, DOM-free logic (plan lookup, reading expansion, translation manifest,

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -19,6 +19,7 @@ import { hydrateDefaults } from '../src/lib/defaults'
 import { prefetchToday } from '../src/lib/bibleSource'
 import { hydrateDownloads } from '../src/lib/downloads/manifest'
 import { hydrateRecents } from '../src/lib/recents'
+import { hydrateReadingStreak } from '../src/lib/readingStreak'
 import { hydrateViewerPrefs } from '../src/lib/viewerPrefs'
 
 // Keep the native splash up past first render so we can resolve the persisted
@@ -139,6 +140,7 @@ export default function RootLayout() {
       hydrateDefaults(AsyncStorage),
       hydrateDownloads(AsyncStorage),
       hydrateRecents(AsyncStorage),
+      hydrateReadingStreak(AsyncStorage),
       hydrateViewerPrefs(AsyncStorage),
     ]).then(([session]) => {
       setSession(session)

--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -36,7 +36,7 @@ import { capoChipLabel } from '../../src/lib/capo'
 import { exportSong } from '../../src/lib/exportSong'
 import { pushSongToTelegram, TELEGRAM_BOT_URL } from '../../src/lib/telegramPush'
 import { useSong } from '../../src/lib/useSong'
-import { recordSongOpened } from '../../src/lib/recents'
+import { recordSongOpened, updateRecentKey } from '../../src/lib/recents'
 import { useAutoHideChrome, useAutoHidePref } from '../../src/lib/autoHideChrome'
 import { getDefaultsSnapshot, setDefaultKeepAwake, useAppDefaults } from '../../src/lib/defaults'
 import { useKeepAwakeWhileFocused } from '../../src/lib/keepAwake'
@@ -129,6 +129,13 @@ export default function ViewerScreen() {
   const steps = (((seedSteps + delta) % 12) + 12) % 12
   const preferFlat = resolvePreferFlat(accidental)
   const effectiveKey = steps ? transposeSymPrefer(nativeKey, steps, preferFlat) : nativeKey
+
+  // Mirror the displayed key into the recent-songs entry (data only — the
+  // Home Recent-songs card reopens the song in this key via initialKey).
+  // Runs after the recordSongOpened effect above, so the entry always exists.
+  useEffect(() => {
+    if (song && effectiveKey) updateRecentKey(song.slug, effectiveKey)
+  }, [song, effectiveKey])
 
   useEffect(() => {
     if (!accidentalTouched.current) setAccidental(defaultAccidental(nativeKey))

--- a/apps/mobile/src/components/ConstrainedContent.tsx
+++ b/apps/mobile/src/components/ConstrainedContent.tsx
@@ -16,7 +16,7 @@ export default function ConstrainedContent({
   style,
   children,
 }: {
-  tier: 'form' | 'content'
+  tier: 'form' | 'content' | 'dashboard'
   style?: StyleProp<ViewStyle>
   children: ReactNode
 }) {

--- a/apps/mobile/src/components/home/DailyWordCard.tsx
+++ b/apps/mobile/src/components/home/DailyWordCard.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import { formatPassageLabel } from '@gracechords/core'
+import SymbolIcon from '../SymbolIcon'
+import { cardStyle } from './cardStyle'
+import { useTheme } from '../../theme/ThemeProvider'
+import { expandReadings, getPlanForDate } from '../../lib/bibleSource'
+import { currentStreak, useReadingStreak } from '../../lib/readingStreak'
+
+// Home's Daily Word card: today's date and the day's M'Cheyne passage chips,
+// plus the reading streak — shown ONLY when the user has opted in (the enable
+// toggle lives in the Daily Word reader settings; no nagging here). The whole
+// card opens the Daily Word tab, which defaults to today.
+
+export default function DailyWordCard() {
+  const t = useTheme()
+  const router = useRouter()
+  const streak = useReadingStreak()
+
+  const today = new Date()
+  // Keyed by calendar day so the plan re-derives at midnight, not per render.
+  const dayKey = today.toDateString()
+  const passages = useMemo(() => expandReadings(getPlanForDate(new Date()).readings), [dayKey])
+  const dateLabel = today.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  })
+  const streakCount = currentStreak(streak, today)
+
+  return (
+    <Pressable
+      onPress={() => router.navigate('/daily')}
+      accessibilityRole="button"
+      accessibilityLabel="Open today's Daily Word"
+      style={cardStyle(t)}
+    >
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '700',
+          letterSpacing: 0.7,
+          textTransform: 'uppercase',
+          color: t.colors.textAccent,
+        }}
+      >
+        Daily Word
+      </Text>
+      <Text style={{ marginTop: 6, fontSize: 19, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
+        {dateLabel}
+      </Text>
+
+      {passages.length > 0 ? (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: t.spacing.md }}>
+          {passages.map((p) => (
+            <View
+              key={formatPassageLabel(p)}
+              style={{
+                backgroundColor: t.colors.accentSoft,
+                borderRadius: 8,
+                paddingHorizontal: 9,
+                paddingVertical: 5,
+              }}
+            >
+              <Text style={{ fontSize: 12, fontWeight: '600', color: t.colors.textAccent }}>
+                {formatPassageLabel(p)}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : (
+        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+          Open today's reading.
+        </Text>
+      )}
+
+      {streak.enabled ? (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5, marginTop: t.spacing.md }}>
+          <SymbolIcon name="flame.fill" size={14} color={streakCount > 0 ? t.colors.star : t.colors.muted} />
+          <Text style={{ fontSize: 12.5, fontWeight: '600', color: t.colors.sec }}>
+            {streakCount === 1 ? '1-day streak' : `${streakCount}-day streak`}
+          </Text>
+        </View>
+      ) : null}
+    </Pressable>
+  )
+}

--- a/apps/mobile/src/components/home/RecentSongsCard.tsx
+++ b/apps/mobile/src/components/home/RecentSongsCard.tsx
@@ -1,0 +1,104 @@
+import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import { cardStyle } from './cardStyle'
+import { useTheme } from '../../theme/ThemeProvider'
+import { getRecentlyOpened, type RecentSong } from '../../lib/recents'
+
+// Home's Recent-songs card: the most-recently-opened songs (count from tokens
+// layout.recentSongs), each showing the key it was LAST VIEWED in. Tapping
+// reopens the song in that stored key via the viewer's existing initialKey
+// param — opening the same song from the Library still uses its default key.
+
+export default function RecentSongsCard() {
+  const t = useTheme()
+  const router = useRouter()
+  const recents = getRecentlyOpened().slice(0, t.layout.recentSongs)
+
+  function openSong(s: RecentSong) {
+    router.push({
+      pathname: '/viewer/[slug]',
+      params: {
+        slug: s.slug,
+        title: s.title,
+        artist: s.artist ?? '',
+        songKey: s.default_key ?? '',
+        ...(s.lastKey ? { initialKey: s.lastKey } : {}),
+      },
+    })
+  }
+
+  return (
+    <View style={cardStyle(t)}>
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '700',
+          letterSpacing: 0.7,
+          textTransform: 'uppercase',
+          color: t.colors.textAccent,
+        }}
+      >
+        Recent songs
+      </Text>
+
+      {recents.length === 0 ? (
+        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+          Songs you open will appear here.
+        </Text>
+      ) : (
+        <View style={{ marginTop: t.spacing.xs }}>
+          {recents.map((s, i) => (
+            <Pressable
+              key={s.slug}
+              onPress={() => openSong(s)}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${s.title}`}
+              style={({ pressed }) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: t.spacing.md,
+                paddingVertical: 10,
+                borderTopWidth: i === 0 ? 0 : 0.5,
+                borderTopColor: t.colors.border,
+                opacity: pressed ? 0.6 : 1,
+              })}
+            >
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text
+                  numberOfLines={1}
+                  style={{
+                    fontSize: t.typography.rowTitle.fontSize,
+                    fontWeight: t.typography.rowTitle.fontWeight,
+                    letterSpacing: t.typography.rowTitle.letterSpacing,
+                    color: t.colors.ink,
+                  }}
+                >
+                  {s.title}
+                </Text>
+                {s.artist ? (
+                  <Text
+                    numberOfLines={1}
+                    style={{ marginTop: 1, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}
+                  >
+                    {s.artist}
+                  </Text>
+                ) : null}
+              </View>
+              {s.lastKey ?? s.default_key ? (
+                <Text
+                  style={{
+                    fontSize: t.typography.rowKey.fontSize,
+                    fontWeight: t.typography.rowKey.fontWeight,
+                    color: t.colors.textAccent,
+                  }}
+                >
+                  {s.lastKey ?? s.default_key}
+                </Text>
+              ) : null}
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  )
+}

--- a/apps/mobile/src/components/home/cardStyle.ts
+++ b/apps/mobile/src/components/home/cardStyle.ts
@@ -1,0 +1,20 @@
+import type { ViewStyle } from 'react-native'
+import type { Tokens } from '@gracechords/tokens/native'
+
+// The Home dashboard's card surface. Unlike the Card primitive (which clips
+// with overflow:hidden), this keeps shadows visible — needed for the hero's
+// overlapping "Continue" card, and shared by every dashboard card.
+export function cardStyle(t: Tokens, elevated = false): ViewStyle {
+  return {
+    backgroundColor: t.colors.surface,
+    borderWidth: 1,
+    borderColor: t.colors.border,
+    borderRadius: t.radii.card,
+    padding: t.spacing.lg,
+    shadowColor: '#000',
+    shadowOpacity: elevated ? 0.12 : 0.05,
+    shadowRadius: elevated ? 16 : 3,
+    shadowOffset: { width: 0, height: elevated ? 8 : 1 },
+    elevation: elevated ? 6 : 2,
+  }
+}

--- a/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
+++ b/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
@@ -1,7 +1,8 @@
-import { Pressable, Text, View } from 'react-native'
+import { Pressable, Switch, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import BottomSheet from '../BottomSheet'
 import { useTheme } from '../../theme/ThemeProvider'
+import { setStreakEnabled, useReadingStreak } from '../../lib/readingStreak'
 import {
   READER_PT_MAX,
   READER_PT_MIN,
@@ -13,7 +14,9 @@ import {
 
 // Reader settings sheet (Daily Word screen 18): text size stepper, typeface,
 // verse layout, and line spacing. All session-ephemeral — the screen owns the
-// state and nothing persists across launches.
+// state and nothing persists across launches — EXCEPT the reading-streak
+// opt-in at the bottom, which is a persisted device-local preference
+// (src/lib/readingStreak.ts, read by Home's Daily Word card).
 
 function Segmented<T extends string>({
   options,
@@ -99,6 +102,7 @@ export default function ReaderSettingsSheet({
 }) {
   const t = useTheme()
   const insets = useSafeAreaInsets()
+  const streak = useReadingStreak()
 
   const stepPt = (dir: 1 | -1) => {
     const next = Math.min(READER_PT_MAX, Math.max(READER_PT_MIN, settings.pt + dir))
@@ -191,6 +195,22 @@ export default function ReaderSettingsSheet({
           value={settings.lineSpacing}
           onChange={(v) => onChange({ ...settings, lineSpacing: v })}
         />
+
+        <OverlineLabel>Reading streak</OverlineLabel>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: t.spacing.md }}>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 16, color: t.colors.ink }}>Track reading streak</Text>
+            <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 2 }}>
+              Counts consecutive days you open today's reading.
+            </Text>
+          </View>
+          <Switch
+            value={streak.enabled}
+            onValueChange={setStreakEnabled}
+            trackColor={{ true: t.colors.accent }}
+            accessibilityLabel="Track reading streak"
+          />
+        </View>
       </View>
     </BottomSheet>
   )

--- a/apps/mobile/src/lib/__tests__/readingStreak.test.ts
+++ b/apps/mobile/src/lib/__tests__/readingStreak.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  __resetReadingStreakForTest,
+  currentStreak,
+  getReadingStreak,
+  hydrateReadingStreak,
+  markReadToday,
+  setStreakEnabled,
+  streakDateKey,
+} from '../readingStreak'
+import type { KVStorage } from '../defaults'
+
+function memoryStorage(initial: Record<string, string> = {}): KVStorage & { store: Map<string, string> } {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    getItem: async (k) => store.get(k) ?? null,
+    setItem: async (k, v) => void store.set(k, v),
+    removeItem: async (k) => void store.delete(k),
+  }
+}
+
+const d = (iso: string) => new Date(`${iso}T12:00:00`)
+
+describe('reading streak', () => {
+  beforeEach(() => __resetReadingStreakForTest())
+
+  it('is disabled by default and marking is a no-op while disabled', async () => {
+    await hydrateReadingStreak(memoryStorage())
+    expect(getReadingStreak()).toEqual({ enabled: false, count: 0, lastReadDate: null })
+
+    markReadToday(d('2026-07-07'))
+    expect(getReadingStreak().count).toBe(0)
+    expect(currentStreak(getReadingStreak(), d('2026-07-07'))).toBe(0)
+  })
+
+  it('marks are idempotent within a day', async () => {
+    await hydrateReadingStreak(memoryStorage())
+    setStreakEnabled(true)
+    markReadToday(d('2026-07-07'))
+    markReadToday(d('2026-07-07'))
+    expect(getReadingStreak().count).toBe(1)
+  })
+
+  it('consecutive days extend the streak; a gap restarts at 1', async () => {
+    await hydrateReadingStreak(memoryStorage())
+    setStreakEnabled(true)
+    markReadToday(d('2026-07-05'))
+    markReadToday(d('2026-07-06'))
+    markReadToday(d('2026-07-07'))
+    expect(getReadingStreak().count).toBe(3)
+
+    markReadToday(d('2026-07-10')) // missed the 8th and 9th
+    expect(getReadingStreak().count).toBe(1)
+  })
+
+  it('currentStreak shows the count while alive (read today or yesterday), else 0', async () => {
+    await hydrateReadingStreak(memoryStorage())
+    setStreakEnabled(true)
+    markReadToday(d('2026-07-06'))
+    markReadToday(d('2026-07-07'))
+
+    const s = getReadingStreak()
+    expect(currentStreak(s, d('2026-07-07'))).toBe(2) // read today
+    expect(currentStreak(s, d('2026-07-08'))).toBe(2) // yesterday — still alive
+    expect(currentStreak(s, d('2026-07-09'))).toBe(0) // broken
+  })
+
+  it('currentStreak is 0 when disabled even with stored history', async () => {
+    await hydrateReadingStreak(memoryStorage())
+    setStreakEnabled(true)
+    markReadToday(d('2026-07-07'))
+    setStreakEnabled(false)
+    expect(currentStreak(getReadingStreak(), d('2026-07-07'))).toBe(0)
+  })
+
+  it('persists enable state and count across a simulated reload', async () => {
+    const s = memoryStorage()
+    await hydrateReadingStreak(s)
+    setStreakEnabled(true)
+    markReadToday(d('2026-07-06'))
+    markReadToday(d('2026-07-07'))
+
+    __resetReadingStreakForTest()
+    await hydrateReadingStreak(s)
+    expect(getReadingStreak()).toEqual({
+      enabled: true,
+      count: 2,
+      lastReadDate: streakDateKey(d('2026-07-07')),
+    })
+  })
+
+  it('falls back to the disabled default on a corrupt read', async () => {
+    const s = memoryStorage({ 'gc.readingStreak.v1': '{not json' })
+    await hydrateReadingStreak(s)
+    expect(getReadingStreak()).toEqual({ enabled: false, count: 0, lastReadDate: null })
+  })
+})

--- a/apps/mobile/src/lib/__tests__/recents.test.ts
+++ b/apps/mobile/src/lib/__tests__/recents.test.ts
@@ -4,6 +4,7 @@ import {
   getRecentlyOpened,
   hydrateRecents,
   recordSongOpened,
+  updateRecentKey,
 } from '../recents'
 import type { KVStorage } from '../defaults'
 
@@ -60,6 +61,53 @@ describe('recently-opened history (getRecentlyOpened seam)', () => {
     const list = getRecentlyOpened()
     expect(list.map((s) => s.slug)).toEqual(['song-a', 'song-b'])
     expect(list.length).toBe(2)
+  })
+
+  it('stores the viewed key: seeded on record, mirrored by updateRecentKey', async () => {
+    await hydrateRecents(memoryStorage())
+    recordSongOpened(songA)
+    expect(getRecentlyOpened()[0]?.lastKey).toBe(null)
+
+    updateRecentKey('song-a', 'A')
+    expect(getRecentlyOpened()[0]?.lastKey).toBe('A')
+
+    // Update is in place — no reorder, and unknown slugs are a no-op.
+    recordSongOpened(songB)
+    updateRecentKey('song-a', 'Bb')
+    updateRecentKey('missing', 'C')
+    expect(getRecentlyOpened().map((s) => [s.slug, s.lastKey])).toEqual([
+      ['song-b', null],
+      ['song-a', 'Bb'],
+    ])
+  })
+
+  it('re-recording a song resets lastKey to the new open', async () => {
+    await hydrateRecents(memoryStorage())
+    recordSongOpened(songA)
+    updateRecentKey('song-a', 'A')
+    recordSongOpened(songA) // reopened (e.g. from the Library, default key)
+    expect(getRecentlyOpened()[0]?.lastKey).toBe(null)
+  })
+
+  it('persists lastKey across a simulated reload and tolerates pre-lastKey data', async () => {
+    const s = memoryStorage()
+    await hydrateRecents(s)
+    recordSongOpened(songA)
+    updateRecentKey('song-a', 'D')
+
+    __resetRecentsForTest()
+    await hydrateRecents(s)
+    expect(getRecentlyOpened()[0]?.lastKey).toBe('D')
+
+    // Entries written before the field existed normalize to null.
+    const legacy = memoryStorage({
+      'gc.recents.songs.v1': JSON.stringify([
+        { ...songA, time_signature: null, tempo: null, tags: null, created_at: null, openedAt: '2026-01-01T00:00:00.000Z' },
+      ]),
+    })
+    __resetRecentsForTest()
+    await hydrateRecents(legacy)
+    expect(getRecentlyOpened()[0]?.lastKey).toBe(null)
   })
 
   it('survives a simulated reload (re-hydrate from the same storage)', async () => {

--- a/apps/mobile/src/lib/readingStreak.ts
+++ b/apps/mobile/src/lib/readingStreak.ts
@@ -1,0 +1,128 @@
+import { useSyncExternalStore } from 'react'
+import type { KVStorage } from './defaults'
+
+// Reading streak — consecutive days the user opened today's Daily Word
+// reading. OPT-IN and off by default: nothing is tracked or shown until the
+// user enables it (Daily Word → Reader settings). Device-local (AsyncStorage),
+// NOT Supabase-synced.
+//
+// Follows the defaults.ts pattern: storage is INJECTED so the module is RN-free
+// and unit-testable headless; the app root hydrates once at splash, after which
+// reads are synchronous and `useReadingStreak` re-renders subscribers.
+
+export type ReadingStreak = {
+  enabled: boolean
+  /** Consecutive-day count as of lastReadDate (raw — display via currentStreak). */
+  count: number
+  /** Local date key (YYYY-MM-DD) of the most recent counted read. */
+  lastReadDate: string | null
+}
+
+export const DEFAULT_READING_STREAK: ReadingStreak = {
+  enabled: false,
+  count: 0,
+  lastReadDate: null,
+}
+
+const STORAGE_KEY = 'gc.readingStreak.v1'
+
+let cache: ReadingStreak = DEFAULT_READING_STREAK
+let storage: KVStorage | null = null
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function persist() {
+  storage?.setItem(STORAGE_KEY, JSON.stringify(cache)).catch(() => {})
+}
+
+/** Local-time date key — streaks follow the user's calendar day, not UTC. */
+export function streakDateKey(d: Date): string {
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${mm}-${dd}`
+}
+
+function yesterdayKey(today: Date): string {
+  const y = new Date(today)
+  y.setDate(y.getDate() - 1)
+  return streakDateKey(y)
+}
+
+function isReadingStreak(v: unknown): v is ReadingStreak {
+  if (!v || typeof v !== 'object') return false
+  const r = v as Record<string, unknown>
+  return (
+    typeof r.enabled === 'boolean' &&
+    typeof r.count === 'number' &&
+    (r.lastReadDate === null || typeof r.lastReadDate === 'string')
+  )
+}
+
+/** Load the stored streak; a bad read falls back to the (disabled) default. */
+export async function hydrateReadingStreak(store: KVStorage): Promise<ReadingStreak> {
+  storage = store
+  try {
+    const parsed = JSON.parse((await store.getItem(STORAGE_KEY)) ?? 'null') as unknown
+    cache = isReadingStreak(parsed) ? parsed : DEFAULT_READING_STREAK
+  } catch {
+    cache = DEFAULT_READING_STREAK
+  }
+  emit()
+  return cache
+}
+
+/** Synchronous read (safe before hydrate — returns the disabled default). */
+export function getReadingStreak(): ReadingStreak {
+  return cache
+}
+
+export function setStreakEnabled(v: boolean): void {
+  if (cache.enabled === v) return
+  cache = { ...cache, enabled: v }
+  emit()
+  persist()
+}
+
+/**
+ * Count today as read. No-op unless enabled; idempotent within a day.
+ * Consecutive with yesterday extends the streak, anything else restarts at 1.
+ */
+export function markReadToday(today: Date = new Date()): void {
+  if (!cache.enabled) return
+  const todayKey = streakDateKey(today)
+  if (cache.lastReadDate === todayKey) return
+  const count = cache.lastReadDate === yesterdayKey(today) ? cache.count + 1 : 1
+  cache = { ...cache, count, lastReadDate: todayKey }
+  emit()
+  persist()
+}
+
+/**
+ * The streak to DISPLAY: the stored count while it is still alive (last read
+ * today or yesterday), else 0. Disabled always reads 0.
+ */
+export function currentStreak(state: ReadingStreak = cache, today: Date = new Date()): number {
+  if (!state.enabled || !state.lastReadDate) return 0
+  const alive =
+    state.lastReadDate === streakDateKey(today) || state.lastReadDate === yesterdayKey(today)
+  return alive ? state.count : 0
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Subscribing hook — re-renders on any streak change (Home card + settings). */
+export function useReadingStreak(): ReadingStreak {
+  return useSyncExternalStore(subscribe, getReadingStreak, getReadingStreak)
+}
+
+/** Test-only reset so each test starts from a clean module state. */
+export function __resetReadingStreakForTest(): void {
+  cache = DEFAULT_READING_STREAK
+  storage = null
+}

--- a/apps/mobile/src/lib/recents.ts
+++ b/apps/mobile/src/lib/recents.ts
@@ -21,9 +21,14 @@ export type RecentSongInput = {
   default_key: string | null
   time_signature?: string | null
   tempo?: number | null
+  /** The key showing in the viewer when recorded (effective/transposed key). */
+  lastKey?: string | null
 }
 
-type RecentRecord = Song & { openedAt: string }
+/** A recent entry: the Song plus the key it was last viewed in (if known). */
+export type RecentSong = Song & { lastKey: string | null }
+
+type RecentRecord = RecentSong & { openedAt: string }
 
 const STORAGE_KEY = 'gc.recents.songs.v1'
 const MAX_RECENTS = 20
@@ -56,7 +61,11 @@ function parse(raw: string | null): RecentRecord[] {
   try {
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) return []
-    return parsed.filter(isRecentRecord).slice(0, MAX_RECENTS)
+    return parsed
+      .filter(isRecentRecord)
+      // Entries written before lastKey existed normalize to null.
+      .map((r) => ({ ...r, lastKey: typeof r.lastKey === 'string' ? r.lastKey : null }))
+      .slice(0, MAX_RECENTS)
   } catch {
     return []
   }
@@ -78,7 +87,7 @@ export async function hydrateRecents(store: KVStorage): Promise<Song[]> {
 }
 
 /** Most-recently-opened songs, newest first. Synchronous — safe before hydrate. */
-export function getRecentlyOpened(): Song[] {
+export function getRecentlyOpened(): RecentSong[] {
   return cache.map(({ openedAt: _openedAt, ...song }) => song)
 }
 
@@ -89,8 +98,24 @@ export function getRecentlyOpened(): Song[] {
  */
 export function recordSongOpened(input: RecentSongInput): void {
   if (!input?.slug) return
-  const record: RecentRecord = { ...toSong(input), openedAt: new Date().toISOString() }
+  const record: RecentRecord = {
+    ...toSong(input),
+    lastKey: input.lastKey ?? null,
+    openedAt: new Date().toISOString(),
+  }
   cache = [record, ...cache.filter((r) => r.slug !== input.slug)].slice(0, MAX_RECENTS)
+  storage?.setItem(STORAGE_KEY, JSON.stringify(cache)).catch(() => {})
+}
+
+/**
+ * Mirror the viewer's displayed key into an existing entry (called as the
+ * effective key changes, so the stored value is the key showing when the user
+ * leaves). Updates in place — no reorder — and no-ops for unknown slugs.
+ */
+export function updateRecentKey(slug: string, key: string | null): void {
+  const entry = cache.find((r) => r.slug === slug)
+  if (!entry || entry.lastKey === key) return
+  cache = cache.map((r) => (r.slug === slug ? { ...r, lastKey: key } : r))
   storage?.setItem(STORAGE_KEY, JSON.stringify(cache)).catch(() => {})
 }
 

--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -30,6 +30,7 @@ import TranslationPickerSheet from '../components/reader/TranslationPickerSheet'
 import DatePickerSheet from '../components/reader/DatePickerSheet'
 import { useTheme } from '../theme/ThemeProvider'
 import { expandReadings, getPlanForDate } from '../lib/bibleSource'
+import { markReadToday, streakDateKey } from '../lib/readingStreak'
 import { useBibleTranslations } from '../lib/useBibleTranslations'
 import { useDailyHighlights } from '../lib/useDailyHighlights'
 import {
@@ -115,6 +116,13 @@ export default function DailyWordScreen() {
   useEffect(() => {
     setPassageIndex(0)
   }, [date])
+
+  // Reading streak: an opted-in user "reads" a day by loading any of TODAY's
+  // passages (browsing past dates doesn't count). Idempotent per day and a
+  // no-op while the streak is off.
+  useEffect(() => {
+    if (chapter && streakDateKey(date) === streakDateKey(new Date())) markReadToday()
+  }, [chapter, date])
 
   // Fade the reading region in whenever new chapter content arrives (chapter
   // switch, translation switch, or first load). The Animated.View is persistent

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react'
 import {
   ActivityIndicator,
   Image,
@@ -6,45 +7,29 @@ import {
   StyleSheet,
   Text,
   View,
-  type ViewStyle,
 } from 'react-native'
 import { LinearGradient } from 'expo-linear-gradient'
-import { useRouter } from 'expo-router'
+import { useFocusEffect, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import ConstrainedContent from '../components/ConstrainedContent'
 import ListRow from '../components/ListRow'
 import SymbolIcon from '../components/SymbolIcon'
+import DailyWordCard from '../components/home/DailyWordCard'
+import RecentSongsCard from '../components/home/RecentSongsCard'
+import { cardStyle } from '../components/home/cardStyle'
 import { useTheme } from '../theme/ThemeProvider'
-import type { Tokens } from '@gracechords/tokens/native'
 import {
   getDisplayName,
   pickSubGreeting,
   timeGreeting,
   useCurrentUser,
 } from '../lib/greetings'
+import { useIsTabletWidth } from '../lib/useIsTabletWidth'
 import { useProfileSprite } from '../lib/useProfileSprite'
 import { getRecentlyOpened } from '../lib/recents'
 import { useLastSet } from '../lib/useLastSet'
 import { useStarredSongs, type StarredSong } from '../lib/useStarredSongs'
 import type { Song } from '../lib/useSongList'
-
-// A themed card surface. Unlike the Card primitive (which clips with
-// overflow:hidden), this keeps shadows visible — needed for the hero's
-// overlapping "Continue" card.
-function cardStyle(t: Tokens, elevated = false): ViewStyle {
-  return {
-    backgroundColor: t.colors.surface,
-    borderWidth: 1,
-    borderColor: t.colors.border,
-    borderRadius: t.radii.card,
-    padding: t.spacing.lg,
-    shadowColor: '#000',
-    shadowOpacity: elevated ? 0.12 : 0.05,
-    shadowRadius: elevated ? 16 : 3,
-    shadowOffset: { width: 0, height: elevated ? 8 : 1 },
-    elevation: elevated ? 6 : 2,
-  }
-}
 
 function songMeta(song: Song): string {
   return [
@@ -60,6 +45,7 @@ export default function HomeScreen() {
   const t = useTheme()
   const router = useRouter()
   const insets = useSafeAreaInsets()
+  const isTablet = useIsTabletWidth()
   const user = useCurrentUser()
   const { source: spriteSource } = useProfileSprite()
   const { songs: starred, loading: starredLoading, error: starredError } = useStarredSongs()
@@ -68,7 +54,15 @@ export default function HomeScreen() {
   const subGreeting = pickSubGreeting()
 
   // Recently-opened comes from on-device history (recorded by the Viewer);
-  // the Last set card reads the real most-recently-edited setlist.
+  // the Last set card reads the real most-recently-edited setlist. Re-render
+  // on focus so the Continue card and Recent-songs card reflect opens made
+  // since Home last rendered.
+  const [, setFocusTick] = useState(0)
+  useFocusEffect(
+    useCallback(() => {
+      setFocusTick((n) => n + 1)
+    }, []),
+  )
   const continueSong = getRecentlyOpened()[0] ?? null
   const { lastSet } = useLastSet()
 
@@ -87,6 +81,121 @@ export default function HomeScreen() {
       },
     })
   }
+
+  // ===== Dashboard cards, arranged by the grid/stack below =====
+
+  const lastSetCard = lastSet ? (
+    <View style={cardStyle(t)}>
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '700',
+          letterSpacing: 0.7,
+          textTransform: 'uppercase',
+          color: t.colors.textAccent,
+        }}
+      >
+        Last set
+      </Text>
+      <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginTop: 6 }}>
+        <View style={{ minWidth: 0, flex: 1 }}>
+          <Text style={{ fontSize: 19, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
+            {lastSet.name}
+          </Text>
+          <Text style={{ fontSize: 13, color: t.colors.sec, marginTop: 4 }}>
+            {lastSet.songCount} {lastSet.songCount === 1 ? 'song' : 'songs'} · ~{lastSet.durationMin} min
+          </Text>
+        </View>
+        {lastSet.keys ? (
+          <Text
+            style={{
+              fontSize: 12,
+              fontWeight: '600',
+              color: t.colors.textAccent,
+              backgroundColor: t.colors.accentSoft,
+              borderRadius: 8,
+              paddingHorizontal: 9,
+              paddingVertical: 5,
+              overflow: 'hidden',
+            }}
+          >
+            Keys {lastSet.keys}
+          </Text>
+        ) : null}
+      </View>
+      <View style={{ flexDirection: 'row', gap: 10, marginTop: 16 }}>
+        <Pressable
+          onPress={() => router.push(`/setlist/${lastSet.id}`)}
+          accessibilityRole="button"
+          style={{
+            flex: 1,
+            height: 46,
+            borderRadius: t.radii.md,
+            backgroundColor: t.colors.accent,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+          }}
+        >
+          <Text style={{ fontSize: 16, fontWeight: '600', letterSpacing: -0.2, color: t.colors.onAccent }}>
+            Resume
+          </Text>
+          <SymbolIcon name="chevron.right" size={14} color={t.colors.onAccent} weight="semibold" />
+        </Pressable>
+        <Pressable
+          onPress={() => router.push(`/setlist/${lastSet.id}`)}
+          accessibilityRole="button"
+          accessibilityLabel="Edit set"
+          style={{
+            width: 46,
+            height: 46,
+            borderRadius: t.radii.md,
+            backgroundColor: t.colors.accentSoft,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <SymbolIcon name="square.and.pencil" size={20} color={t.colors.textAccent} />
+        </Pressable>
+      </View>
+    </View>
+  ) : null
+
+  const starredSection = (
+    <View>
+      <View style={{ paddingHorizontal: t.spacing.xl }}>
+        <Text style={{ fontSize: 18, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
+          Starred songs
+        </Text>
+      </View>
+
+      {starredLoading ? (
+        <ActivityIndicator color={t.colors.accent} style={{ marginTop: t.spacing.lg }} />
+      ) : starredError ? (
+        <Text style={{ paddingHorizontal: t.spacing.xl, marginTop: t.spacing.md, color: t.colors.muted }}>
+          {starredError}
+        </Text>
+      ) : starred.length === 0 ? (
+        <Text style={{ paddingHorizontal: t.spacing.xl, marginTop: t.spacing.md, fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+          Songs you star will appear here.
+        </Text>
+      ) : (
+        <View style={{ marginTop: t.spacing.sm }}>
+          {starred.map((s: StarredSong) => (
+            <ListRow
+              key={s.id}
+              title={s.title}
+              subtitle={s.artist}
+              trailingTop={s.default_key}
+              trailingBottom={s.time_signature}
+              onPress={() => openSong(s)}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  )
 
   return (
     <View style={{ flex: 1, backgroundColor: t.colors.bg }}>
@@ -114,7 +223,7 @@ export default function HomeScreen() {
               style={StyleSheet.absoluteFill}
             />
 
-            <ConstrainedContent tier="content">
+            <ConstrainedContent tier="dashboard">
             {/* Brand row + avatar */}
             <View
               style={{
@@ -181,7 +290,7 @@ export default function HomeScreen() {
               when there is recent history. */}
           {continueSong ? (
             <View style={{ paddingHorizontal: t.spacing.lg, marginTop: -66 }}>
-              <ConstrainedContent tier="content">
+              <ConstrainedContent tier="dashboard">
               <View style={cardStyle(t, true)}>
                 <Text style={{ fontSize: 13, fontWeight: '700', letterSpacing: 0.2, color: t.colors.ink, marginBottom: 13 }}>
                   Continue where you left off
@@ -239,124 +348,43 @@ export default function HomeScreen() {
           ) : null}
         </View>
 
-        {/* ===== Last set — shown only if present ===== */}
-        {lastSet ? (
-          <View style={{ paddingHorizontal: t.spacing.lg, marginTop: 26 }}>
-            <ConstrainedContent tier="content">
-            <View style={cardStyle(t)}>
-              <Text
-                style={{
-                  fontSize: 11,
-                  fontWeight: '700',
-                  letterSpacing: 0.7,
-                  textTransform: 'uppercase',
-                  color: t.colors.textAccent,
-                }}
-              >
-                Last set
-              </Text>
-              <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginTop: 6 }}>
-                <View style={{ minWidth: 0, flex: 1 }}>
-                  <Text style={{ fontSize: 19, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
-                    {lastSet.name}
-                  </Text>
-                  <Text style={{ fontSize: 13, color: t.colors.sec, marginTop: 4 }}>
-                    {lastSet.songCount} {lastSet.songCount === 1 ? 'song' : 'songs'} · ~{lastSet.durationMin} min
-                  </Text>
-                </View>
-                {lastSet.keys ? (
-                  <Text
-                    style={{
-                      fontSize: 12,
-                      fontWeight: '600',
-                      color: t.colors.textAccent,
-                      backgroundColor: t.colors.accentSoft,
-                      borderRadius: 8,
-                      paddingHorizontal: 9,
-                      paddingVertical: 5,
-                      overflow: 'hidden',
-                    }}
-                  >
-                    Keys {lastSet.keys}
-                  </Text>
-                ) : null}
+        {/* ===== Dashboard: 2-column grid on tablets, one stack on phones.
+            Same cards on both form factors — only the arrangement differs. ===== */}
+        <ConstrainedContent tier="dashboard">
+          {isTablet ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'flex-start',
+                gap: t.spacing.lg,
+                paddingHorizontal: t.spacing.lg,
+                marginTop: 26,
+              }}
+            >
+              <View style={{ flex: 1, gap: t.spacing.lg }}>
+                {lastSetCard}
+                {starredSection}
               </View>
-              <View style={{ flexDirection: 'row', gap: 10, marginTop: 16 }}>
-                <Pressable
-                  onPress={() => router.push(`/setlist/${lastSet.id}`)}
-                  accessibilityRole="button"
-                  style={{
-                    flex: 1,
-                    height: 46,
-                    borderRadius: t.radii.md,
-                    backgroundColor: t.colors.accent,
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: 8,
-                  }}
-                >
-                  <Text style={{ fontSize: 16, fontWeight: '600', letterSpacing: -0.2, color: t.colors.onAccent }}>
-                    Resume
-                  </Text>
-                  <SymbolIcon name="chevron.right" size={14} color={t.colors.onAccent} weight="semibold" />
-                </Pressable>
-                <Pressable
-                  onPress={() => router.push(`/setlist/${lastSet.id}`)}
-                  accessibilityRole="button"
-                  accessibilityLabel="Edit set"
-                  style={{
-                    width: 46,
-                    height: 46,
-                    borderRadius: t.radii.md,
-                    backgroundColor: t.colors.accentSoft,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <SymbolIcon name="square.and.pencil" size={20} color={t.colors.textAccent} />
-                </Pressable>
+              <View style={{ flex: 1, gap: t.spacing.lg }}>
+                <DailyWordCard />
+                <RecentSongsCard />
               </View>
             </View>
-            </ConstrainedContent>
-          </View>
-        ) : null}
-
-        {/* ===== Starred songs (real data) ===== */}
-        <View style={{ marginTop: 28 }}>
-          <ConstrainedContent tier="content">
-          <View style={{ paddingHorizontal: t.spacing.xl }}>
-            <Text style={{ fontSize: 18, fontWeight: '700', letterSpacing: -0.3, color: t.colors.ink }}>
-              Starred songs
-            </Text>
-          </View>
-
-          {starredLoading ? (
-            <ActivityIndicator color={t.colors.accent} style={{ marginTop: t.spacing.lg }} />
-          ) : starredError ? (
-            <Text style={{ paddingHorizontal: t.spacing.xl, marginTop: t.spacing.md, color: t.colors.muted }}>
-              {starredError}
-            </Text>
-          ) : starred.length === 0 ? (
-            <Text style={{ paddingHorizontal: t.spacing.xl, marginTop: t.spacing.md, fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
-              Songs you star will appear here.
-            </Text>
           ) : (
-            <View style={{ marginTop: t.spacing.sm }}>
-              {starred.map((s: StarredSong) => (
-                <ListRow
-                  key={s.id}
-                  title={s.title}
-                  subtitle={s.artist}
-                  trailingTop={s.default_key}
-                  trailingBottom={s.time_signature}
-                  onPress={() => openSong(s)}
-                />
-              ))}
-            </View>
+            <>
+              {lastSetCard ? (
+                <View style={{ paddingHorizontal: t.spacing.lg, marginTop: 26 }}>{lastSetCard}</View>
+              ) : null}
+              <View style={{ paddingHorizontal: t.spacing.lg, marginTop: 26 }}>
+                <DailyWordCard />
+              </View>
+              <View style={{ paddingHorizontal: t.spacing.lg, marginTop: t.spacing.lg }}>
+                <RecentSongsCard />
+              </View>
+              <View style={{ marginTop: 28 }}>{starredSection}</View>
+            </>
           )}
-          </ConstrainedContent>
-        </View>
+        </ConstrainedContent>
       </ScrollView>
     </View>
   )

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -130,9 +130,13 @@ export const layout = {
   maxWidth: {
     /** Focused single-column forms (e.g. the auth screen). */
     form: 440,
-    /** General content columns (Home, index lists). */
+    /** General content columns (index lists). */
     content: 700,
+    /** The Home dashboard's two-column grid region. */
+    dashboard: 1000,
   },
+  /** Entries shown in Home's Recent-songs card. */
+  recentSongs: 6,
   /**
    * Flex weights for tablet list-detail splits (Setlist Builder's library
    * pane · builder column, Utilities' tool list · tool view): ~1/3 · 2/3.


### PR DESCRIPTION
At regular (tablet) width Home becomes a two-column card dashboard (capped at tokens layout.maxWidth.dashboard): hero + Continue card span full width, then Last set / Starred songs on the left and the new Daily Word / Recent songs cards on the right; phones stack the same cards in one column.

Daily Word card: today's date + the day's M'Cheyne passage chips (core getPlanForDate/expandReadings/formatPassageLabel); whole card opens the Daily tab at today. Reading streak is a new opt-in, device-local store (src/lib/readingStreak.ts, default off) — the toggle lives in the reader-settings sheet, DailyWordScreen marks a day read when one of today's chapters renders, and the card shows the streak only when enabled.

Recent songs card: up to layout.recentSongs (6) most-recent viewer opens. Recents entries now store lastKey — the viewer mirrors its displayed key via updateRecentKey — and tapping reopens the song in that key through the existing initialKey param; Library opens keep the default key. Home re-reads device-local stores on focus so both cards stay fresh. Streak + lastKey behavior unit-tested (198 passing).


Claude-Session: https://claude.ai/code/session_01Ac5rQtEBpYhYNzx52CTVxM