### PR TITLE
Redesign export format selection as equal side-by-side tiles

### DIFF
--- a/apps/mobile/src/components/ExportSheet.tsx
+++ b/apps/mobile/src/components/ExportSheet.tsx
@@ -10,10 +10,10 @@ import { useTheme } from '../theme/ThemeProvider'
 // formSheet route (src/lib/formSheetHost.ts): a bottom sheet on phones, a
 // centered narrow form sheet on tablets. The screen owns the async work (export
 // endpoint fetch, system share sheet, Telegram push, error alerts); this
-// component only tracks which action is busy and disables the rest. PDF is the
-// primary (blue) action in every mode — exporting a PDF already opens the
-// system share sheet, so there is no separate "share" button. No ChordPro
-// option by design.
+// component only tracks which action is busy and disables the rest. PDF and
+// JPG are equal side-by-side tiles — both export a file and open the system
+// share sheet, just in different formats — so neither is a hero and there is
+// no separate "share" button. No ChordPro option by design.
 
 type Busy = 'pdf' | 'jpg' | 'telegram' | null
 
@@ -47,42 +47,25 @@ function ExportContent({ onClose, onExport, onTelegram }: ExportSheetProps) {
   return (
     <FormSheetShell title="Export & share" onAction={onClose}>
       <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.md }}>
-        {/* Primary: export as PDF (opens the system share sheet). */}
-        <Pressable
-          onPress={run('pdf', () => onExport('pdf'))}
-          disabled={!!busy}
-          accessibilityRole="button"
-          accessibilityLabel="Export as PDF"
-          style={{
-            height: 50,
-            borderRadius: 13,
-            backgroundColor: t.colors.accent,
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: t.spacing.sm,
-            opacity: busy && busy !== 'pdf' ? 0.5 : 1,
-          }}
-        >
-          {busy === 'pdf' ? (
-            <ActivityIndicator color={t.colors.onAccent} />
-          ) : (
-            <SymbolIcon name="square.and.arrow.up" size={19} color={t.colors.onAccent} />
-          )}
-          <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.onAccent }}>
-            Export as PDF
-          </Text>
-        </Pressable>
-
-        {/* Secondary: JPG image. */}
-        <SecondaryRow
-          label="Export as JPG"
-          icon="photo"
-          busy={busy === 'jpg'}
-          dimmed={!!busy && busy !== 'jpg'}
-          disabled={!!busy}
-          onPress={run('jpg', () => onExport('jpg'))}
-        />
+        {/* Format tiles — PDF and JPG as equals; both open the share sheet. */}
+        <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+          {(
+            [
+              { format: 'pdf', label: 'PDF', icon: 'doc.text' },
+              { format: 'jpg', label: 'JPG', icon: 'photo' },
+            ] as const
+          ).map((tile) => (
+            <FormatTile
+              key={tile.format}
+              label={tile.label}
+              icon={tile.icon}
+              busy={busy === tile.format}
+              dimmed={!!busy && busy !== tile.format}
+              disabled={!!busy}
+              onPress={run(tile.format, () => onExport(tile.format))}
+            />
+          ))}
+        </View>
 
         {/* Telegram */}
         <SecondaryRow
@@ -99,8 +82,55 @@ function ExportContent({ onClose, onExport, onTelegram }: ExportSheetProps) {
   )
 }
 
+// Side-by-side export-format tile: accent icon over a short label, sized to
+// share the row equally with its sibling. PDF and JPG use the same shape so
+// the two formats read as equals.
+function FormatTile({
+  label,
+  icon,
+  busy,
+  dimmed,
+  disabled,
+  onPress,
+}: {
+  label: string
+  icon: SymbolIconProps['name']
+  busy: boolean
+  dimmed: boolean
+  disabled: boolean
+  onPress: () => void
+}) {
+  const t = useTheme()
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={`Export as ${label}`}
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        gap: 6,
+        paddingVertical: 14,
+        borderRadius: 13,
+        backgroundColor: t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+        opacity: dimmed ? 0.5 : 1,
+      }}
+    >
+      {busy ? (
+        <ActivityIndicator color={t.colors.accent} />
+      ) : (
+        <SymbolIcon name={icon} size={24} color={t.colors.accent} />
+      )}
+      <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+    </Pressable>
+  )
+}
+
 // Full-width secondary action row: accentSoft icon chip, label (+ optional
-// subtitle), trailing chevron. Shared shape for the JPG and Telegram rows.
+// subtitle), trailing chevron. Used for the Telegram row.
 function SecondaryRow({
   label,
   subtitle,

--- a/apps/mobile/src/components/setlist/PerformerShareSheet.tsx
+++ b/apps/mobile/src/components/setlist/PerformerShareSheet.tsx
@@ -9,10 +9,10 @@ import { useTheme } from '../../theme/ThemeProvider'
 // Performer "Export & share" sheet with a This song / Whole set scope toggle,
 // presented via the native formSheet route (src/lib/formSheetHost.ts) — the
 // viewer version, which keeps the scope toggle (the builder's ShareSetSheet
-// does not). This-song mirrors the Song Viewer's ExportSheet (PDF primary + JPG
-// + Telegram); Whole-set offers the combined PDF (server endpoint), Copy link
-// and Telegram. PDF is the primary (blue) action in both scopes — exporting a
-// PDF already opens the system share sheet, so there is no separate "share"
+// does not). This-song mirrors the Song Viewer's ExportSheet (PDF and JPG as
+// equal side-by-side tiles — both export a file and open the system share
+// sheet — plus Telegram); Whole-set offers the combined PDF (server endpoint)
+// as the primary (blue) action, Copy link and Telegram. No separate "share"
 // button, and no ChordPro. The screen owns the async work and error alerts;
 // this component only tracks which action is busy.
 
@@ -138,6 +138,36 @@ function PerformerShareContent({ onClose, songCount, initialScope, handlers }: P
     </Pressable>
   )
 
+  // Side-by-side export-format tile: accent icon over a short label, sized to
+  // share the row equally with its sibling — mirrors the Song Viewer's
+  // ExportSheet so PDF and JPG read as equals.
+  const formatTile = (label: string, icon: SymbolIconProps['name'], which: string, fn: () => Promise<void>) => (
+    <Pressable
+      onPress={run(which, fn)}
+      disabled={!!busy}
+      accessibilityRole="button"
+      accessibilityLabel={`Export as ${label}`}
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        gap: 6,
+        paddingVertical: 14,
+        borderRadius: 13,
+        backgroundColor: t.colors.surfaceAlt,
+        borderWidth: 1,
+        borderColor: t.colors.border,
+        opacity: busy && busy !== which ? 0.5 : 1,
+      }}
+    >
+      {busy === which ? (
+        <ActivityIndicator color={t.colors.accent} />
+      ) : (
+        <SymbolIcon name={icon} size={24} color={t.colors.accent} />
+      )}
+      <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+    </Pressable>
+  )
+
   const segment = (value: Scope, label: string) => {
     const active = scope === value
     return (
@@ -179,8 +209,11 @@ function PerformerShareContent({ onClose, songCount, initialScope, handlers }: P
 
         {scope === 'song' ? (
           <>
-            {primaryButton('Export as PDF', 'square.and.arrow.up', 'song-pdf', () => handlers.onExportSong('pdf'))}
-            {secondaryRow('Export as JPG', 'photo', 'song-jpg', () => handlers.onExportSong('jpg'))}
+            {/* Format tiles — PDF and JPG as equals; both open the share sheet. */}
+            <View style={{ flexDirection: 'row', gap: t.spacing.sm }}>
+              {formatTile('PDF', 'doc.text', 'song-pdf', () => handlers.onExportSong('pdf'))}
+              {formatTile('JPG', 'photo', 'song-jpg', () => handlers.onExportSong('jpg'))}
+            </View>
             {secondaryRow('Send to Telegram', 'paperplane.fill', 'song-telegram', handlers.onTelegramSong, 'Optional bot')}
           </>
         ) : (


### PR DESCRIPTION
## Summary
Refactors the export UI in both the Song Viewer and Performer share sheets to present PDF and JPG as equal side-by-side tiles instead of a primary (blue) PDF button with a secondary JPG row. This change reflects that both formats serve the same purpose—exporting a file and opening the system share sheet—so neither should be visually prioritized.

## Changes

**ExportSheet.tsx:**
- Updated component documentation to reflect the new equal-tile design for PDF and JPG
- Extracted a new `FormatTile` component for the side-by-side export format tiles
- Replaced the primary PDF button and secondary JPG row with a flexbox row containing two equal-width tiles
- Both tiles use the same styling (accent icon, short label, bordered surface) to read as equals
- Removed the full-width blue accent styling that previously made PDF the hero action

**PerformerShareSheet.tsx:**
- Updated component documentation to clarify the new PDF/JPG tile design in the "This song" scope
- Added a `formatTile` helper function that mirrors the Song Viewer's tile styling
- Refactored the "This song" scope to use side-by-side format tiles instead of primary/secondary buttons
- Kept the "Whole set" scope's PDF as a primary (blue) action since it's the only export option in that scope

## Implementation Details
- Both components now use consistent tile styling: `flex: 1` for equal width sharing, centered layout with icon above label, `surfaceAlt` background with border
- The tiles maintain the same busy/dimmed state logic as before
- Accessibility labels remain descriptive ("Export as PDF", "Export as JPG")
- The Telegram action remains a secondary row in both sheets

https://claude.ai/code/session_01SF5pNXEpcLcjzuwMT9ET29