### PR TITLE
Fix module import paths for songs/sort exports

### DIFF
--- a/apps/web/src/utils/songs/sort.js
+++ b/apps/web/src/utils/songs/sort.js
@@ -1,3 +1,3 @@
 // Compatibility shim — re-exports from @gracechords/core. Do not add logic here.
 // The implementation moved to packages/core/src/songs/sort.
-export * from '@gracechords/core/songs/sort'
+export * from '@gracechords/core/songs/sort.js'

--- a/workers/telegram-bot/wrangler.toml
+++ b/workers/telegram-bot/wrangler.toml
@@ -76,6 +76,7 @@ binding = "AI"
 "@gracechords/core/chordpro/index.js" = "../../packages/core/src/chordpro/index.js"
 "@gracechords/core/chordpro/parser.ts" = "../../packages/core/src/chordpro/parser.ts"
 "@gracechords/core/songs/instrumental.js" = "../../packages/core/src/songs/instrumental.js"
+"@gracechords/core/songs/sort.js" = "../../packages/core/src/songs/sort.js"
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
Updates module import paths to include explicit `.js` file extensions for better compatibility with module resolution systems, particularly in Cloudflare Workers environments.

## Changes
- **apps/web/src/utils/songs/sort.js**: Added `.js` extension to the re-export path from `@gracechords/core/songs/sort`
- **workers/telegram-bot/wrangler.toml**: Added module alias mapping for `@gracechords/core/songs/sort.js` to resolve to the correct source file in the monorepo

## Details
These changes ensure consistent module resolution across the monorepo, particularly for the Cloudflare Workers environment which has stricter module path requirements. The explicit `.js` extensions align with the existing pattern used for other core module aliases in the wrangler configuration.

https://claude.ai/code/session_01Y65b111gi9bhak1W86u4J3