### PR TITLE
Window tap tempo to the time signature's beat count

### DIFF
--- a/apps/mobile/src/lib/__tests__/tapTempo.test.ts
+++ b/apps/mobile/src/lib/__tests__/tapTempo.test.ts
@@ -11,6 +11,21 @@ function tapSeries(tapper: ReturnType<typeof createTapTempo>, start: number, int
   return bpm
 }
 
+function tapSeries2(
+  tapper: ReturnType<typeof createTapTempo>,
+  start: number,
+  intervals: number[],
+  windowSize: number
+) {
+  let now = start
+  let bpm: number | null = tapper.tap(now, windowSize)
+  for (const gap of intervals) {
+    now += gap
+    bpm = tapper.tap(now, windowSize)
+  }
+  return bpm
+}
+
 describe('createTapTempo', () => {
   it('returns null on the first tap', () => {
     expect(createTapTempo().tap(1000)).toBeNull()
@@ -36,6 +51,30 @@ describe('createTapTempo', () => {
     // holds only the fast ones, so the slow start no longer drags the BPM.
     const bpm = tapSeries(tapper, 0, [1000, 1000, 1000, 1000, 500, 500, 500, 500])
     expect(bpm).toBeCloseTo(120, 6)
+  })
+
+  it('honors a per-tap window (X most recent taps)', () => {
+    const tapper = createTapTempo()
+    // Window of 3 gaps (4 taps). Three slow gaps then three fast: only the fast
+    // ones remain, so a new slow→fast switch catches up within a measure.
+    const bpm = tapSeries2(tapper, 0, [1000, 1000, 1000, 500, 500, 500], 3)
+    expect(bpm).toBeCloseTo(120, 6)
+  })
+
+  it('shrinking the window mid-run drops older gaps at once', () => {
+    const tapper = createTapTempo()
+    // Fill five 1000 ms gaps under a wide window...
+    tapSeries2(tapper, 0, [1000, 1000, 1000, 1000, 1000], 6)
+    // ...then a single 500 ms tap under a window of 1 → only that gap counts.
+    expect(tapper.tap(5500, 1)).toBeCloseTo(120, 6)
+  })
+
+  it('a window of 1 uses only the single most recent gap (2/4 case)', () => {
+    const tapper = createTapTempo()
+    expect(tapper.tap(0, 1)).toBeNull()
+    expect(tapper.tap(1000, 1)).toBeCloseTo(60, 6)
+    // The next gap fully replaces the tempo — no smoothing.
+    expect(tapper.tap(1500, 1)).toBeCloseTo(120, 6)
   })
 
   it('resets after a stale gap and needs a fresh second tap', () => {

--- a/apps/mobile/src/lib/tapTempo.ts
+++ b/apps/mobile/src/lib/tapTempo.ts
@@ -1,26 +1,35 @@
 // Pure tap-tempo math — RN-free so it unit-tests headless. A rolling window of
 // recent tap intervals is averaged into a BPM; a gap longer than `staleGapMs`
 // abandons the old run and starts a fresh one (whose first tap, like the very
-// first tap overall, yields no BPM yet).
+// first tap overall, yields no BPM yet). The window can be set per tap so it can
+// track the time signature (X most recent taps → X − 1 gaps averaged).
 
 export interface TapTempoOptions {
-  /** Rolling window: how many recent intervals are averaged (default 6). */
+  /** Fallback rolling window used when `tap` isn't given one (default 6). */
   windowSize?: number
   /** A gap longer than this abandons the run and starts over (default 2 s). */
   staleGapMs?: number
 }
 
 export interface TapTempo {
-  /** Register a tap at `nowMs`. Returns the running BPM, or null on a run's first tap. */
-  tap(nowMs: number): number | null
+  /**
+   * Register a tap at `nowMs`. Returns the running BPM, or null on a run's first
+   * tap. `windowSize` (in gaps between taps) overrides the constructor default
+   * for this tap — pass X − 1 to average the X most recent taps. A smaller
+   * window than before immediately drops older gaps, so the BPM catches up at
+   * once rather than one tap at a time.
+   */
+  tap(nowMs: number, windowSize?: number): number | null
   reset(): void
 }
 
 export function createTapTempo({ windowSize = 6, staleGapMs = 2000 }: TapTempoOptions = {}): TapTempo {
+  const defaultWindow = windowSize
   let lastTapMs: number | null = null
   let intervals: number[] = []
   return {
-    tap(nowMs: number): number | null {
+    tap(nowMs: number, windowSize: number = defaultWindow): number | null {
+      const effectiveWindow = Math.max(1, windowSize)
       if (lastTapMs !== null) {
         const gap = nowMs - lastTapMs
         // Non-increasing timestamps are treated like a stale gap: start over
@@ -29,10 +38,12 @@ export function createTapTempo({ windowSize = 6, staleGapMs = 2000 }: TapTempoOp
           intervals = []
         } else {
           intervals.push(gap)
-          if (intervals.length > windowSize) intervals.shift()
         }
       }
       lastTapMs = nowMs
+      // Keep only the most recent `effectiveWindow` gaps. Using slice (not a
+      // single shift) means a window that just shrank is honored on this tap.
+      if (intervals.length > effectiveWindow) intervals = intervals.slice(-effectiveWindow)
       if (intervals.length === 0) return null
       const avgMs = intervals.reduce((sum, v) => sum + v, 0) / intervals.length
       return 60000 / avgMs

--- a/apps/mobile/src/screens/MetronomeScreen.tsx
+++ b/apps/mobile/src/screens/MetronomeScreen.tsx
@@ -97,14 +97,16 @@ export default function MetronomeScreen({ embedded }: { embedded?: boolean }) {
   // Silence the clicks whenever the screen loses focus (back, app switch).
   useFocusEffect(useCallback(() => stop, [stop]))
 
+  const beats = beatsInMeasure(signature)
+
   const tapperRef = useRef(createTapTempo())
   const onTap = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {})
-    const tapped = tapperRef.current.tap(Date.now())
+    // Average the last X taps (X = measure's top number) → X − 1 gaps, so a new
+    // tempo catches up within a measure instead of dragging old taps along.
+    const tapped = tapperRef.current.tap(Date.now(), beats - 1)
     if (tapped != null) setBpm(tapped)
   }
-
-  const beats = beatsInMeasure(signature)
 
   return (
     <Screen edges={['left', 'right']}>


### PR DESCRIPTION
Tap tempo averaged a fixed window of the 6 most recent inter-tap
intervals, so after fast taps a switch to a slow tempo took ~6 taps to
flush the old fast intervals and catch up.

Average only the X most recent taps instead, where X is the top number
of the selected time signature (X - 1 gaps): 4/4 uses the last 4 taps,
3/4 the last 3, 6/8 the last 6. The window is now passed per tap so it
tracks the live signature, and a shrunk window drops older gaps at once
rather than one tap at a time. Reset-on-stale-gap behavior is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017QBvRqrdUyk4LdsyBW1pRP