### PR TITLE
Add songbook builder tool to utilities

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -71,6 +71,12 @@
             "useFrameworks": "static"
           }
         }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "GraceChords uses your photo library only so you can pick a cover image for a songbook PDF you export."
+        }
       ]
     ],
     "experiments": {

--- a/apps/mobile/app/songbook.tsx
+++ b/apps/mobile/app/songbook.tsx
@@ -1,0 +1,7 @@
+import SongbookBuilderScreen from '../src/screens/SongbookBuilderScreen'
+
+// Songbook builder — pushed from the Utilities tab (phone). On tablet the tool
+// renders embedded in the Utilities split instead of this route.
+export default function Songbook() {
+  return <SongbookBuilderScreen />
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-font": "~55.0.8",
     "expo-glass-effect": "55.0.11",
     "expo-haptics": "~55.0.15",
+    "expo-image-picker": "~55.0.21",
     "expo-keep-awake": "~55.0.8",
     "expo-linear-gradient": "~55.0.15",
     "expo-linking": "~55.0.16",

--- a/apps/mobile/src/components/songbook/SongbookOptionsSheet.tsx
+++ b/apps/mobile/src/components/songbook/SongbookOptionsSheet.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react'
+import { ActivityIndicator, Image, Pressable, Switch, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTranslation } from 'react-i18next'
+import FormSheetShell from '../FormSheetShell'
+import TextField from '../TextField'
+import SymbolIcon from '../SymbolIcon'
+import { useFormSheet } from '../../lib/formSheetHost'
+import { useTheme } from '../../theme/ThemeProvider'
+
+// The Songbook "Customize & export" sheet, presented via the native formSheet
+// route (bottom sheet on phone, centered form sheet on iPad). The owner screen
+// keeps all the option state; this sheet renders it and calls back. Modeled on
+// ShareSetSheet. The single primary action exports the PDF (server-rendered via
+// /api/export/songbook) and hands the file to the share sheet.
+
+export type SongbookOptionsProps = {
+  visible: boolean
+  onClose: () => void
+  songCount: number
+  title: string
+  onChangeTitle: (v: string) => void
+  subtitle: string
+  onChangeSubtitle: (v: string) => void
+  includeTOC: boolean
+  onToggleTOC: (v: boolean) => void
+  coverImageDataUrl: string | null
+  coverName: string | null
+  onPickCover: () => void
+  onClearCover: () => void
+  onExport: () => Promise<void>
+}
+
+export default function SongbookOptionsSheet(props: SongbookOptionsProps) {
+  useFormSheet(props.visible, () => <SongbookOptionsContent {...props} />, props.onClose)
+  return null
+}
+
+function SongbookOptionsContent({
+  onClose,
+  songCount,
+  title,
+  onChangeTitle,
+  subtitle,
+  onChangeSubtitle,
+  includeTOC,
+  onToggleTOC,
+  coverImageDataUrl,
+  coverName,
+  onPickCover,
+  onClearCover,
+  onExport,
+}: SongbookOptionsProps) {
+  const t = useTheme()
+  const { t: tx } = useTranslation('utilities')
+  const insets = useSafeAreaInsets()
+  const [busy, setBusy] = useState(false)
+
+  const runExport = async () => {
+    if (busy || songCount === 0) return
+    setBusy(true)
+    try {
+      await onExport()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <FormSheetShell title={tx('songbook.optionsTitle')} onAction={onClose}>
+      <View style={{ padding: t.spacing.lg, paddingBottom: t.spacing.lg + insets.bottom, gap: t.spacing.lg }}>
+        <TextField
+          label={tx('songbook.nameLabel')}
+          icon="book"
+          value={title}
+          onChangeText={onChangeTitle}
+          placeholder={tx('songbook.namePlaceholder')}
+          autoCapitalize="words"
+        />
+
+        <TextField
+          label={tx('songbook.subtitleLabel')}
+          icon="calendar"
+          value={subtitle}
+          onChangeText={onChangeSubtitle}
+          placeholder={tx('songbook.subtitlePlaceholder')}
+          autoCapitalize="words"
+        />
+
+        {/* TOC toggle */}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: t.spacing.md,
+            padding: t.spacing.md,
+            borderRadius: 13,
+            backgroundColor: t.colors.surfaceAlt,
+            borderWidth: 1,
+            borderColor: t.colors.border,
+          }}
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>
+              {tx('songbook.tocLabel')}
+            </Text>
+            <Text style={{ fontSize: 11.5, color: t.colors.muted, marginTop: 2 }}>
+              {tx('songbook.tocHint')}
+            </Text>
+          </View>
+          <Switch
+            value={includeTOC}
+            onValueChange={onToggleTOC}
+            trackColor={{ true: t.colors.accent, false: t.colors.border }}
+            accessibilityLabel={tx('songbook.tocLabel')}
+          />
+        </View>
+
+        {/* Cover image */}
+        <View style={{ gap: t.spacing.sm }}>
+          <Text style={{ fontSize: 13.5, fontWeight: '600', letterSpacing: -0.1, color: t.colors.sec }}>
+            {tx('songbook.coverLabel')}
+          </Text>
+          {coverImageDataUrl ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: t.spacing.md,
+                padding: t.spacing.sm,
+                borderRadius: 13,
+                backgroundColor: t.colors.surfaceAlt,
+                borderWidth: 1,
+                borderColor: t.colors.border,
+              }}
+            >
+              <Image
+                source={{ uri: coverImageDataUrl }}
+                style={{ width: 40, height: 40, borderRadius: 6, backgroundColor: t.colors.border }}
+                resizeMode="cover"
+              />
+              <Text numberOfLines={1} style={{ flex: 1, fontSize: 14, color: t.colors.ink }}>
+                {coverName || tx('songbook.coverLabel')}
+              </Text>
+              <Pressable
+                onPress={onPickCover}
+                accessibilityRole="button"
+                accessibilityLabel={tx('songbook.replaceCover')}
+                hitSlop={8}
+              >
+                <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.textAccent }}>
+                  {tx('songbook.replaceCover')}
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={onClearCover}
+                accessibilityRole="button"
+                accessibilityLabel={tx('songbook.removeCover')}
+                hitSlop={8}
+              >
+                <SymbolIcon name="trash" size={16} color={t.colors.muted} />
+              </Pressable>
+            </View>
+          ) : (
+            <Pressable
+              onPress={onPickCover}
+              accessibilityRole="button"
+              accessibilityLabel={tx('songbook.addCover')}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 11,
+                padding: t.spacing.md,
+                borderRadius: 13,
+                backgroundColor: t.colors.surfaceAlt,
+                borderWidth: 1,
+                borderColor: t.colors.border,
+              }}
+            >
+              <View
+                style={{
+                  width: 30,
+                  height: 30,
+                  borderRadius: 15,
+                  backgroundColor: t.colors.accentSoft,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <SymbolIcon name="photo" size={15} color={t.colors.accent} />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>
+                  {tx('songbook.addCover')}
+                </Text>
+                <Text style={{ fontSize: 11.5, color: t.colors.muted }}>{tx('songbook.coverHint')}</Text>
+              </View>
+            </Pressable>
+          )}
+        </View>
+
+        {/* Export */}
+        <Pressable
+          onPress={runExport}
+          disabled={busy || songCount === 0}
+          accessibilityRole="button"
+          accessibilityLabel={tx('songbook.exportPdf', { count: songCount })}
+          style={{
+            height: 50,
+            borderRadius: 13,
+            backgroundColor: t.colors.accent,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: t.spacing.sm,
+            opacity: busy || songCount === 0 ? 0.5 : 1,
+          }}
+        >
+          {busy ? (
+            <ActivityIndicator color={t.colors.onAccent} />
+          ) : (
+            <SymbolIcon name="square.and.arrow.up" size={19} color={t.colors.onAccent} />
+          )}
+          <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.onAccent }}>
+            {tx('songbook.exportPdf', { count: songCount })}
+          </Text>
+        </Pressable>
+      </View>
+    </FormSheetShell>
+  )
+}

--- a/apps/mobile/src/i18n/locales/en/utilities.json
+++ b/apps/mobile/src/i18n/locales/en/utilities.json
@@ -6,7 +6,8 @@
   "tools": {
     "tuner": "Tuner",
     "metronome": "Tap Tempo / Metronome",
-    "pitchPipe": "Pitch Pipe"
+    "pitchPipe": "Pitch Pipe",
+    "songbook": "Songbook"
   },
   "tuner": {
     "title": "Tuner",
@@ -41,5 +42,32 @@
     "octaveDown": "Octave down",
     "octaveUp": "Octave up",
     "holdNote": "Hold note"
+  },
+  "songbook": {
+    "title": "Songbook",
+    "defaultTitle": "Songbook",
+    "addSongs": "Add songs",
+    "selectedCount_one": "{{count}} song selected",
+    "selectedCount_other": "{{count}} songs selected",
+    "noneSelected": "No songs selected yet. Add songs to build your songbook.",
+    "removeSong": "Remove {{title}}",
+    "customizeExport": "Customize & export",
+    "optionsTitle": "Songbook options",
+    "nameLabel": "Name",
+    "namePlaceholder": "Songbook",
+    "subtitleLabel": "Subtitle",
+    "subtitlePlaceholder": "Optional subtitle or date",
+    "tocLabel": "Table of contents",
+    "tocHint": "Adds a contents page and numbers each song.",
+    "coverLabel": "Cover image",
+    "addCover": "Add cover image",
+    "replaceCover": "Replace",
+    "removeCover": "Remove cover",
+    "coverHint": "Optional. Replaces the text cover page.",
+    "coverTooLargeTitle": "Image too large",
+    "coverTooLarge": "Please choose a smaller cover image (under about 2 MB).",
+    "pickCoverErrorTitle": "Could not open photos",
+    "exportPdf_one": "Export PDF ({{count}} song)",
+    "exportPdf_other": "Export PDF ({{count}} songs)"
   }
 }

--- a/apps/mobile/src/i18n/locales/es/utilities.json
+++ b/apps/mobile/src/i18n/locales/es/utilities.json
@@ -6,7 +6,8 @@
   "tools": {
     "tuner": "Afinador",
     "metronome": "Marca tempo / Metrónomo",
-    "pitchPipe": "Diapasón"
+    "pitchPipe": "Diapasón",
+    "songbook": "Cancionero"
   },
   "tuner": {
     "title": "Afinador",
@@ -41,5 +42,32 @@
     "octaveDown": "Bajar octava",
     "octaveUp": "Subir octava",
     "holdNote": "Mantener nota"
+  },
+  "songbook": {
+    "title": "Cancionero",
+    "defaultTitle": "Cancionero",
+    "addSongs": "Añadir canciones",
+    "selectedCount_one": "{{count}} canción seleccionada",
+    "selectedCount_other": "{{count}} canciones seleccionadas",
+    "noneSelected": "Aún no hay canciones seleccionadas. Añade canciones para crear tu cancionero.",
+    "removeSong": "Quitar {{title}}",
+    "customizeExport": "Personalizar y exportar",
+    "optionsTitle": "Opciones del cancionero",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "Cancionero",
+    "subtitleLabel": "Subtítulo",
+    "subtitlePlaceholder": "Subtítulo o fecha (opcional)",
+    "tocLabel": "Índice",
+    "tocHint": "Añade una página de índice y numera cada canción.",
+    "coverLabel": "Imagen de portada",
+    "addCover": "Añadir imagen de portada",
+    "replaceCover": "Reemplazar",
+    "removeCover": "Quitar portada",
+    "coverHint": "Opcional. Reemplaza la página de portada de texto.",
+    "coverTooLargeTitle": "Imagen demasiado grande",
+    "coverTooLarge": "Elige una imagen de portada más pequeña (menos de unos 2 MB).",
+    "pickCoverErrorTitle": "No se pudieron abrir las fotos",
+    "exportPdf_one": "Exportar PDF ({{count}} canción)",
+    "exportPdf_other": "Exportar PDF ({{count}} canciones)"
   }
 }

--- a/apps/mobile/src/i18n/locales/ko/utilities.json
+++ b/apps/mobile/src/i18n/locales/ko/utilities.json
@@ -6,7 +6,8 @@
   "tools": {
     "tuner": "튜너",
     "metronome": "탭 템포 / 메트로놈",
-    "pitchPipe": "피치 파이프"
+    "pitchPipe": "피치 파이프",
+    "songbook": "노래책"
   },
   "tuner": {
     "title": "튜너",
@@ -41,5 +42,32 @@
     "octaveDown": "옥타브 내림",
     "octaveUp": "옥타브 올림",
     "holdNote": "음 유지"
+  },
+  "songbook": {
+    "title": "노래책",
+    "defaultTitle": "노래책",
+    "addSongs": "노래 추가",
+    "selectedCount_one": "{{count}}곡 선택됨",
+    "selectedCount_other": "{{count}}곡 선택됨",
+    "noneSelected": "아직 선택된 노래가 없습니다. 노래를 추가해 노래책을 만드세요.",
+    "removeSong": "{{title}} 제거",
+    "customizeExport": "맞춤 설정 및 내보내기",
+    "optionsTitle": "노래책 옵션",
+    "nameLabel": "이름",
+    "namePlaceholder": "노래책",
+    "subtitleLabel": "부제",
+    "subtitlePlaceholder": "부제 또는 날짜 (선택 사항)",
+    "tocLabel": "목차",
+    "tocHint": "목차 페이지를 추가하고 각 노래에 번호를 매깁니다.",
+    "coverLabel": "표지 이미지",
+    "addCover": "표지 이미지 추가",
+    "replaceCover": "교체",
+    "removeCover": "표지 제거",
+    "coverHint": "선택 사항입니다. 텍스트 표지 페이지를 대체합니다.",
+    "coverTooLargeTitle": "이미지가 너무 큼",
+    "coverTooLarge": "더 작은 표지 이미지를 선택하세요 (약 2MB 미만).",
+    "pickCoverErrorTitle": "사진을 열 수 없음",
+    "exportPdf_one": "PDF 내보내기 ({{count}}곡)",
+    "exportPdf_other": "PDF 내보내기 ({{count}}곡)"
   }
 }

--- a/apps/mobile/src/i18n/locales/tr/utilities.json
+++ b/apps/mobile/src/i18n/locales/tr/utilities.json
@@ -6,7 +6,8 @@
   "tools": {
     "tuner": "Akort Aleti",
     "metronome": "Tempo / Metronom",
-    "pitchPipe": "Nota Düdüğü"
+    "pitchPipe": "Nota Düdüğü",
+    "songbook": "Şarkı Kitabı"
   },
   "tuner": {
     "title": "Akort Aleti",
@@ -41,5 +42,32 @@
     "octaveDown": "Oktav aşağı",
     "octaveUp": "Oktav yukarı",
     "holdNote": "Notayı tut"
+  },
+  "songbook": {
+    "title": "Şarkı Kitabı",
+    "defaultTitle": "Şarkı Kitabı",
+    "addSongs": "Şarkı ekle",
+    "selectedCount_one": "{{count}} şarkı seçildi",
+    "selectedCount_other": "{{count}} şarkı seçildi",
+    "noneSelected": "Henüz şarkı seçilmedi. Şarkı kitabınızı oluşturmak için şarkı ekleyin.",
+    "removeSong": "{{title}} kaldır",
+    "customizeExport": "Özelleştir ve dışa aktar",
+    "optionsTitle": "Şarkı kitabı seçenekleri",
+    "nameLabel": "Ad",
+    "namePlaceholder": "Şarkı Kitabı",
+    "subtitleLabel": "Alt başlık",
+    "subtitlePlaceholder": "İsteğe bağlı alt başlık veya tarih",
+    "tocLabel": "İçindekiler",
+    "tocHint": "Bir içindekiler sayfası ekler ve her şarkıyı numaralandırır.",
+    "coverLabel": "Kapak görseli",
+    "addCover": "Kapak görseli ekle",
+    "replaceCover": "Değiştir",
+    "removeCover": "Kapağı kaldır",
+    "coverHint": "İsteğe bağlı. Metin kapak sayfasının yerini alır.",
+    "coverTooLargeTitle": "Görsel çok büyük",
+    "coverTooLarge": "Lütfen daha küçük bir kapak görseli seçin (yaklaşık 2 MB altında).",
+    "pickCoverErrorTitle": "Fotoğraflar açılamadı",
+    "exportPdf_one": "PDF'yi dışa aktar ({{count}} şarkı)",
+    "exportPdf_other": "PDF'yi dışa aktar ({{count}} şarkı)"
   }
 }

--- a/apps/mobile/src/lib/exportSong.ts
+++ b/apps/mobile/src/lib/exportSong.ts
@@ -38,6 +38,38 @@ export async function exportSong(opts: {
   return file.uri
 }
 
+// Songbook export: renders the selected songs to one PDF via the web app's
+// POST /api/export/songbook — a cover page, an optional numbered table of
+// contents, then every song (one per page) in alphabetical order. Songs render
+// in their default key. Writes the bytes to the app cache and returns the local
+// URI for expo-sharing.
+export async function exportSongbook(opts: {
+  items: Array<{ songId: string; key?: string | null }>
+  title?: string
+  subtitle?: string
+  includeTOC?: boolean
+  coverImageDataUrl?: string | null
+}): Promise<string> {
+  const res = await apiPost('/api/export/songbook', {
+    items: opts.items.map((it) => ({ song_id: it.songId, key: it.key || '' })),
+    title: opts.title || '',
+    subtitle: opts.subtitle || '',
+    include_toc: opts.includeTOC !== false,
+    cover_image: opts.coverImageDataUrl || undefined,
+  })
+
+  if (!res.ok) throw await apiError(res, 'export_failed')
+
+  const disposition = res.headers.get('content-disposition') || ''
+  const nameMatch = disposition.match(/filename="([^"]+)"/)
+  const filename = nameMatch?.[1] || 'songbook.pdf'
+
+  const file = new File(Paths.cache, filename)
+  if (file.exists) file.delete()
+  file.write(new Uint8Array(await res.arrayBuffer()))
+  return file.uri
+}
+
 // Whole-set export: renders the ordered setlist to one combined PDF via the
 // web app's POST /api/export/setlist (the multi-song counterpart of
 // /api/export/song), writes the bytes to the app cache, and returns the local

--- a/apps/mobile/src/screens/SongbookBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SongbookBuilderScreen.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Alert, Pressable, ScrollView, Text, View } from 'react-native'
+import { router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTranslation } from 'react-i18next'
+import * as ImagePicker from 'expo-image-picker'
+import * as Sharing from 'expo-sharing'
+import Screen from '../components/Screen'
+import Card from '../components/Card'
+import ListRow from '../components/ListRow'
+import Button from '../components/Button'
+import SectionHeader from '../components/SectionHeader'
+import SymbolIcon from '../components/SymbolIcon'
+import AddSongsModal from '../components/setlist/AddSongsModal'
+import SongbookOptionsSheet from '../components/songbook/SongbookOptionsSheet'
+import { useTheme } from '../theme/ThemeProvider'
+import { useSongList, type Song } from '../lib/useSongList'
+import { exportSongbook } from '../lib/exportSong'
+import { errMessage } from '../lib/errors'
+
+// Utilities tool: build a songbook PDF. Pick songs (reusing the setlist
+// AddSongsModal), optionally name it / add a cover image / toggle a numbered
+// table of contents, then export one combined PDF (server-rendered via
+// /api/export/songbook, the same pdf_mvp engine the web songbook uses) and hand
+// it to the system share sheet. Songs always render alphabetically in their
+// default key.
+//
+// `embedded`: rendered inside the Utilities tab's tablet split (right pane) —
+// drops the back link and top safe-area padding.
+
+// Server rejects a cover data URL over ~3 MB; guard client-side with a friendly
+// message before the round-trip.
+const MAX_COVER_CHARS = 3 * 1024 * 1024
+
+function defaultDate() {
+  const d = new Date()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${mm}.${dd}.${d.getFullYear()}`
+}
+
+export default function SongbookBuilderScreen({ embedded }: { embedded?: boolean }) {
+  const t = useTheme()
+  const { t: tx } = useTranslation(['utilities', 'export', 'nav', 'common'])
+  const insets = useSafeAreaInsets()
+  const { songs, loading } = useSongList()
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const [addOpen, setAddOpen] = useState(false)
+  const [optionsOpen, setOptionsOpen] = useState(false)
+  const [title, setTitle] = useState(() => tx('songbook.defaultTitle'))
+  const [subtitle, setSubtitle] = useState(defaultDate)
+  const [includeTOC, setIncludeTOC] = useState(true)
+  const [coverImageDataUrl, setCoverImageDataUrl] = useState<string | null>(null)
+  const [coverName, setCoverName] = useState<string | null>(null)
+
+  const selectedSongs = useMemo(
+    () => songs.filter((s) => selectedIds.has(s.id)).sort((a, b) => a.title.localeCompare(b.title)),
+    [songs, selectedIds],
+  )
+
+  const toggleSong = useCallback((song: Song) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(song.id)) next.delete(song.id)
+      else next.add(song.id)
+      return next
+    })
+  }, [])
+
+  const pickCover = useCallback(async () => {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        quality: 0.7,
+        base64: true,
+      })
+      if (result.canceled) return
+      const asset = result.assets?.[0]
+      if (!asset?.base64) return
+      const mime = asset.mimeType || 'image/jpeg'
+      const dataUrl = `data:${mime};base64,${asset.base64}`
+      if (dataUrl.length > MAX_COVER_CHARS) {
+        Alert.alert(tx('songbook.coverTooLargeTitle'), tx('songbook.coverTooLarge'))
+        return
+      }
+      setCoverImageDataUrl(dataUrl)
+      setCoverName(asset.fileName || tx('songbook.coverLabel'))
+    } catch (err: unknown) {
+      Alert.alert(tx('songbook.pickCoverErrorTitle'), errMessage(err))
+    }
+  }, [tx])
+
+  const clearCover = useCallback(() => {
+    setCoverImageDataUrl(null)
+    setCoverName(null)
+  }, [])
+
+  const onExport = useCallback(async () => {
+    if (selectedSongs.length === 0) return
+    try {
+      const uri = await exportSongbook({
+        items: selectedSongs.map((s) => ({ songId: s.id })),
+        title: title.trim(),
+        subtitle: subtitle.trim(),
+        includeTOC,
+        coverImageDataUrl,
+      })
+      await Sharing.shareAsync(uri)
+    } catch (err: unknown) {
+      Alert.alert(tx('export:alerts.exportFailedTitle'), errMessage(err))
+    }
+  }, [selectedSongs, title, subtitle, includeTOC, coverImageDataUrl, tx])
+
+  const body = (
+    <>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: t.spacing.lg,
+          paddingBottom: t.spacing.xxl,
+          gap: t.spacing.md,
+        }}
+      >
+        <Button
+          variant="secondary"
+          title={tx('songbook.addSongs')}
+          onPress={() => setAddOpen(true)}
+        />
+
+        <SectionHeader label={tx('songbook.selectedCount', { count: selectedSongs.length })} />
+
+        {selectedSongs.length === 0 ? (
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted, paddingHorizontal: t.spacing.xs }}>
+            {tx('songbook.noneSelected')}
+          </Text>
+        ) : (
+          <Card>
+            {selectedSongs.map((s, i) => (
+              <ListRow
+                key={s.id}
+                title={s.title}
+                subtitle={s.artist}
+                trailingTop={s.default_key}
+                isLast={i === selectedSongs.length - 1}
+                accessibilityLabel={tx('songbook.removeSong', { title: s.title })}
+                onPress={() => toggleSong(s)}
+                trailing={
+                  <View
+                    style={{
+                      width: 30,
+                      height: 30,
+                      borderRadius: t.radii.pill,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: t.colors.accentSoft,
+                    }}
+                  >
+                    <SymbolIcon name="minus" size={15} weight="semibold" color={t.colors.textAccent} />
+                  </View>
+                }
+              />
+            ))}
+          </Card>
+        )}
+      </ScrollView>
+
+      {/* Pinned export CTA */}
+      <View
+        style={{
+          paddingHorizontal: t.spacing.lg,
+          paddingTop: t.spacing.md,
+          paddingBottom: (embedded ? t.spacing.md : insets.bottom) + t.spacing.sm,
+          borderTopWidth: 1,
+          borderTopColor: t.colors.border,
+          backgroundColor: t.colors.bg,
+        }}
+      >
+        <Button
+          variant="primary"
+          title={tx('songbook.customizeExport')}
+          disabled={selectedSongs.length === 0}
+          onPress={() => setOptionsOpen(true)}
+        />
+      </View>
+
+      <AddSongsModal
+        visible={addOpen}
+        onClose={() => setAddOpen(false)}
+        songs={songs}
+        addedSongIds={selectedIds}
+        onToggle={toggleSong}
+      />
+
+      <SongbookOptionsSheet
+        visible={optionsOpen}
+        onClose={() => setOptionsOpen(false)}
+        songCount={selectedSongs.length}
+        title={title}
+        onChangeTitle={setTitle}
+        subtitle={subtitle}
+        onChangeSubtitle={setSubtitle}
+        includeTOC={includeTOC}
+        onToggleTOC={setIncludeTOC}
+        coverImageDataUrl={coverImageDataUrl}
+        coverName={coverName}
+        onPickCover={pickCover}
+        onClearCover={clearCover}
+        onExport={onExport}
+      />
+    </>
+  )
+
+  return (
+    <Screen edges={embedded ? ['left', 'right'] : ['top', 'left', 'right']}>
+      {/* Top bar: back link (route) or spacer (embedded), centered title. */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingTop: embedded ? t.spacing.sm : t.spacing.xs,
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        {embedded ? (
+          <View style={{ width: 90 }} />
+        ) : (
+          <Pressable
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel={tx('common:back')}
+            hitSlop={8}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 2, width: 90 }}
+          >
+            <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+          </Pressable>
+        )}
+        <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('songbook.title')}</Text>
+        <View style={{ width: 90 }} />
+      </View>
+
+      {loading && songs.length === 0 ? (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+            {tx('common:loading')}
+          </Text>
+        </View>
+      ) : (
+        body
+      )}
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/UtilitiesScreen.tsx
+++ b/apps/mobile/src/screens/UtilitiesScreen.tsx
@@ -11,6 +11,7 @@ import SymbolIcon from '../components/SymbolIcon'
 import TunerScreen from './TunerScreen'
 import MetronomeScreen from './MetronomeScreen'
 import PitchPipeScreen from './PitchPipeScreen'
+import SongbookBuilderScreen from './SongbookBuilderScreen'
 import { useTheme } from '../theme/ThemeProvider'
 import { useIsTabletWidth } from '../lib/useIsTabletWidth'
 import type { Tokens } from '@gracechords/tokens/native'
@@ -45,7 +46,7 @@ function RowIcon({ name, t }: { name: Parameters<typeof SymbolIcon>[0]['name']; 
   )
 }
 
-type ToolRoute = '/tuner' | '/metronome' | '/pitch-pipe'
+type ToolRoute = '/tuner' | '/metronome' | '/pitch-pipe' | '/songbook'
 
 const UTILITIES: {
   icon: Parameters<typeof SymbolIcon>[0]['name']
@@ -55,6 +56,7 @@ const UTILITIES: {
   { icon: 'tuningfork', titleKey: 'tools.tuner', route: '/tuner' },
   { icon: 'metronome', titleKey: 'tools.metronome', route: '/metronome' },
   { icon: 'pianokeys', titleKey: 'tools.pitchPipe', route: '/pitch-pipe' },
+  { icon: 'book', titleKey: 'tools.songbook', route: '/songbook' },
 ]
 
 export default function UtilitiesScreen() {
@@ -135,6 +137,8 @@ export default function UtilitiesScreen() {
             <MetronomeScreen embedded />
           ) : tool === '/pitch-pipe' ? (
             <PitchPipeScreen embedded />
+          ) : tool === '/songbook' ? (
+            <SongbookBuilderScreen embedded />
           ) : (
             <View
               style={{

--- a/apps/web/functions/api/export/songbook.js
+++ b/apps/web/functions/api/export/songbook.js
@@ -1,0 +1,122 @@
+// POST /api/export/songbook
+//   Body: {
+//     items: [{ song_id: uuid, key?: string }]   (max 200),
+//     title?: string,          // cover title
+//     subtitle?: string,       // cover subtitle (e.g. a date)
+//     include_toc?: boolean,   // default true; also numbers song titles
+//     cover_image?: string     // optional data: URL used as the cover page
+//   }
+//   Headers: Authorization: Bearer <supabase access token>
+//
+// Renders a songbook — a cover page, an optional numbered table of contents,
+// then every song (one per page) in alphabetical order — to a single PDF using
+// the same DOM-free pdf_mvp engine the browser songbook and the setlist export
+// use. Returns application/pdf bytes. This is the multi-song counterpart to
+// /api/export/setlist with cover + TOC front matter; songs render in their
+// default (or requested) key.
+//
+// Fonts: registers Noto from R2 (makeFontRegistrar) so output matches the
+// browser + Telegram bot, falling back to Helvetica/Courier if R2 is absent.
+
+import { renderSongbookPdfBuffer } from '../../../src/utils/pdf_mvp/pure.js'
+import { toRenderableSong } from '../../../src/utils/pdf_mvp/serverSong.js'
+import { makeFontRegistrar } from '../../../src/utils/pdf_mvp/fontsR2.js'
+import {
+  UUID_RE,
+  corsPreflight,
+  ensureWindowShim,
+  fetchSongsByFilter,
+  jsonError,
+  verifySupabaseJwt,
+} from './_shared.js'
+
+ensureWindowShim()
+
+const MAX_ITEMS = 200
+// ~3 MB of base64 data covers a reasonably sized cover image without letting a
+// runaway payload tie up the renderer.
+const MAX_COVER_CHARS = 3 * 1024 * 1024
+
+function sanitizeFilename(name) {
+  const base = String(name || 'songbook').replace(/[\\/:*?"<>|]+/g, '_').trim()
+  return base || 'songbook'
+}
+
+export async function onRequest(context) {
+  const { request, env } = context
+
+  if (request.method === 'OPTIONS') return corsPreflight(request)
+  if (request.method !== 'POST') return jsonError('Method not allowed', 405)
+
+  const auth = await verifySupabaseJwt(request, env)
+  if (auth.error) return jsonError(auth.error, auth.status)
+
+  let body
+  try {
+    body = await request.json()
+  } catch {
+    return jsonError('Invalid JSON', 400)
+  }
+
+  const items = Array.isArray(body?.items) ? body.items : null
+  if (!items || items.length === 0) return jsonError('items required', 400)
+  if (items.length > MAX_ITEMS) return jsonError(`Too many items (max ${MAX_ITEMS})`, 400)
+
+  const normalized = []
+  for (const it of items) {
+    const songId = typeof it?.song_id === 'string' ? it.song_id.trim() : ''
+    if (!UUID_RE.test(songId)) return jsonError('each item.song_id must be a UUID', 400)
+    const key = typeof it?.key === 'string' ? it.key.trim() : ''
+    normalized.push({ song_id: songId, key })
+  }
+
+  const title = typeof body?.title === 'string' && body.title.trim() ? body.title.trim() : 'Songbook'
+  const subtitle = typeof body?.subtitle === 'string' ? body.subtitle.trim() : ''
+  const includeTOC = body?.include_toc !== false
+
+  let coverImageDataUrl = null
+  if (body?.cover_image != null) {
+    if (typeof body.cover_image !== 'string' || !body.cover_image.startsWith('data:image/')) {
+      return jsonError('cover_image must be a data:image/ URL', 400)
+    }
+    if (body.cover_image.length > MAX_COVER_CHARS) {
+      return jsonError('cover_image too large', 413)
+    }
+    coverImageDataUrl = body.cover_image
+  }
+
+  // One query for all unique ids, then map back (dropping any id the query
+  // didn't return, e.g. soft-deleted since). The renderer sorts alphabetically.
+  const uniqueIds = [...new Set(normalized.map((n) => n.song_id))]
+  const inList = uniqueIds.map((id) => encodeURIComponent(id)).join(',')
+  const found = await fetchSongsByFilter(env, `id=in.(${inList})`)
+  if (found.error) return jsonError(found.error, found.status)
+  const rowById = new Map(found.rows.map((r) => [r.id, r]))
+
+  const renderables = []
+  for (const n of normalized) {
+    const row = rowById.get(n.song_id)
+    if (row) renderables.push(toRenderableSong(row, n.key))
+  }
+  if (renderables.length === 0) return jsonError('No songs found', 404)
+
+  let pdf
+  try {
+    pdf = await renderSongbookPdfBuffer(renderables, {
+      includeTOC,
+      coverImageDataUrl,
+      title,
+      subtitle,
+      registerFonts: makeFontRegistrar(env),
+    })
+  } catch (err) {
+    return jsonError(`Render failed: ${err?.message || err}`, 500)
+  }
+
+  return new Response(pdf, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="${sanitizeFilename(title)}.pdf"`,
+    },
+  })
+}

--- a/apps/web/src/__tests__/pdf_mvp.songbook.test.js
+++ b/apps/web/src/__tests__/pdf_mvp.songbook.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { renderSongbookPdfDoc, renderSongbookPdfBuffer } from '../utils/pdf_mvp/pure.js'
+
+// Small single-page songs (short body → one page each) so page-count math is
+// deterministic: front matter is 1 cover page + (TOC ? tocPages : 0), and each
+// song is exactly one page. With ≤ ~43 entries the TOC fits on a single page.
+function tinySong(title) {
+  return {
+    title,
+    key: 'C',
+    lyricsBlocks: [
+      {
+        section: 'Verse',
+        lines: [{ plain: 'la la la', chordPositions: [{ sym: 'C', index: 0 }] }],
+      },
+    ],
+  }
+}
+
+describe('songbook PDF renderer', () => {
+  it('returns non-empty bytes', async () => {
+    const bytes = await renderSongbookPdfBuffer([tinySong('Amazing Grace')], {})
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes.length).toBeGreaterThan(0)
+  })
+
+  it('returns null for an empty song list', async () => {
+    const res = await renderSongbookPdfDoc([], {})
+    expect(res).toBeNull()
+  })
+
+  it('with TOC on: cover + 1 TOC page + one page per song', async () => {
+    const songs = [tinySong('Cornerstone'), tinySong('Amazing Grace'), tinySong('Blessed Be')]
+    const { doc } = await renderSongbookPdfDoc(songs, { includeTOC: true })
+    // 1 cover + 1 TOC + 3 songs
+    expect(doc.getNumberOfPages()).toBe(5)
+  })
+
+  it('with TOC off: cover + one page per song, no TOC page', async () => {
+    const songs = [tinySong('Cornerstone'), tinySong('Amazing Grace'), tinySong('Blessed Be')]
+    const { doc } = await renderSongbookPdfDoc(songs, { includeTOC: false })
+    // 1 cover + 3 songs (no TOC)
+    expect(doc.getNumberOfPages()).toBe(4)
+  })
+
+  it('renders alphabetically regardless of input order', async () => {
+    const forward = [tinySong('Apple'), tinySong('Mango'), tinySong('Zebra')]
+    const shuffled = [tinySong('Zebra'), tinySong('Apple'), tinySong('Mango')]
+    const a = await renderSongbookPdfDoc(forward, { includeTOC: true })
+    const b = await renderSongbookPdfDoc(shuffled, { includeTOC: true })
+    // Same alphabetized content → same page count from either input order.
+    expect(a.doc.getNumberOfPages()).toBe(b.doc.getNumberOfPages())
+  })
+
+  it('accepts a cover image data URL without throwing', async () => {
+    // 1x1 transparent PNG.
+    const png =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+    const { doc } = await renderSongbookPdfDoc([tinySong('Doxology')], {
+      includeTOC: true,
+      coverImageDataUrl: png,
+    })
+    expect(doc.getNumberOfPages()).toBe(3) // cover + TOC + 1 song
+  })
+})

--- a/apps/web/src/utils/pdf_mvp/index.js
+++ b/apps/web/src/utils/pdf_mvp/index.js
@@ -5,18 +5,14 @@
 //
 // Decision ladder, sectionising, and layout math live in pure.js.
 
-import { applyFooterToAllPages } from './footer'
 import { registerPdfFonts } from './fonts.js'
 import {
-  createDoc,
   renderSingleSongPdfDoc,
   renderMultiSongPdfDoc,
+  renderSongbookPdfDoc,
   planSingleSong as planSingleSongPure,
-  __internal,
   __test as __testPure,
 } from './pure.js'
-
-const { PAGE, MARGINS, TITLE_PT, SUBTITLE_PT, sectionify, planForSong, renderPlanned, drawTextSafe } = __internal
 
 function triggerDownload(blob, filename){
   const a = document.createElement('a')
@@ -51,147 +47,19 @@ export async function downloadMultiSongPdf(songs = []){
 
 export async function downloadSongbookPdf(songs = [], { includeTOC = true, coverImageDataUrl = null } = {}){
   if (!Array.isArray(songs) || songs.length === 0) return
-  const doc = createDoc()
-  await registerPdfFonts(doc)
-  try { doc.setFont('NotoSans', 'normal') } catch { try { doc.setFont('helvetica', 'normal') } catch {} }
-  try { doc.setTextColor(0,0,0) } catch {}
-
-  const pre = []
-  for (const s of songs){
-    const plan = planForSong(doc, s)
-    pre.push({ song: s, plan, sections: sectionify(s) })
-  }
-
-  let pageNo = 1
-  if (coverImageDataUrl){
-    try {
-      const availW = PAGE.w - MARGINS.left - MARGINS.right
-      const availH = PAGE.h - MARGINS.top - MARGINS.bottom
-      const img = await new Promise((resolve, reject) => {
-        const i = new Image()
-        i.onload = () => resolve(i)
-        i.onerror = reject
-        i.src = coverImageDataUrl
-      })
-      const scale = Math.min(availW / img.width, availH / img.height)
-      const w = img.width * scale
-      const h = img.height * scale
-      const x = MARGINS.left + (availW - w) / 2
-      const y = MARGINS.top + (availH - h) / 2
-      doc.addImage(coverImageDataUrl, undefined, x, y, w, h, undefined, 'FAST')
-    } catch {
-      try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
-      doc.setFontSize(TITLE_PT)
-      try { doc.text('GraceChords Songbook', PAGE.w/2, PAGE.h/2 - 10, { align: 'center', baseline: 'middle' }) } catch {}
-      try { doc.setFont('NotoSans', 'italic') } catch { try { doc.setFont('helvetica', 'italic') } catch {} }
-      doc.setFontSize(SUBTITLE_PT)
-      try { doc.setTextColor(90,90,90) } catch {}
-      const d1 = new Date();
-      const mm1 = String(d1.getMonth() + 1).padStart(2, '0');
-      const dd1 = String(d1.getDate()).padStart(2, '0');
-      const yyyy1 = d1.getFullYear();
-      const dateStr1 = `${mm1}.${dd1}.${yyyy1}`
-      try { doc.text(dateStr1, PAGE.w/2, PAGE.h/2 + 14, { align: 'center', baseline: 'middle' }) } catch {}
-      try { doc.setTextColor(0,0,0) } catch {}
-    }
-    pageNo++
-  } else {
-    try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
-    doc.setFontSize(TITLE_PT)
-    try { doc.text('GraceChords Songbook', PAGE.w/2, PAGE.h/2 - 10, { align: 'center', baseline: 'middle' }) } catch {}
-    try { doc.setFont('NotoSans', 'italic') } catch { try { doc.setFont('helvetica', 'italic') } catch {} }
-    doc.setFontSize(SUBTITLE_PT)
-    try { doc.setTextColor(90,90,90) } catch {}
-    const d2 = new Date();
-    const mm2 = String(d2.getMonth() + 1).padStart(2, '0');
-    const dd2 = String(d2.getDate()).padStart(2, '0');
-    const yyyy2 = d2.getFullYear();
-    const dateStr2 = `${mm2}.${dd2}.${yyyy2}`
-    try { doc.text(dateStr2, PAGE.w/2, PAGE.h/2 + 14, { align: 'center', baseline: 'middle' }) } catch {}
-    try { doc.setTextColor(0,0,0) } catch {}
-    pageNo++
-  }
-
-  const entries = pre.length
-  const lineH = 16
-  const yStartFirst = MARGINS.top + 24
-  const rowsPerColFirst = Math.max(1, Math.floor((PAGE.h - MARGINS.bottom - yStartFirst) / lineH))
-  const rowsPerColNext  = Math.max(1, Math.floor((PAGE.h - MARGINS.bottom - MARGINS.top) / lineH))
-
-  let tocPages = 0
-  if (includeTOC) {
-    if (entries <= rowsPerColFirst) tocPages = 1
-    else if (entries <= 2 * rowsPerColFirst) tocPages = 1
-    else {
-      const remaining = Math.max(0, entries - 2 * rowsPerColFirst)
-      const extraPages = Math.ceil(remaining / (2 * rowsPerColNext))
-      tocPages = 1 + extraPages
-    }
-  }
-
-  if (includeTOC){
-    const leftX = MARGINS.left
-    const rightX = PAGE.w / 2 + 10
-
-    doc.addPage([PAGE.w, PAGE.h])
-    try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
-    doc.setFontSize(18)
-    drawTextSafe(doc, 'Table of Contents', MARGINS.left, MARGINS.top)
-    try { doc.setFont('NotoSans', 'normal') } catch { try { doc.setFont('helvetica', 'normal') } catch {} }
-    doc.setFontSize(11)
-
-    let idx = 0
-    if (entries <= rowsPerColFirst) {
-      let y = yStartFirst
-      while (idx < entries && y <= PAGE.h - MARGINS.bottom - lineH) {
-        const title = String(pre[idx].song?.title || 'Untitled')
-        drawTextSafe(doc, `${idx+1}. ${title}`, leftX, y)
-        y += lineH
-        idx++
-      }
-    } else {
-      let yL = yStartFirst, yR = yStartFirst
-      for (let c = 0; c < rowsPerColFirst && idx < entries; c++, idx++) {
-        const title = String(pre[idx].song?.title || 'Untitled')
-        drawTextSafe(doc, `${idx+1}. ${title}`, leftX, yL)
-        yL += lineH
-      }
-      for (let c = 0; c < rowsPerColFirst && idx < entries; c++, idx++) {
-        const title = String(pre[idx].song?.title || 'Untitled')
-        drawTextSafe(doc, `${idx+1}. ${title}`, rightX, yR)
-        yR += lineH
-      }
-
-      while (idx < entries) {
-        doc.addPage([PAGE.w, PAGE.h])
-        try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
-        doc.setFontSize(18)
-        drawTextSafe(doc, 'Table of Contents (continued)', MARGINS.left, MARGINS.top)
-        try { doc.setFont('NotoSans', 'normal') } catch { try { doc.setFont('helvetica', 'normal') } catch {} }
-        doc.setFontSize(11)
-        let yL2 = MARGINS.top + 24, yR2 = MARGINS.top + 24
-        for (let c = 0; c < rowsPerColNext && idx < entries; c++, idx++) {
-          const title = String(pre[idx].song?.title || 'Untitled')
-          drawTextSafe(doc, `${idx+1}. ${title}`, leftX, yL2)
-          yL2 += lineH
-        }
-        for (let c = 0; c < rowsPerColNext && idx < entries; c++, idx++) {
-          const title = String(pre[idx].song?.title || 'Untitled')
-          drawTextSafe(doc, `${idx+1}. ${title}`, rightX, yR2)
-          yR2 += lineH
-        }
-      }
-    }
-  }
-
-  for (let i = 0; i < pre.length; i++){
-    doc.addPage([PAGE.w, PAGE.h])
-    const numbered = { ...pre[i].song, title: `${i+1}. ${pre[i].song?.title || 'Untitled'}` }
-    renderPlanned(doc, pre[i].plan, pre[i].sections, numbered)
-  }
-  const prePages = 1 + (includeTOC ? tocPages : 0)
-  applyFooterToAllPages(doc, { left: MARGINS.left, bottom: MARGINS.bottom }, { w: PAGE.w, h: PAGE.h }, { startPage: prePages + 1 })
-  const blob = doc.output('blob')
+  const d = new Date()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const subtitle = `${mm}.${dd}.${d.getFullYear()}`
+  const res = await renderSongbookPdfDoc(songs, {
+    includeTOC,
+    coverImageDataUrl,
+    title: 'GraceChords Songbook',
+    subtitle,
+    registerFonts: registerPdfFonts,
+  })
+  if (!res) return
+  const blob = res.doc.output('blob')
   triggerDownload(blob, `songbook-${new Date().toISOString().slice(0,10)}.pdf`)
 }
 

--- a/apps/web/src/utils/pdf_mvp/pure.js
+++ b/apps/web/src/utils/pdf_mvp/pure.js
@@ -17,6 +17,7 @@
 import { jsPDF } from 'jspdf'
 import { applyFooterToAllPages } from './footer'
 import { formatInstrumental } from '../songs/instrumental.js'
+import { compareSongsByTitle } from '../songs/sort.js'
 
 const PAGE = { w: 612, h: 792 } // Letter
 const MARGINS = { top: 36, right: 36, bottom: 36, left: 36 }
@@ -436,6 +437,166 @@ export async function renderSingleSongPdfBuffer(song, opts = {}){
 
 export async function renderMultiSongPdfBuffer(songs, opts = {}){
   const res = await renderMultiSongPdfDoc(songs, opts)
+  if (!res) return new Uint8Array(0)
+  return bufferOf(res.doc)
+}
+
+// Songbook: a cover page, an optional numbered table of contents, then every
+// song (one per page) in alphabetical order. DOM-free — the cover image is
+// sized via jsPDF's getImageProperties (not `new Image()`), so this runs both
+// in the browser (via ./index.js) and server-side (the /api/export/songbook
+// Pages Function). `subtitle` is supplied by the caller (e.g. a date string)
+// to keep this function deterministic. When `includeTOC` is false, no TOC
+// pages are emitted and song titles are not numbered.
+export async function renderSongbookPdfDoc(songs = [], {
+  includeTOC = true,
+  coverImageDataUrl = null,
+  title = 'GraceChords Songbook',
+  subtitle = '',
+  registerFonts,
+} = {}){
+  if (!Array.isArray(songs) || songs.length === 0) return null
+
+  const ordered = songs.slice().sort(compareSongsByTitle)
+
+  const doc = createDoc()
+  await applyFonts(doc, registerFonts)
+
+  const pre = []
+  for (const s of ordered){
+    const plan = planForSong(doc, s)
+    pre.push({ song: s, plan, sections: sectionify(s) })
+  }
+
+  // --- Cover page ---------------------------------------------------------
+  const drawTextCover = () => {
+    try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
+    doc.setFontSize(TITLE_PT)
+    try { doc.text(title, PAGE.w / 2, PAGE.h / 2 - 10, { align: 'center', baseline: 'middle' }) } catch {}
+    if (subtitle) {
+      try { doc.setFont('NotoSans', 'italic') } catch { try { doc.setFont('helvetica', 'italic') } catch {} }
+      doc.setFontSize(SUBTITLE_PT)
+      try { doc.setTextColor(90, 90, 90) } catch {}
+      try { doc.text(subtitle, PAGE.w / 2, PAGE.h / 2 + 14, { align: 'center', baseline: 'middle' }) } catch {}
+      try { doc.setTextColor(0, 0, 0) } catch {}
+    }
+  }
+
+  if (coverImageDataUrl){
+    try {
+      const availW = PAGE.w - MARGINS.left - MARGINS.right
+      const availH = PAGE.h - MARGINS.top - MARGINS.bottom
+      const props = doc.getImageProperties(coverImageDataUrl)
+      const iw = props?.width
+      const ih = props?.height
+      if (!iw || !ih) throw new Error('image has no dimensions')
+      const scale = Math.min(availW / iw, availH / ih)
+      const w = iw * scale
+      const h = ih * scale
+      const x = MARGINS.left + (availW - w) / 2
+      const y = MARGINS.top + (availH - h) / 2
+      doc.addImage(coverImageDataUrl, undefined, x, y, w, h, undefined, 'FAST')
+    } catch {
+      drawTextCover()
+    }
+  } else {
+    drawTextCover()
+  }
+
+  // --- Table of contents (optional) --------------------------------------
+  const entries = pre.length
+  const lineH = 16
+  const yStartFirst = MARGINS.top + 24
+  const rowsPerColFirst = Math.max(1, Math.floor((PAGE.h - MARGINS.bottom - yStartFirst) / lineH))
+  const rowsPerColNext = Math.max(1, Math.floor((PAGE.h - MARGINS.bottom - MARGINS.top) / lineH))
+
+  let tocPages = 0
+  if (includeTOC){
+    if (entries <= rowsPerColFirst) tocPages = 1
+    else if (entries <= 2 * rowsPerColFirst) tocPages = 1
+    else {
+      const remaining = Math.max(0, entries - 2 * rowsPerColFirst)
+      const extraPages = Math.ceil(remaining / (2 * rowsPerColNext))
+      tocPages = 1 + extraPages
+    }
+
+    const leftX = MARGINS.left
+    const rightX = PAGE.w / 2 + 10
+
+    doc.addPage([PAGE.w, PAGE.h])
+    try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
+    doc.setFontSize(18)
+    drawTextSafe(doc, 'Table of Contents', MARGINS.left, MARGINS.top)
+    try { doc.setFont('NotoSans', 'normal') } catch { try { doc.setFont('helvetica', 'normal') } catch {} }
+    doc.setFontSize(11)
+
+    let idx = 0
+    if (entries <= rowsPerColFirst){
+      let y = yStartFirst
+      while (idx < entries && y <= PAGE.h - MARGINS.bottom - lineH){
+        const t = String(pre[idx].song?.title || 'Untitled')
+        drawTextSafe(doc, `${idx + 1}. ${t}`, leftX, y)
+        y += lineH
+        idx++
+      }
+    } else {
+      let yL = yStartFirst
+      for (let c = 0; c < rowsPerColFirst && idx < entries; c++, idx++){
+        const t = String(pre[idx].song?.title || 'Untitled')
+        drawTextSafe(doc, `${idx + 1}. ${t}`, leftX, yL)
+        yL += lineH
+      }
+      let yR = yStartFirst
+      for (let c = 0; c < rowsPerColFirst && idx < entries; c++, idx++){
+        const t = String(pre[idx].song?.title || 'Untitled')
+        drawTextSafe(doc, `${idx + 1}. ${t}`, rightX, yR)
+        yR += lineH
+      }
+
+      while (idx < entries){
+        doc.addPage([PAGE.w, PAGE.h])
+        try { doc.setFont('NotoSans', 'bold') } catch { try { doc.setFont('helvetica', 'bold') } catch {} }
+        doc.setFontSize(18)
+        drawTextSafe(doc, 'Table of Contents (continued)', MARGINS.left, MARGINS.top)
+        try { doc.setFont('NotoSans', 'normal') } catch { try { doc.setFont('helvetica', 'normal') } catch {} }
+        doc.setFontSize(11)
+        let yL2 = MARGINS.top + 24
+        for (let c = 0; c < rowsPerColNext && idx < entries; c++, idx++){
+          const t = String(pre[idx].song?.title || 'Untitled')
+          drawTextSafe(doc, `${idx + 1}. ${t}`, leftX, yL2)
+          yL2 += lineH
+        }
+        let yR2 = MARGINS.top + 24
+        for (let c = 0; c < rowsPerColNext && idx < entries; c++, idx++){
+          const t = String(pre[idx].song?.title || 'Untitled')
+          drawTextSafe(doc, `${idx + 1}. ${t}`, rightX, yR2)
+          yR2 += lineH
+        }
+      }
+    }
+  }
+
+  // --- Songs (one per page) ----------------------------------------------
+  for (let i = 0; i < pre.length; i++){
+    doc.addPage([PAGE.w, PAGE.h])
+    const baseTitle = pre[i].song?.title || 'Untitled'
+    const displayTitle = includeTOC ? `${i + 1}. ${baseTitle}` : baseTitle
+    const numbered = { ...pre[i].song, title: displayTitle }
+    renderPlanned(doc, pre[i].plan, pre[i].sections, numbered)
+  }
+
+  const prePages = 1 + (includeTOC ? tocPages : 0)
+  applyFooterToAllPages(
+    doc,
+    { left: MARGINS.left, bottom: MARGINS.bottom },
+    { w: PAGE.w, h: PAGE.h },
+    { startPage: prePages + 1 },
+  )
+  return { doc }
+}
+
+export async function renderSongbookPdfBuffer(songs, opts = {}){
+  const res = await renderSongbookPdfDoc(songs, opts)
   if (!res) return new Uint8Array(0)
   return bufferOf(res.doc)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "expo-font": "~55.0.8",
         "expo-glass-effect": "55.0.11",
         "expo-haptics": "~55.0.15",
+        "expo-image-picker": "~55.0.21",
         "expo-keep-awake": "~55.0.8",
         "expo-linear-gradient": "~55.0.15",
         "expo-linking": "~55.0.16",
@@ -945,6 +946,27 @@
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-55.0.15.tgz",
       "integrity": "sha512-RREAflKxOIPAJ5l5M22eHUDU4PGetH2xvQN4ihN4rNEKrzbxrxI2e8yf3MopujCOz5aV5JO1gaGezdJbWEeS9w==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-image-loader": {
+      "version": "55.0.1",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.1.tgz",
+      "integrity": "sha512-o8gCo1j59XpXDh0/llgNYPcnfecYQhafQAO0yw5pb+kukPizvNoEqea8tFQIIQmNYqxd6Ljgs7lLXed0gXpOdQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-image-picker": {
+      "version": "55.0.22",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.22.tgz",
+      "integrity": "sha512-pO/CJ2kjZ6HFSEjVlBMF7TiQVHai3M4itkWP9EklQP/grJGN6X4Yd4LK6acRwpkC+Icn7kiJhxN5sXgxNanXHA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.1"
+      },
       "peerDependencies": {
         "expo": "*"
       }


### PR DESCRIPTION
## Summary
Adds a new "Songbook" utility tool that allows users to select multiple songs, customize a cover page with title/subtitle/image, optionally include a table of contents, and export them as a single PDF. The feature is available on both mobile and web platforms.

## Key Changes

### Mobile App
- **New screen**: `SongbookBuilderScreen` — main UI for selecting songs and triggering export, with support for embedded mode (tablet split view in Utilities)
- **New sheet**: `SongbookOptionsSheet` — bottom sheet/form sheet for customizing songbook metadata (title, subtitle, TOC toggle, cover image picker)
- **Export function**: `exportSongbook()` in `exportSong.ts` — calls `/api/export/songbook` endpoint and returns local file URI for sharing
- **Route**: `app/songbook.tsx` — navigation entry point for the songbook builder
- **Utilities integration**: Updated `UtilitiesScreen` to include songbook tool in the tools list
- **i18n**: Added songbook strings to all locale files (en, es, ko, tr) with pluralization support
- **Dependencies**: Added `expo-image-picker` for cover image selection

### Web/API
- **New endpoint**: `POST /api/export/songbook` — server-side PDF renderer that accepts items, title, subtitle, TOC flag, and cover image data URL; returns PDF bytes
- **PDF renderer**: `renderSongbookPdfDoc()` and `renderSongbookPdfBuffer()` in `pure.js` — DOM-free PDF generation with cover page, optional numbered TOC, and alphabetically sorted songs (one per page)
- **Refactoring**: Extracted songbook rendering logic from browser `index.js` into reusable `pure.js` functions for server-side use
- **Tests**: Added `pdf_mvp.songbook.test.js` covering page count math, alphabetical ordering, and cover image handling

## Implementation Details

- **Alphabetical ordering**: Songs always render alphabetically by title in their default key, regardless of selection order
- **Cover image handling**: Client-side validation limits cover data URLs to ~3 MB before upload; server-side uses jsPDF's `getImageProperties()` for DOM-free sizing, with fallback to text cover on error
- **TOC logic**: When enabled, adds a numbered table of contents page(s) and prefixes song titles with numbers; layout adapts for single or multi-page TOC based on entry count
- **Deterministic rendering**: Server function accepts explicit `subtitle` parameter (e.g., date string) to ensure consistent output across requests
- **Reusable PDF engine**: Shares the same `pdf_mvp` rendering pipeline as setlist export and web songbook, ensuring visual consistency

https://claude.ai/code/session_016fXmir6PVfDQmRuFHJ3Gtk