### PR TITLE
Fix hero gradient overscroll appearance on mobile

### DIFF
--- a/apps/mobile/src/components/HeroOverscrollFill.tsx
+++ b/apps/mobile/src/components/HeroOverscrollFill.tsx
@@ -1,0 +1,23 @@
+import { View } from 'react-native'
+import { useTheme } from '../theme/ThemeProvider'
+
+// Fills the top overscroll region of a ScrollView whose first child is the hero
+// gradient. Without it, a downward bounce past the top reveals the dark page
+// background as a black void; this extends the gradient's top color upward so
+// the bounce reads as more hero. The negative margin cancels the height, so it
+// occupies the strip above content y=0 (only ever seen while overscrolling) and
+// adds no layout. Render it as the FIRST child of the ScrollView content.
+
+export default function HeroOverscrollFill() {
+  const t = useTheme()
+  return (
+    <View
+      pointerEvents="none"
+      style={{
+        height: 600,
+        marginTop: -600,
+        backgroundColor: t.colors.heroGradient.colors[0],
+      }}
+    />
+  )
+}

--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -16,6 +16,7 @@ import { useRouter } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '../theme/ThemeProvider'
 import ConstrainedContent from '../components/ConstrainedContent'
+import HeroOverscrollFill from '../components/HeroOverscrollFill'
 import TextField from '../components/TextField'
 import SymbolIcon from '../components/SymbolIcon'
 import { supabase } from '../lib/supabase'
@@ -98,6 +99,7 @@ export default function AuthScreen() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: t.spacing.xl }}
       >
+        <HeroOverscrollFill />
         {/* Hero band: the sanctioned atmospheric gradient (same tokens as Home). */}
         <LinearGradient
           colors={t.colors.heroGradient.colors}

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import ConstrainedContent from '../components/ConstrainedContent'
+import HeroOverscrollFill from '../components/HeroOverscrollFill'
 import SymbolIcon from '../components/SymbolIcon'
 import DailyWordCard from '../components/home/DailyWordCard'
 import RecentSongsCard from '../components/home/RecentSongsCard'
@@ -272,6 +273,7 @@ export default function HomeScreen() {
         // under native tabs) so the last card scrolls fully above it.
         contentContainerStyle={{ paddingBottom: insets.bottom + t.spacing.xl }}
       >
+        <HeroOverscrollFill />
         {/* ===== Hero ===== */}
         <View>
           <LinearGradient


### PR DESCRIPTION
## Summary
Adds a `HeroOverscrollFill` component to prevent the dark page background from showing as a black void when users overscroll past the top of ScrollViews with hero gradients. The component extends the gradient's top color into the overscroll region.

## Changes
- **New component**: `HeroOverscrollFill.tsx` — A zero-layout View that fills the top overscroll region with the hero gradient's top color. Uses negative margin to occupy space above content y=0 without affecting layout, and sets `pointerEvents="none"` to remain non-interactive.
- **AuthScreen**: Added `HeroOverscrollFill` as the first child of the ScrollView content
- **HomeScreen**: Added `HeroOverscrollFill` as the first child of the ScrollView content

## Implementation Details
The component uses a fixed 600pt height with a -600pt top margin, which cancels the height and positions it in the overscroll region. It pulls the hero gradient's top color from the theme to ensure visual consistency. The component must be rendered as the first child of ScrollView content to work correctly.

https://claude.ai/code/session_016fomeD4uy962B2CZFDoYbJ