### PR TITLE
fix(mobile): match Daily Word header font to the rest of the app

### DIFF
--- a/apps/mobile/src/screens/DailyWordLandingScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordLandingScreen.tsx
@@ -95,16 +95,15 @@ export default function DailyWordLandingScreen() {
           paddingBottom: insets.bottom + t.spacing.xxl,
         }}
       >
-        {/* Header: serif title (+ optional streak) + the profile/settings avatar,
-            matching the Home header for cross-app consistency. */}
+        {/* Header: large-title (+ optional streak) + the profile/settings avatar,
+            matching the Home header and every other screen's page title. */}
         <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between' }}>
           <View style={{ flex: 1, minWidth: 0 }}>
             <Text
               style={{
-                fontFamily: 'Georgia',
-                fontSize: 30,
-                fontWeight: '700',
-                letterSpacing: -0.4,
+                fontSize: t.typography.largeTitle.fontSize,
+                fontWeight: t.typography.largeTitle.fontWeight,
+                letterSpacing: t.typography.largeTitle.letterSpacing,
                 color: t.colors.ink,
               }}
             >


### PR DESCRIPTION
The landing's "Daily Word" title was hardcoded to Georgia serif at 30pt — every other screen (Settings, Setlists, Song Library, Utilities, etc.) uses the shared largeTitle token (system sans-serif, 27pt). Switch to the token so the header is visually consistent app-wide; the serif stays where it's intentional (reflection body text).


Claude-Session: https://claude.ai/code/session_01WDpXY9x73Lyzvp1hkQvBdU