### PR TITLE
refactor(mobile): move reading streak toggle from reader settings to …

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -320,7 +320,8 @@ duplicate logic here and never edit core internals to suit mobile.
   existing `initialKey` param (Library opens still use the default key).
 - **Reading streak** (`src/lib/readingStreak.ts`, same injected-storage /
   `useSyncExternalStore` pattern): OPT-IN, off by default — the toggle lives in
-  the Daily Word reader-settings sheet, and `DailyWordScreen` marks a day read
+  **Settings → Reader** (alongside the Daily Word reminder), not the reader
+  settings sheet, and `DailyWordScreen` marks a day read
   when one of TODAY's chapters renders. Home's Daily Word card shows the streak
   only when enabled (`currentStreak` — 0 once a day is missed). Unit-tested.
   Editable greeting phrases live in `src/lib/greetings.ts` (`SUB_GREETINGS`).

--- a/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
+++ b/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
@@ -1,12 +1,11 @@
 import type { ReactNode } from 'react'
-import { Pressable, Switch, Text, View, useWindowDimensions } from 'react-native'
+import { Pressable, Text, View, useWindowDimensions } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTranslation } from 'react-i18next'
 import FormSheetShell from '../FormSheetShell'
 import SegmentedPill from '../SegmentedPill'
 import { useFormSheet } from '../../lib/formSheetHost'
 import { useTheme } from '../../theme/ThemeProvider'
-import { setStreakEnabled, useReadingStreak } from '../../lib/readingStreak'
 import {
   READER_PT_MAX,
   READER_PT_MIN,
@@ -18,9 +17,8 @@ import {
 
 // Reader settings sheet (Daily Word screen 18): text size stepper, typeface,
 // verse layout, and line spacing. All session-ephemeral — the screen owns the
-// state and nothing persists across launches — EXCEPT the reading-streak
-// opt-in at the bottom, which is a persisted device-local preference
-// (src/lib/readingStreak.ts, read by Home's Daily Word card).
+// state and nothing persists across launches. The reading-streak opt-in lives
+// in Settings → Reader (src/lib/readingStreak.ts), not here.
 
 // Inline setting-value row: label left, control right-aligned and content-sized.
 // `stack` puts the control on its own line below the label — used on narrow
@@ -86,7 +84,6 @@ function ReaderSettingsContent({ onClose, settings, onChange }: ReaderSettingsPr
   const t = useTheme()
   const { t: tx } = useTranslation('reader')
   const insets = useSafeAreaInsets()
-  const streak = useReadingStreak()
   // On narrow iPhone widths the 3-option Line spacing control would collide
   // with its label, so that row stacks. 2-option rows stay inline everywhere.
   const { width } = useWindowDimensions()
@@ -186,22 +183,6 @@ function ReaderSettingsContent({ onClose, settings, onChange }: ReaderSettingsPr
             onChange={(v) => onChange({ ...settings, lineSpacing: v })}
           />
         </SettingRow>
-
-        <OverlineLabel>{tx('settings.readingStreak')}</OverlineLabel>
-        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: t.spacing.md }}>
-          <View style={{ flex: 1 }}>
-            <Text style={{ fontSize: 16, color: t.colors.ink }}>{tx('settings.trackReadingStreak')}</Text>
-            <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 2 }}>
-              {tx('settings.trackReadingStreakDesc')}
-            </Text>
-          </View>
-          <Switch
-            value={streak.enabled}
-            onValueChange={setStreakEnabled}
-            trackColor={{ true: t.colors.accent }}
-            accessibilityLabel={tx('settings.trackReadingStreak')}
-          />
-        </View>
       </View>
     </FormSheetShell>
   )

--- a/apps/mobile/src/i18n/locales/en/reader.json
+++ b/apps/mobile/src/i18n/locales/en/reader.json
@@ -117,10 +117,7 @@
     "lineSpacing": "Line spacing",
     "tight": "Tight",
     "normal": "Normal",
-    "relaxed": "Relaxed",
-    "readingStreak": "Reading streak",
-    "trackReadingStreak": "Track reading streak",
-    "trackReadingStreakDesc": "Counts consecutive days you open today's reading."
+    "relaxed": "Relaxed"
   },
   "datePicker": {
     "title": "Select date",

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -27,6 +27,10 @@
     "notificationBody": "Today's reading is ready. Take a moment to spend in the Word.",
     "channelName": "Daily Word reminders"
   },
+  "readingStreak": {
+    "title": "Reading streak",
+    "description": "Counts consecutive days you open today's reading."
+  },
   "appearance": "Appearance",
   "appearanceOptions": {
     "auto": "Auto",

--- a/apps/mobile/src/i18n/locales/es/reader.json
+++ b/apps/mobile/src/i18n/locales/es/reader.json
@@ -117,10 +117,7 @@
     "lineSpacing": "Interlineado",
     "tight": "Estrecho",
     "normal": "Normal",
-    "relaxed": "Amplio",
-    "readingStreak": "Racha de lectura",
-    "trackReadingStreak": "Registrar racha de lectura",
-    "trackReadingStreakDesc": "Cuenta los días seguidos que abres la lectura de hoy."
+    "relaxed": "Amplio"
   },
   "datePicker": {
     "title": "Seleccionar fecha",

--- a/apps/mobile/src/i18n/locales/es/settings.json
+++ b/apps/mobile/src/i18n/locales/es/settings.json
@@ -27,6 +27,10 @@
     "notificationBody": "La lectura de hoy está lista. Tómate un momento para estar en la Palabra.",
     "channelName": "Recordatorios de Palabra diaria"
   },
+  "readingStreak": {
+    "title": "Racha de lectura",
+    "description": "Cuenta los días consecutivos que abres la lectura de hoy."
+  },
   "appearance": "Apariencia",
   "appearanceOptions": {
     "auto": "Automático",

--- a/apps/mobile/src/i18n/locales/ko/reader.json
+++ b/apps/mobile/src/i18n/locales/ko/reader.json
@@ -117,10 +117,7 @@
     "lineSpacing": "줄 간격",
     "tight": "좁게",
     "normal": "보통",
-    "relaxed": "넓게",
-    "readingStreak": "읽기 연속 기록",
-    "trackReadingStreak": "읽기 연속 기록 추적",
-    "trackReadingStreakDesc": "오늘의 말씀을 연속으로 열어본 일수를 셉니다."
+    "relaxed": "넓게"
   },
   "datePicker": {
     "title": "날짜 선택",

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -27,6 +27,10 @@
     "notificationBody": "오늘의 말씀이 준비되었습니다. 잠시 말씀과 함께하세요.",
     "channelName": "매일 말씀 알림"
   },
+  "readingStreak": {
+    "title": "읽기 연속 기록",
+    "description": "오늘의 읽기를 여는 연속 일수를 계산합니다."
+  },
   "appearance": "테마",
   "appearanceOptions": {
     "auto": "자동",

--- a/apps/mobile/src/i18n/locales/tr/reader.json
+++ b/apps/mobile/src/i18n/locales/tr/reader.json
@@ -117,10 +117,7 @@
     "lineSpacing": "Satır aralığı",
     "tight": "Dar",
     "normal": "Normal",
-    "relaxed": "Geniş",
-    "readingStreak": "Okuma serisi",
-    "trackReadingStreak": "Okuma serisini takip et",
-    "trackReadingStreakDesc": "Bugünün okumasını açtığın ardışık günleri sayar."
+    "relaxed": "Geniş"
   },
   "datePicker": {
     "title": "Tarih seç",

--- a/apps/mobile/src/i18n/locales/tr/settings.json
+++ b/apps/mobile/src/i18n/locales/tr/settings.json
@@ -27,6 +27,10 @@
     "notificationBody": "Bugünün okuması hazır. Söz'le baş başa kalmak için bir an ayırın.",
     "channelName": "Günün Sözü hatırlatıcıları"
   },
+  "readingStreak": {
+    "title": "Okuma serisi",
+    "description": "Bugünün okumasını açtığın ardışık günleri sayar."
+  },
   "appearance": "Görünüm",
   "appearanceOptions": {
     "auto": "Otomatik",

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -35,6 +35,7 @@ import {
   updateReaderReminderTime,
 } from '../lib/readerReminderService'
 import ReminderTimeSheet from '../components/reader/ReminderTimeSheet'
+import { setStreakEnabled, useReadingStreak } from '../lib/readingStreak'
 
 // The grouped "Profile & Settings" screen (design: [CONTENT] Settings Content).
 // Built from Stage-0 primitives — a Profile card, three grouped Cards
@@ -170,6 +171,7 @@ export default function SettingsScreen() {
   const defaults = useAppDefaults()
   const { source: spriteSource } = useProfileSprite()
   const reminder = useReaderReminder()
+  const streak = useReadingStreak()
   const [reminderBusy, setReminderBusy] = useState(false)
   const [sheet, setSheet] = useState<
     null | 'theme' | 'chordStyle' | 'language' | 'reminderTime' | 'dailyEntry'
@@ -376,7 +378,6 @@ export default function SettingsScreen() {
             title={tx('reminder.dailyReminder')}
             subtitle={tx('reminder.dailyReminderDesc')}
             leading={<RowIcon name="bell" t={t} />}
-            isLast={!reminder.enabled}
             trailing={
               <Switch
                 value={reminder.enabled}
@@ -393,10 +394,23 @@ export default function SettingsScreen() {
               leading={<RowIcon name="clock" t={t} />}
               value={formatReminderTime(reminder.hour, reminder.minute, i18n.language)}
               chevron
-              isLast
               onPress={() => setSheet('reminderTime')}
             />
           ) : null}
+          <ListRow
+            title={tx('readingStreak.title')}
+            subtitle={tx('readingStreak.description')}
+            leading={<RowIcon name="flame.fill" t={t} />}
+            isLast
+            trailing={
+              <Switch
+                value={streak.enabled}
+                onValueChange={setStreakEnabled}
+                trackColor={{ true: t.colors.accent }}
+                accessibilityLabel={tx('readingStreak.title')}
+              />
+            }
+          />
         </Card>
 
         {/* LIBRARY */}


### PR DESCRIPTION
…Settings → Reader

The streak opt-in was tucked in the Reader settings sheet (a text-size/ typeface/layout sheet meant for session-ephemeral reading prefs), separate from every other persisted Daily Word preference (reminder, opens-to destination), which all live in Settings → Reader. Move it there as a fourth ListRow (flame icon + switch), removing it from ReaderSettingsSheet. Behavior is unchanged — same readingStreak.ts store, still opt-in/off by default.


Claude-Session: https://claude.ai/code/session_01WDpXY9x73Lyzvp1hkQvBdU