### PR TITLE
feat(mobile): daily word reminder notifications

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -263,10 +263,26 @@ duplicate logic here and never edit core internals to suit mobile.
 
 - **Settings** (`app/settings.tsx` → `SettingsScreen`) is a grouped screen:
   profile card (→ sprite picker), theme, chord style, **Language**, Offline &
-  downloads, library shortcuts, Help/Feedback, About, sign-out, and **Delete
-  account** (`supabase.rpc('delete_user')`). The Language row opens an
-  `OptionSheet` (Automatic + the supported locales) and shows the resolved
-  language — see the i18n section below.
+  downloads, a **Reader** section (Daily Word reminder — see below), library
+  shortcuts, Help/Feedback, About, sign-out, and **Delete account**
+  (`supabase.rpc('delete_user')`). The Language row opens an `OptionSheet`
+  (Automatic + the supported locales) and shows the resolved language — see the
+  i18n section below.
+- **Daily Word reminder** (Settings → Reader) is an OPT-IN, off-by-default local
+  notification via **`expo-notifications`** (config plugin in `app.json`). The
+  preference (enabled + local hour/minute) is device-local in AsyncStorage
+  (`gc.readerReminder.v1`), following the `defaults.ts` injected-storage /
+  `useSyncExternalStore` pattern. `src/lib/readerReminder.ts` is the **pure,
+  RN-free** store plus the dependency-injected `syncReminder()` reconciler (and
+  a locale-aware `formatReminderTime`), unit-tested headless;
+  `src/lib/readerReminderService.ts` wires the real expo-notifications backend
+  (permission request, a single daily-repeating notification under a stable id,
+  the foreground handler, and the tap→`/daily` deep link). Enabling requests
+  notification permission (iOS shows the system prompt then) and only
+  persists/schedules on grant, steering the user to system Settings on denial.
+  The time is set via a custom stepper sheet (`ReminderTimeSheet` — RN
+  primitives, no extra native picker dep, like `DatePickerSheet`). The app root
+  hydrates the preference at splash and reconciles the OS schedule on launch.
 - **App-wide defaults** live in `src/lib/defaults.ts` — `theme`
   (`system`/`light`/`dark`) and `chordStyle` (`letters`/`solfege`), **device-local
   in AsyncStorage, not Supabase-synced**. Storage is injected (KVStorage, like

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -47,6 +47,7 @@
         }
       ],
       "expo-apple-authentication",
+      "expo-notifications",
       [
         "@react-native-google-signin/google-signin",
         {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,12 @@ import { hydrateDownloads } from '../src/lib/downloads/manifest'
 import { hydrateDrafts } from '../src/lib/drafts/draftsStore'
 import { hydrateRecents } from '../src/lib/recents'
 import { hydrateReadingStreak } from '../src/lib/readingStreak'
+import { hydrateReaderReminder } from '../src/lib/readerReminder'
+import {
+  addReminderResponseListener,
+  initReaderReminders,
+  syncReaderReminderOnLaunch,
+} from '../src/lib/readerReminderService'
 import { hydrateViewerPrefs } from '../src/lib/viewerPrefs'
 
 // Keep the native splash up past first render so we can resolve the persisted
@@ -125,12 +131,16 @@ function ConfigErrorScreen({ message }: { message: string }) {
 export default function RootLayout() {
   const [session, setSession] = useState<Session | null>(null)
   const [ready, setReady] = useState(false)
+  const router = useRouter()
 
   useEffect(() => {
     // Missing public config: skip the session read entirely (the supabase client
     // is null here) and let the ConfigErrorScreen below take over.
     if (supabaseConfigError) return
     let stopAutoRefresh: (() => void) | undefined
+    // Install the notification foreground handler / Android channel once, before
+    // any reminder is (re)scheduled below.
+    initReaderReminders()
     // Load app-wide defaults (theme/chord style) before the splash lifts so the
     // resolved theme is applied on first paint — no light→dark flash. Runs in
     // parallel with the session read; both must resolve before `ready`.
@@ -145,6 +155,7 @@ export default function RootLayout() {
       hydrateDrafts(AsyncStorage),
       hydrateRecents(AsyncStorage),
       hydrateReadingStreak(AsyncStorage),
+      hydrateReaderReminder(AsyncStorage),
       hydrateViewerPrefs(AsyncStorage),
       hydrateBibleTranslationPref(AsyncStorage),
     ]).then(([session, defaults]) => {
@@ -153,6 +164,9 @@ export default function RootLayout() {
       applyLanguagePreference(defaults.language)
       setSession(session)
       setReady(true)
+      // Reconcile the OS-scheduled Daily Word reminder with the stored
+      // preference now that it (and the language) are loaded. Best-effort.
+      void syncReaderReminderOnLaunch()
       // Start AppState-driven token auto-refresh only AFTER the persisted
       // session is resolved. resolveInitialSession has already purged any
       // stale/revoked refresh token from storage, so the immediate refresh tick
@@ -181,6 +195,14 @@ export default function RootLayout() {
   useEffect(() => {
     if (session) prefetchToday()
   }, [session])
+
+  // Tapping the Daily Word reminder opens the reader tab. The auth gate still
+  // applies — a signed-out tap lands on /login.
+  useEffect(() => {
+    return addReminderResponseListener((url) => {
+      router.navigate(url as Parameters<typeof router.navigate>[0])
+    })
+  }, [router])
 
   useProtectedRoute(session, ready)
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,6 +36,7 @@
     "expo-linking": "~55.0.16",
     "expo-localization": "~55.0.16",
     "expo-network": "~55.0.15",
+    "expo-notifications": "~55.0.25",
     "expo-router": "55.0.16",
     "expo-sharing": "~55.0.21",
     "expo-splash-screen": "~55.0.22",

--- a/apps/mobile/src/components/reader/ReminderTimeSheet.tsx
+++ b/apps/mobile/src/components/reader/ReminderTimeSheet.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import FormSheetShell from '../FormSheetShell'
+import SymbolIcon from '../SymbolIcon'
+import { useFormSheet } from '../../lib/formSheetHost'
+import { useTheme } from '../../theme/ThemeProvider'
+import { formatReminderTime } from '../../lib/readerReminder'
+
+// Time picker for the Daily Word reminder: a large localized preview over two
+// stepper columns (hour 0–23, minute in 5-minute steps), both wrapping. Built on
+// RN primitives — no extra native date-picker dep, matching DatePickerSheet.
+// The draft time is local to the sheet and committed on "Done" (so we don't
+// reschedule the OS notification on every tap); a swipe-dismiss discards it.
+
+const MINUTE_STEP = 5
+
+type ReminderTimeProps = {
+  visible: boolean
+  onClose: () => void
+  hour: number
+  minute: number
+  onConfirm: (hour: number, minute: number) => void
+}
+
+export default function ReminderTimeSheet(props: ReminderTimeProps) {
+  useFormSheet(props.visible, () => <ReminderTimeContent {...props} />, props.onClose)
+  return null
+}
+
+function StepperColumn({
+  label,
+  display,
+  onUp,
+  onDown,
+  upLabel,
+  downLabel,
+}: {
+  label: string
+  display: string
+  onUp: () => void
+  onDown: () => void
+  upLabel: string
+  downLabel: string
+}) {
+  const t = useTheme()
+  const Button = ({ dir, acc }: { dir: -1 | 1; acc: string }) => (
+    <Pressable
+      onPress={dir < 0 ? onDown : onUp}
+      accessibilityRole="button"
+      accessibilityLabel={acc}
+      style={{
+        width: 56,
+        height: 40,
+        borderRadius: 12,
+        backgroundColor: t.colors.surfaceAlt,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <SymbolIcon name={dir < 0 ? 'chevron.down' : 'chevron.up'} size={15} color={t.colors.ink} weight="semibold" />
+    </Pressable>
+  )
+  return (
+    <View style={{ alignItems: 'center', gap: t.spacing.sm }}>
+      <Text
+        style={{
+          fontSize: t.typography.overline.fontSize,
+          fontWeight: t.typography.overline.fontWeight,
+          letterSpacing: t.typography.overline.letterSpacing,
+          textTransform: 'uppercase',
+          color: t.colors.muted,
+        }}
+      >
+        {label}
+      </Text>
+      <Button dir={1} acc={upLabel} />
+      <Text style={{ minWidth: 56, textAlign: 'center', fontSize: 30, fontWeight: '700', color: t.colors.ink }}>
+        {display}
+      </Text>
+      <Button dir={-1} acc={downLabel} />
+    </View>
+  )
+}
+
+function ReminderTimeContent({ hour, minute, onConfirm, onClose }: ReminderTimeProps) {
+  const t = useTheme()
+  const { t: tx, i18n } = useTranslation(['settings', 'common'])
+  const insets = useSafeAreaInsets()
+  // Draft time — mounts from props on open, commits on Done.
+  const [draft, setDraft] = useState({ hour, minute })
+
+  const stepHour = (dir: 1 | -1) => setDraft((d) => ({ ...d, hour: (d.hour + dir + 24) % 24 }))
+  const stepMinute = (dir: 1 | -1) =>
+    setDraft((d) => ({ ...d, minute: (d.minute + dir * MINUTE_STEP + 60) % 60 }))
+
+  const confirm = () => {
+    onConfirm(draft.hour, draft.minute)
+    onClose()
+  }
+
+  return (
+    <FormSheetShell title={tx('reminder.timeSheetTitle')} onAction={confirm}>
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, alignItems: 'center' }}>
+        <Text style={{ fontSize: 34, fontWeight: '800', letterSpacing: -0.5, color: t.colors.textAccent }}>
+          {formatReminderTime(draft.hour, draft.minute, i18n.language)}
+        </Text>
+        <View style={{ flexDirection: 'row', gap: t.spacing.xxl, marginTop: t.spacing.xl }}>
+          <StepperColumn
+            label={tx('reminder.hour')}
+            display={String(draft.hour).padStart(2, '0')}
+            onUp={() => stepHour(1)}
+            onDown={() => stepHour(-1)}
+            upLabel={tx('reminder.increaseHour')}
+            downLabel={tx('reminder.decreaseHour')}
+          />
+          <StepperColumn
+            label={tx('reminder.minute')}
+            display={String(draft.minute).padStart(2, '0')}
+            onUp={() => stepMinute(1)}
+            onDown={() => stepMinute(-1)}
+            upLabel={tx('reminder.increaseMinute')}
+            downLabel={tx('reminder.decreaseMinute')}
+          />
+        </View>
+      </View>
+    </FormSheetShell>
+  )
+}

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -5,8 +5,27 @@
   "changeYourIcon": "Change your icon",
   "sections": {
     "settings": "SETTINGS",
+    "reader": "READER",
     "library": "LIBRARY",
     "support": "SUPPORT"
+  },
+  "reminder": {
+    "dailyReminder": "Daily Word reminder",
+    "dailyReminderDesc": "A daily nudge to open today's reading.",
+    "time": "Reminder time",
+    "timeSheetTitle": "Reminder time",
+    "hour": "Hour",
+    "minute": "Minute",
+    "increaseHour": "Increase hour",
+    "decreaseHour": "Decrease hour",
+    "increaseMinute": "Increase minute",
+    "decreaseMinute": "Decrease minute",
+    "permissionDeniedTitle": "Notifications are off",
+    "permissionDeniedMessage": "Turn on notifications for GraceChords in your device Settings to get daily reading reminders.",
+    "openSettings": "Open Settings",
+    "notificationTitle": "Daily Word",
+    "notificationBody": "Today's reading is ready. Take a moment to spend in the Word.",
+    "channelName": "Daily Word reminders"
   },
   "appearance": "Appearance",
   "appearanceOptions": {

--- a/apps/mobile/src/i18n/locales/es/settings.json
+++ b/apps/mobile/src/i18n/locales/es/settings.json
@@ -5,8 +5,27 @@
   "changeYourIcon": "Cambia tu icono",
   "sections": {
     "settings": "AJUSTES",
+    "reader": "LECTOR",
     "library": "BIBLIOTECA",
     "support": "AYUDA"
+  },
+  "reminder": {
+    "dailyReminder": "Recordatorio de Palabra diaria",
+    "dailyReminderDesc": "Un aviso diario para abrir la lectura de hoy.",
+    "time": "Hora del recordatorio",
+    "timeSheetTitle": "Hora del recordatorio",
+    "hour": "Hora",
+    "minute": "Minuto",
+    "increaseHour": "Aumentar la hora",
+    "decreaseHour": "Disminuir la hora",
+    "increaseMinute": "Aumentar los minutos",
+    "decreaseMinute": "Disminuir los minutos",
+    "permissionDeniedTitle": "Las notificaciones están desactivadas",
+    "permissionDeniedMessage": "Activa las notificaciones de GraceChords en los Ajustes de tu dispositivo para recibir recordatorios de lectura diaria.",
+    "openSettings": "Abrir Ajustes",
+    "notificationTitle": "Palabra diaria",
+    "notificationBody": "La lectura de hoy está lista. Tómate un momento para estar en la Palabra.",
+    "channelName": "Recordatorios de Palabra diaria"
   },
   "appearance": "Apariencia",
   "appearanceOptions": {

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -5,8 +5,27 @@
   "changeYourIcon": "아이콘 변경",
   "sections": {
     "settings": "설정",
+    "reader": "읽기",
     "library": "라이브러리",
     "support": "지원"
+  },
+  "reminder": {
+    "dailyReminder": "매일 말씀 알림",
+    "dailyReminderDesc": "오늘의 말씀을 열도록 매일 알려드립니다.",
+    "time": "알림 시간",
+    "timeSheetTitle": "알림 시간",
+    "hour": "시",
+    "minute": "분",
+    "increaseHour": "시간 늘리기",
+    "decreaseHour": "시간 줄이기",
+    "increaseMinute": "분 늘리기",
+    "decreaseMinute": "분 줄이기",
+    "permissionDeniedTitle": "알림이 꺼져 있습니다",
+    "permissionDeniedMessage": "매일 말씀 알림을 받으려면 기기 설정에서 GraceChords 알림을 켜세요.",
+    "openSettings": "설정 열기",
+    "notificationTitle": "매일 말씀",
+    "notificationBody": "오늘의 말씀이 준비되었습니다. 잠시 말씀과 함께하세요.",
+    "channelName": "매일 말씀 알림"
   },
   "appearance": "테마",
   "appearanceOptions": {

--- a/apps/mobile/src/i18n/locales/tr/settings.json
+++ b/apps/mobile/src/i18n/locales/tr/settings.json
@@ -5,8 +5,27 @@
   "changeYourIcon": "Simgenizi değiştirin",
   "sections": {
     "settings": "AYARLAR",
+    "reader": "OKUYUCU",
     "library": "KÜTÜPHANE",
     "support": "DESTEK"
+  },
+  "reminder": {
+    "dailyReminder": "Günün Sözü hatırlatıcısı",
+    "dailyReminderDesc": "Bugünün okumasını açmanız için günlük hatırlatma.",
+    "time": "Hatırlatma saati",
+    "timeSheetTitle": "Hatırlatma saati",
+    "hour": "Saat",
+    "minute": "Dakika",
+    "increaseHour": "Saati artır",
+    "decreaseHour": "Saati azalt",
+    "increaseMinute": "Dakikayı artır",
+    "decreaseMinute": "Dakikayı azalt",
+    "permissionDeniedTitle": "Bildirimler kapalı",
+    "permissionDeniedMessage": "Günlük okuma hatırlatmaları almak için cihaz Ayarlarınızdan GraceChords bildirimlerini açın.",
+    "openSettings": "Ayarları aç",
+    "notificationTitle": "Günün Sözü",
+    "notificationBody": "Bugünün okuması hazır. Söz'le baş başa kalmak için bir an ayırın.",
+    "channelName": "Günün Sözü hatırlatıcıları"
   },
   "appearance": "Görünüm",
   "appearanceOptions": {

--- a/apps/mobile/src/lib/__tests__/readerReminder.test.ts
+++ b/apps/mobile/src/lib/__tests__/readerReminder.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetReaderReminderForTest,
+  DEFAULT_READER_REMINDER,
+  formatReminderTime,
+  getReaderReminder,
+  hydrateReaderReminder,
+  REMINDER_NOTIFICATION_ID,
+  setReminderEnabled,
+  setReminderTime,
+  syncReminder,
+  type NotificationBackend,
+  type ReminderContent,
+} from '../readerReminder'
+import type { KVStorage } from '../defaults'
+
+function memoryStorage(initial: Record<string, string> = {}): KVStorage & { store: Map<string, string> } {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    getItem: async (k) => store.get(k) ?? null,
+    setItem: async (k, v) => void store.set(k, v),
+    removeItem: async (k) => void store.delete(k),
+  }
+}
+
+const CONTENT: ReminderContent = { title: 'Daily Word', body: 'Time to read' }
+
+function fakeBackend(granted = true) {
+  return {
+    getPermissionGranted: vi.fn(async () => granted),
+    requestPermission: vi.fn(async () => granted),
+    cancel: vi.fn(async () => {}),
+    scheduleDaily: vi.fn(async () => {}),
+  } satisfies NotificationBackend
+}
+
+describe('reader reminder store', () => {
+  beforeEach(() => __resetReaderReminderForTest())
+
+  it('is disabled at 08:00 by default', async () => {
+    await hydrateReaderReminder(memoryStorage())
+    expect(getReaderReminder()).toEqual(DEFAULT_READER_REMINDER)
+    expect(getReaderReminder()).toEqual({ enabled: false, hour: 8, minute: 0 })
+  })
+
+  it('persists enable state and time across a simulated reload', async () => {
+    const s = memoryStorage()
+    await hydrateReaderReminder(s)
+    setReminderEnabled(true)
+    setReminderTime(6, 30)
+
+    __resetReaderReminderForTest()
+    await hydrateReaderReminder(s)
+    expect(getReaderReminder()).toEqual({ enabled: true, hour: 6, minute: 30 })
+  })
+
+  it('clamps out-of-range and non-integer times', async () => {
+    await hydrateReaderReminder(memoryStorage())
+    setReminderTime(30, -5)
+    expect(getReaderReminder()).toMatchObject({ hour: 23, minute: 0 })
+    setReminderTime(7.9, 61)
+    expect(getReaderReminder()).toMatchObject({ hour: 7, minute: 59 })
+  })
+
+  it('clamps a stored out-of-range time on hydrate', async () => {
+    const s = memoryStorage({
+      'gc.readerReminder.v1': JSON.stringify({ enabled: true, hour: 99, minute: 99 }),
+    })
+    await hydrateReaderReminder(s)
+    expect(getReaderReminder()).toEqual({ enabled: true, hour: 23, minute: 59 })
+  })
+
+  it('falls back to the disabled default on a corrupt read', async () => {
+    await hydrateReaderReminder(memoryStorage({ 'gc.readerReminder.v1': '{not json' }))
+    expect(getReaderReminder()).toEqual(DEFAULT_READER_REMINDER)
+  })
+})
+
+describe('formatReminderTime', () => {
+  it('formats morning and evening times in en-US', () => {
+    expect(formatReminderTime(8, 0, 'en-US')).toBe('8:00 AM')
+    expect(formatReminderTime(20, 5, 'en-US')).toBe('8:05 PM')
+  })
+})
+
+describe('syncReminder', () => {
+  it('cancels and does not schedule when disabled', async () => {
+    const backend = fakeBackend(true)
+    await syncReminder({ enabled: false, hour: 8, minute: 0 }, CONTENT, backend)
+    expect(backend.cancel).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID)
+    expect(backend.scheduleDaily).not.toHaveBeenCalled()
+  })
+
+  it('reschedules when enabled and permission is held', async () => {
+    const backend = fakeBackend(true)
+    await syncReminder({ enabled: true, hour: 7, minute: 15 }, CONTENT, backend)
+    expect(backend.cancel).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID)
+    expect(backend.scheduleDaily).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID, 7, 15, CONTENT)
+  })
+
+  it('does not schedule when enabled but permission is missing', async () => {
+    const backend = fakeBackend(false)
+    await syncReminder({ enabled: true, hour: 7, minute: 15 }, CONTENT, backend)
+    expect(backend.cancel).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID)
+    expect(backend.scheduleDaily).not.toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/lib/readerReminder.ts
+++ b/apps/mobile/src/lib/readerReminder.ts
@@ -1,0 +1,162 @@
+import { useSyncExternalStore } from 'react'
+import type { KVStorage } from './defaults'
+
+// Daily Word reminder — an OPT-IN, off-by-default local notification that nudges
+// the user to open today's reading at a time they pick. Device-local
+// (AsyncStorage), NOT Supabase-synced.
+//
+// Follows the defaults.ts / readingStreak.ts pattern: storage is INJECTED so the
+// module is RN-free and unit-testable headless; the app root hydrates once at
+// splash, after which reads are synchronous and `useReaderReminder` re-renders
+// subscribers. Native scheduling (expo-notifications) is kept out of this module
+// so the preference + reconciliation logic stay testable — see
+// readerReminderService.ts for the wiring.
+
+export type ReaderReminder = {
+  enabled: boolean
+  /** Local hour, 0–23. */
+  hour: number
+  /** Local minute, 0–59. */
+  minute: number
+}
+
+export const DEFAULT_READER_REMINDER: ReaderReminder = {
+  enabled: false,
+  hour: 8,
+  minute: 0,
+}
+
+const STORAGE_KEY = 'gc.readerReminder.v1'
+
+/** Stable identifier for our single scheduled daily notification, so it can be
+ * cancelled/replaced without disturbing anything else the OS has scheduled. */
+export const REMINDER_NOTIFICATION_ID = 'reader-daily-reminder'
+
+let cache: ReaderReminder = DEFAULT_READER_REMINDER
+let storage: KVStorage | null = null
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function persist() {
+  storage?.setItem(STORAGE_KEY, JSON.stringify(cache)).catch(() => {})
+}
+
+function clampHour(h: number): number {
+  if (!Number.isFinite(h)) return DEFAULT_READER_REMINDER.hour
+  return Math.min(23, Math.max(0, Math.trunc(h)))
+}
+
+function clampMinute(m: number): number {
+  if (!Number.isFinite(m)) return DEFAULT_READER_REMINDER.minute
+  return Math.min(59, Math.max(0, Math.trunc(m)))
+}
+
+function isReaderReminder(v: unknown): v is ReaderReminder {
+  if (!v || typeof v !== 'object') return false
+  const r = v as Record<string, unknown>
+  return typeof r.enabled === 'boolean' && typeof r.hour === 'number' && typeof r.minute === 'number'
+}
+
+/** Load the stored reminder; a bad read falls back to the (disabled) default. */
+export async function hydrateReaderReminder(store: KVStorage): Promise<ReaderReminder> {
+  storage = store
+  try {
+    const parsed = JSON.parse((await store.getItem(STORAGE_KEY)) ?? 'null') as unknown
+    cache = isReaderReminder(parsed)
+      ? { enabled: parsed.enabled, hour: clampHour(parsed.hour), minute: clampMinute(parsed.minute) }
+      : DEFAULT_READER_REMINDER
+  } catch {
+    cache = DEFAULT_READER_REMINDER
+  }
+  emit()
+  return cache
+}
+
+/** Synchronous read (safe before hydrate — returns the disabled default). */
+export function getReaderReminder(): ReaderReminder {
+  return cache
+}
+
+export function setReminderEnabled(v: boolean): void {
+  if (cache.enabled === v) return
+  cache = { ...cache, enabled: v }
+  emit()
+  persist()
+}
+
+export function setReminderTime(hour: number, minute: number): void {
+  const h = clampHour(hour)
+  const m = clampMinute(minute)
+  if (cache.hour === h && cache.minute === m) return
+  cache = { ...cache, hour: h, minute: m }
+  emit()
+  persist()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Subscribing hook — re-renders on any reminder change (Settings screen). */
+export function useReaderReminder(): ReaderReminder {
+  return useSyncExternalStore(subscribe, getReaderReminder, getReaderReminder)
+}
+
+/** Locale-aware "8:00 AM" / "20:00" display for the settings row and picker. */
+export function formatReminderTime(hour: number, minute: number, locale?: string): string {
+  const d = new Date(2000, 0, 1, clampHour(hour), clampMinute(minute))
+  try {
+    return new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' }).format(d)
+  } catch {
+    return `${String(clampHour(hour)).padStart(2, '0')}:${String(clampMinute(minute)).padStart(2, '0')}`
+  }
+}
+
+// --- OS scheduling reconciliation (dependency-injected, testable) -----------
+
+export type ReminderContent = { title: string; body: string }
+
+/** Minimal surface of expo-notifications we depend on — injected so the
+ * reconciliation logic below can be unit-tested without the native module. */
+export type NotificationBackend = {
+  /** Whether the app currently holds permission to post notifications. */
+  getPermissionGranted(): Promise<boolean>
+  /** Prompt the user for permission; resolves to whether it was granted. */
+  requestPermission(): Promise<boolean>
+  /** Cancel the scheduled notification with this id (no-op if none). */
+  cancel(id: string): Promise<void>
+  /** Schedule a daily-repeating notification at the given local time. */
+  scheduleDaily(
+    id: string,
+    hour: number,
+    minute: number,
+    content: ReminderContent,
+  ): Promise<void>
+}
+
+/**
+ * Reconcile the OS-scheduled reminder with the current preference: always clear
+ * the existing one first, then (re)schedule the single daily notification when
+ * the reminder is enabled AND permission is held. Safe to call repeatedly
+ * (launch, toggle, time change, language change).
+ */
+export async function syncReminder(
+  pref: ReaderReminder,
+  content: ReminderContent,
+  backend: NotificationBackend,
+): Promise<void> {
+  await backend.cancel(REMINDER_NOTIFICATION_ID)
+  if (!pref.enabled) return
+  if (!(await backend.getPermissionGranted())) return
+  await backend.scheduleDaily(REMINDER_NOTIFICATION_ID, pref.hour, pref.minute, content)
+}
+
+/** Test-only reset so each test starts from a clean module state. */
+export function __resetReaderReminderForTest(): void {
+  cache = DEFAULT_READER_REMINDER
+  storage = null
+}

--- a/apps/mobile/src/lib/readerReminderService.ts
+++ b/apps/mobile/src/lib/readerReminderService.ts
@@ -1,0 +1,156 @@
+import { Platform } from 'react-native'
+import * as Notifications from 'expo-notifications'
+import i18n from '../i18n'
+import {
+  getReaderReminder,
+  REMINDER_NOTIFICATION_ID,
+  setReminderEnabled,
+  setReminderTime,
+  syncReminder,
+  type NotificationBackend,
+  type ReminderContent,
+} from './readerReminder'
+
+// Native wiring for the Daily Word reminder. Keeps expo-notifications isolated
+// from the pure preference/reconciliation logic in readerReminder.ts (which is
+// where the testable behavior lives). This module holds only the thin adapter to
+// the native module plus the app-facing flows the Settings screen and app root
+// call.
+
+const ANDROID_CHANNEL_ID = 'reader-reminders'
+
+// The passages nudge deep-links straight to the Daily Word tab on tap.
+const REMINDER_DEEP_LINK = '/daily'
+
+/** Localized notification copy — rebuilt on each (re)schedule so it follows the
+ * current UI language. */
+function reminderContent(): ReminderContent {
+  return {
+    title: i18n.t('settings:reminder.notificationTitle'),
+    body: i18n.t('settings:reminder.notificationBody'),
+  }
+}
+
+/** The real backend, delegating to expo-notifications. */
+const backend: NotificationBackend = {
+  async getPermissionGranted() {
+    try {
+      const settings = await Notifications.getPermissionsAsync()
+      return permissionGranted(settings)
+    } catch {
+      return false
+    }
+  },
+  async requestPermission() {
+    try {
+      const settings = await Notifications.requestPermissionsAsync()
+      return permissionGranted(settings)
+    } catch {
+      return false
+    }
+  },
+  async cancel(id) {
+    try {
+      await Notifications.cancelScheduledNotificationAsync(id)
+    } catch {
+      // No-op if nothing is scheduled under this id.
+    }
+  },
+  async scheduleDaily(id, hour, minute, content) {
+    await Notifications.scheduleNotificationAsync({
+      identifier: id,
+      content: {
+        title: content.title,
+        body: content.body,
+        sound: true,
+        data: { url: REMINDER_DEEP_LINK },
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DAILY,
+        hour,
+        minute,
+        ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
+      },
+    })
+  },
+}
+
+function permissionGranted(settings: Notifications.NotificationPermissionsStatus): boolean {
+  const s = settings as unknown as {
+    granted?: boolean
+    status?: string
+    ios?: { status?: number }
+  }
+  if (s.granted || s.status === 'granted') return true
+  // iOS reports provisional (quiet) authorization as its own status; treat it as
+  // granted since notifications will still be delivered.
+  return s.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+}
+
+/**
+ * Install the foreground handler (show the reminder even while the app is open)
+ * and, on Android, the notification channel. Safe to call once at app start.
+ */
+export function initReaderReminders(): void {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowBanner: true,
+      shouldShowList: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+    }),
+  })
+  if (Platform.OS === 'android') {
+    void Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+      name: i18n.t('settings:reminder.channelName'),
+      importance: Notifications.AndroidImportance.DEFAULT,
+    }).catch(() => {})
+  }
+}
+
+/** Reconcile the OS schedule with the stored preference (call at launch). */
+export async function syncReaderReminderOnLaunch(): Promise<void> {
+  try {
+    await syncReminder(getReaderReminder(), reminderContent(), backend)
+  } catch {
+    // Best-effort — a scheduling hiccup must never block launch.
+  }
+}
+
+/**
+ * Turn the reminder on: request permission (this is where iOS shows the system
+ * prompt), and only persist + schedule when granted. Returns whether it was
+ * granted so the UI can steer the user to Settings on denial.
+ */
+export async function enableReaderReminder(hour: number, minute: number): Promise<boolean> {
+  const granted = await backend.requestPermission()
+  if (!granted) return false
+  setReminderTime(hour, minute)
+  setReminderEnabled(true)
+  await syncReminder(getReaderReminder(), reminderContent(), backend)
+  return true
+}
+
+/** Turn the reminder off and cancel the scheduled notification. */
+export async function disableReaderReminder(): Promise<void> {
+  setReminderEnabled(false)
+  await syncReminder(getReaderReminder(), reminderContent(), backend)
+}
+
+/** Change the reminder time and reschedule (no-op on the OS if disabled). */
+export async function updateReaderReminderTime(hour: number, minute: number): Promise<void> {
+  setReminderTime(hour, minute)
+  await syncReminder(getReaderReminder(), reminderContent(), backend)
+}
+
+/**
+ * Route to the Daily Word tab when the user taps the reminder. Returns the
+ * subscription's remover. `onOpen` receives the deep-link path.
+ */
+export function addReminderResponseListener(onOpen: (url: string) => void): () => void {
+  const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+    const url = response.notification.request.content.data?.url
+    if (typeof url === 'string') onOpen(url)
+  })
+  return () => sub.remove()
+}

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Alert, Image, Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import { Alert, Image, Linking, Pressable, ScrollView, Switch, Text, View } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -26,6 +26,13 @@ import {
 } from '../lib/defaults'
 import { applyLanguagePreference, SUPPORTED_LOCALES } from '../i18n'
 import { localeLabel, normalizeLanguageTag } from '../i18n/config'
+import { formatReminderTime, useReaderReminder } from '../lib/readerReminder'
+import {
+  disableReaderReminder,
+  enableReaderReminder,
+  updateReaderReminderTime,
+} from '../lib/readerReminderService'
+import ReminderTimeSheet from '../components/reader/ReminderTimeSheet'
 
 // The grouped "Profile & Settings" screen (design: [CONTENT] Settings Content).
 // Built from Stage-0 primitives — a Profile card, three grouped Cards
@@ -156,7 +163,9 @@ export default function SettingsScreen() {
   const user = useCurrentUser()
   const defaults = useAppDefaults()
   const { source: spriteSource } = useProfileSprite()
-  const [sheet, setSheet] = useState<null | 'theme' | 'chordStyle' | 'language'>(null)
+  const reminder = useReaderReminder()
+  const [reminderBusy, setReminderBusy] = useState(false)
+  const [sheet, setSheet] = useState<null | 'theme' | 'chordStyle' | 'language' | 'reminderTime'>(null)
   // Measured glass-bar height feeds the scroll-behind top inset.
   const [barH, setBarH] = useState(0)
 
@@ -181,6 +190,29 @@ export default function SettingsScreen() {
     const pref = value === LANGUAGE_SYSTEM ? null : value
     setDefaultLanguage(pref)
     applyLanguagePreference(pref)
+  }
+
+  // Enabling requests notification permission (the iOS system prompt appears
+  // here); we only persist + schedule when it's granted, and steer the user to
+  // the system Settings app on denial. Disabling cancels the scheduled reminder.
+  async function onToggleReminder(next: boolean) {
+    if (reminderBusy) return
+    setReminderBusy(true)
+    try {
+      if (next) {
+        const granted = await enableReaderReminder(reminder.hour, reminder.minute)
+        if (!granted) {
+          Alert.alert(tx('reminder.permissionDeniedTitle'), tx('reminder.permissionDeniedMessage'), [
+            { text: tx('common:cancel'), style: 'cancel' },
+            { text: tx('reminder.openSettings'), onPress: () => void Linking.openSettings() },
+          ])
+        }
+      } else {
+        await disableReaderReminder()
+      }
+    } finally {
+      setReminderBusy(false)
+    }
   }
 
   function onSignOut() {
@@ -321,6 +353,36 @@ export default function SettingsScreen() {
           />
         </Card>
 
+        {/* READER */}
+        <SectionHeader label={tx('sections.reader')} />
+        <Card>
+          <ListRow
+            title={tx('reminder.dailyReminder')}
+            subtitle={tx('reminder.dailyReminderDesc')}
+            leading={<RowIcon name="bell" t={t} />}
+            isLast={!reminder.enabled}
+            trailing={
+              <Switch
+                value={reminder.enabled}
+                disabled={reminderBusy}
+                onValueChange={(v) => void onToggleReminder(v)}
+                trackColor={{ true: t.colors.accent }}
+                accessibilityLabel={tx('reminder.dailyReminder')}
+              />
+            }
+          />
+          {reminder.enabled ? (
+            <ListRow
+              title={tx('reminder.time')}
+              leading={<RowIcon name="clock" t={t} />}
+              value={formatReminderTime(reminder.hour, reminder.minute, i18n.language)}
+              chevron
+              isLast
+              onPress={() => setSheet('reminderTime')}
+            />
+          ) : null}
+        </Card>
+
         {/* LIBRARY */}
         <SectionHeader label={tx('sections.library')} />
         <Card>
@@ -417,6 +479,13 @@ export default function SettingsScreen() {
         options={chordOptions}
         value={defaults.chordStyle}
         onSelect={setDefaultChordStyle}
+        onClose={() => setSheet(null)}
+      />
+      <ReminderTimeSheet
+        visible={sheet === 'reminderTime'}
+        hour={reminder.hour}
+        minute={reminder.minute}
+        onConfirm={(h, m) => void updateReaderReminderTime(h, m)}
         onClose={() => setSheet(null)}
       />
     </Screen>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "expo-linking": "~55.0.16",
         "expo-localization": "~55.0.16",
         "expo-network": "~55.0.15",
+        "expo-notifications": "~55.0.25",
         "expo-router": "55.0.16",
         "expo-sharing": "~55.0.21",
         "expo-splash-screen": "~55.0.22",
@@ -796,6 +797,15 @@
         "react-native": "*"
       }
     },
+    "apps/mobile/node_modules/expo-application": {
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.17.tgz",
+      "integrity": "sha512-ASuZe+Sl8ax+0pQOjd8L5cz5xpxW0F1VSorRKFr9LHxDSQwH929nYjbMrvW6KlRIIWZBIAQQsYqWiowytCLMRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "apps/mobile/node_modules/expo-build-properties": {
       "version": "55.0.15",
       "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.15.tgz",
@@ -822,12 +832,12 @@
       }
     },
     "apps/mobile/node_modules/expo-constants": {
-      "version": "55.0.16",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.16.tgz",
-      "integrity": "sha512-Z15/No94UHoogD+pulxjudGAeOHTEIWZgb/vnX48Wx5D+apWTeCbnKxQZZtGQlosvduYL5kaic2/W8U+NHfBQQ==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.17.tgz",
+      "integrity": "sha512-t0SNWmXTjXPCHzjNsv1Okjaj8SpXQcUjDPtYDqvofDS+BhAsvlKNmwaaWXvduBjjmmmJWNH8q1/x9IWQ+upg8g==",
       "license": "MIT",
       "dependencies": {
-        "@expo/env": "~2.1.2"
+        "@expo/env": "~2.1.3"
       },
       "peerDependencies": {
         "expo": "*",
@@ -1007,6 +1017,24 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-notifications": {
+      "version": "55.0.25",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.25.tgz",
+      "integrity": "sha512-yCbZElqHLvGommwMXJn0ZS/8kJ8wbf7Ujn5or4lVGthRUhaRZfTrN/UJlc9FnQmuKJ35I4rSzo1fqeQjxb+XOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.15",
+        "abort-controller": "^3.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~55.0.17",
+        "expo-constants": "~55.0.17"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "apps/mobile/node_modules/expo-router": {
@@ -5077,9 +5105,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.2.tgz",
-      "integrity": "sha512-RJtGFfj/ygO/6zcVbV3cckHf4THcEkv5IZft1GjCB3dfT6axvzvIwXE9EiQqQYmGHcQ+ZrvC8xZcIhiHba0pYg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.3.tgz",
+      "integrity": "sha512-Rhu/lJ1kOhqzJvLwW0iB4WKUzB1nFa8WBwXFL44qkSTNwibjrbI8lA46Ix6W2MMTdlUqL1m85Gdyx0T7nGpREg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -5203,12 +5231,12 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.14.tgz",
-      "integrity": "sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.15.tgz",
+      "integrity": "sha512-3f5CgKJnJ8m4mp8VTcAFQqLrxof99RDr77Aa+7hgzDPg3ZotjLnofl77hf+COQRYi/kuqRYdYFgPIqOIOIdWJA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^55.0.5",
+        "@expo/require-utils": "^55.0.6",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
@@ -5318,9 +5346,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.5.tgz",
-      "integrity": "sha512-U4K/CQ2VpXuwfNGsN+daKmYOt15hCP8v/pXaYH6eut7kdYZo6SfJ1yr67BIcJ+1Gzzs+QzTxswAZChKpXmceyw==",
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.6.tgz",
+      "integrity": "sha512-IqsRGPdGbF0lAIrg3XQ+GzcITYcsskvIRmFAjw2kBnr8RgSrRhFAJY1bKksukEUsuZy0knhTCVIIUce7hocqeA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -10177,6 +10205,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",


### PR DESCRIPTION
Add an opt-in, off-by-default daily local notification that nudges the
user to open the day's reading at a time they choose, configured from a
new "Reader" section on the Settings screen.

- src/lib/readerReminder.ts: pure, RN-free preference store (enabled +
  local hour/minute, gc.readerReminder.v1) following the defaults.ts
  injected-storage / useSyncExternalStore pattern, plus a
  dependency-injected syncReminder() reconciler and a locale-aware
  formatReminderTime helper — all unit-tested headless.
- src/lib/readerReminderService.ts: wires the real expo-notifications
  backend — permission request, a single daily-repeating notification
  under a stable id, the foreground handler, an Android channel, and a
  tap -> /daily deep link.
- Settings screen: Reader section with an enable Switch (requests
  notification permission on enable; steers to system Settings on
  denial) and a time row opening ReminderTimeSheet, a custom stepper
  built on RN primitives (no extra native picker dep, like
  DatePickerSheet).
- App root hydrates the preference at splash, installs the handler, and
  reconciles the OS schedule on launch.
- Add expo-notifications (~55.0.25) + config plugin; localize the new
  strings across en/es/ko/tr.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y1wWeDZoK5Kce8XfuYwdXW