### PR TITLE
fix(mobile): clear glass tab bar in Home dashboard scroll

### DIFF
--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -268,7 +268,9 @@ export default function HomeScreen() {
     <View style={{ flex: 1, backgroundColor: t.colors.bg }}>
       <ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: t.spacing.xl }}
+        // Clear the floating native tab bar (insets.bottom includes its height
+        // under native tabs) so the last card scrolls fully above it.
+        contentContainerStyle={{ paddingBottom: insets.bottom + t.spacing.xl }}
       >
         {/* ===== Hero ===== */}
         <View>


### PR DESCRIPTION
Home's ScrollView used a flat paddingBottom that didn't account for the
floating native (Liquid Glass) tab bar, so the last card couldn't scroll
fully above it. Add insets.bottom, matching Daily Word/Utilities.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013BAkFnqGeCBZSSNGufUGxu