### PR TITLE
fix(mobile): give non-glass top bars a hairline edge

### DIFF
--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useMemo } from 'react'
-import { Platform, View, type StyleProp, type ViewProps, type ViewStyle } from 'react-native'
+import { Platform, StyleSheet, View, type StyleProp, type ViewProps, type ViewStyle } from 'react-native'
 import {
   GlassView,
   isGlassEffectAPIAvailable,
@@ -44,6 +44,13 @@ export type GlassSurfaceProps = {
   style?: StyleProp<ViewStyle>
   /** Solid fill on non-glass devices. Defaults to the raised `surface` token. */
   fallbackColor?: string
+  /**
+   * Non-glass only: draw a hairline bottom separator on the solid fallback.
+   * Glass supplies its own edge via the blurred material, so this is ignored on
+   * iOS 26. Set it on scroll-behind top bars whose fallback fill matches the
+   * page background — without it the bar has no visible edge on iOS < 26.
+   */
+  fallbackHairline?: boolean
   /** GlassView tint on iOS 26. Omit for a neutral (untinted) material. */
   glassTint?: string
   /** Glass material weight on iOS 26. */
@@ -60,6 +67,7 @@ export type GlassSurfaceProps = {
 export default function GlassSurface({
   style,
   fallbackColor,
+  fallbackHairline = false,
   glassTint,
   glassStyle = 'regular',
   isInteractive = false,
@@ -92,7 +100,14 @@ export default function GlassSurface({
     <View
       onLayout={onLayout}
       pointerEvents={pointerEvents}
-      style={[style, { backgroundColor: fallbackColor ?? t.colors.surface }]}
+      style={[
+        style,
+        { backgroundColor: fallbackColor ?? t.colors.surface },
+        fallbackHairline && {
+          borderBottomWidth: StyleSheet.hairlineWidth,
+          borderBottomColor: t.colors.border,
+        },
+      ]}
     >
       {children}
     </View>

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -135,6 +135,7 @@ export default function AboutScreen() {
           iOS < 26 / Android. Content scrolls under it (measured via onLayout). */}
       <GlassSurface
         fallbackColor={t.colors.bg}
+        fallbackHairline
         onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
         style={{
           position: 'absolute',

--- a/apps/mobile/src/screens/MetronomeScreen.tsx
+++ b/apps/mobile/src/screens/MetronomeScreen.tsx
@@ -268,6 +268,7 @@ export default function MetronomeScreen({ embedded }: { embedded?: boolean }) {
       {/* Scroll-behind top bar, same pattern as Tuner/Settings. */}
       <GlassSurface
         fallbackColor={t.colors.bg}
+        fallbackHairline
         onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
         style={{
           position: 'absolute',

--- a/apps/mobile/src/screens/OfflineDownloadsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineDownloadsScreen.tsx
@@ -309,6 +309,7 @@ export default function OfflineDownloadsScreen() {
           iOS < 26 / Android. Content scrolls under it (measured via onLayout). */}
       <GlassSurface
         fallbackColor={t.colors.bg}
+        fallbackHairline
         onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
         style={{
           position: 'absolute',

--- a/apps/mobile/src/screens/PitchPipeScreen.tsx
+++ b/apps/mobile/src/screens/PitchPipeScreen.tsx
@@ -287,6 +287,7 @@ export default function PitchPipeScreen({ embedded }: { embedded?: boolean }) {
       {/* Scroll-behind top bar, same pattern as Tuner/Settings. */}
       <GlassSurface
         fallbackColor={t.colors.bg}
+        fallbackHairline
         onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
         style={{
           position: 'absolute',

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -433,6 +433,7 @@ export default function SettingsScreen() {
           iOS < 26 / Android. Content scrolls under it (measured via onLayout). */}
       <GlassSurface
         fallbackColor={t.colors.bg}
+        fallbackHairline
         onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
         style={{
           position: 'absolute',

--- a/apps/mobile/src/screens/TunerScreen.tsx
+++ b/apps/mobile/src/screens/TunerScreen.tsx
@@ -339,6 +339,7 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
       {/* Scroll-behind top bar, same pattern as Settings/About. */}
       <GlassSurface
         fallbackColor={t.colors.bg}
+        fallbackHairline
         onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
         style={{
           position: 'absolute',


### PR DESCRIPTION
The scroll-behind top bars (Settings, About, Offline, Tuner, Metronome,
Pitch Pipe) rendered their solid fallback filled with the page background
and no separator on iOS < 26. With the fill matching the page and no edge,
the bar was effectively invisible: the back button/title appeared to float
and content scrolled under an undefined boundary. Glass devices were fine —
the blurred material supplies its own edge.

Add an opt-in `fallbackHairline` to GlassSurface that draws a hairline
bottom border on the non-glass fallback only (glass branch unchanged), and
set it on the six scroll-behind top bars.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HGBmg79eT5dMLwMXhASU1e