### PR TITLE
Add Capo Calculator tool to Utilities tab

### DIFF
--- a/apps/mobile/app/capo.tsx
+++ b/apps/mobile/app/capo.tsx
@@ -1,0 +1,6 @@
+import CapoCalculatorScreen from '../src/screens/CapoCalculatorScreen'
+
+// Capo Calculator — pushed from the Utilities tab.
+export default function Capo() {
+  return <CapoCalculatorScreen />
+}

--- a/apps/mobile/src/i18n/locales/en/utilities.json
+++ b/apps/mobile/src/i18n/locales/en/utilities.json
@@ -7,7 +7,8 @@
     "tuner": "Tuner",
     "metronome": "Tap Tempo / Metronome",
     "pitchPipe": "Pitch Pipe",
-    "songbook": "Songbook"
+    "songbook": "Songbook",
+    "capo": "Capo Calculator"
   },
   "tuner": {
     "title": "Tuner",
@@ -69,5 +70,14 @@
     "pickCoverErrorTitle": "Could not open photos",
     "exportPdf_one": "Export PDF ({{count}} song)",
     "exportPdf_other": "Export PDF ({{count}} songs)"
+  },
+  "capo": {
+    "title": "Capo Calculator",
+    "songKey": "SONG KEY",
+    "playIn": "PLAY SHAPES IN",
+    "result": "Capo {{fret}}",
+    "resultNone": "No capo",
+    "hint": "Play {{shape}} shapes to sound in {{key}}.",
+    "hintNone": "Play in {{key}} — no capo needed."
   }
 }

--- a/apps/mobile/src/i18n/locales/es/utilities.json
+++ b/apps/mobile/src/i18n/locales/es/utilities.json
@@ -7,7 +7,8 @@
     "tuner": "Afinador",
     "metronome": "Marca tempo / Metrónomo",
     "pitchPipe": "Diapasón",
-    "songbook": "Cancionero"
+    "songbook": "Cancionero",
+    "capo": "Calculadora de cejilla"
   },
   "tuner": {
     "title": "Afinador",
@@ -69,5 +70,14 @@
     "pickCoverErrorTitle": "No se pudieron abrir las fotos",
     "exportPdf_one": "Exportar PDF ({{count}} canción)",
     "exportPdf_other": "Exportar PDF ({{count}} canciones)"
+  },
+  "capo": {
+    "title": "Calculadora de cejilla",
+    "songKey": "TONO DE LA CANCIÓN",
+    "playIn": "TOCAR ACORDES EN",
+    "result": "Cejilla {{fret}}",
+    "resultNone": "Sin cejilla",
+    "hint": "Toca acordes de {{shape}} para sonar en {{key}}.",
+    "hintNone": "Toca en {{key}} — no hace falta cejilla."
   }
 }

--- a/apps/mobile/src/i18n/locales/ko/utilities.json
+++ b/apps/mobile/src/i18n/locales/ko/utilities.json
@@ -7,7 +7,8 @@
     "tuner": "튜너",
     "metronome": "탭 템포 / 메트로놈",
     "pitchPipe": "피치 파이프",
-    "songbook": "노래책"
+    "songbook": "노래책",
+    "capo": "카포 계산기"
   },
   "tuner": {
     "title": "튜너",
@@ -69,5 +70,14 @@
     "pickCoverErrorTitle": "사진을 열 수 없음",
     "exportPdf_one": "PDF 내보내기 ({{count}}곡)",
     "exportPdf_other": "PDF 내보내기 ({{count}}곡)"
+  },
+  "capo": {
+    "title": "카포 계산기",
+    "songKey": "곡의 조",
+    "playIn": "연주할 코드 조",
+    "result": "카포 {{fret}}",
+    "resultNone": "카포 없음",
+    "hint": "{{key}} 조로 소리 내려면 {{shape}} 코드로 연주하세요.",
+    "hintNone": "{{key}} 조로 연주 — 카포가 필요 없습니다."
   }
 }

--- a/apps/mobile/src/i18n/locales/tr/utilities.json
+++ b/apps/mobile/src/i18n/locales/tr/utilities.json
@@ -7,7 +7,8 @@
     "tuner": "Akort Aleti",
     "metronome": "Tempo / Metronom",
     "pitchPipe": "Nota Düdüğü",
-    "songbook": "Şarkı Kitabı"
+    "songbook": "Şarkı Kitabı",
+    "capo": "Kapo Hesaplayıcı"
   },
   "tuner": {
     "title": "Akort Aleti",
@@ -69,5 +70,14 @@
     "pickCoverErrorTitle": "Fotoğraflar açılamadı",
     "exportPdf_one": "PDF'yi dışa aktar ({{count}} şarkı)",
     "exportPdf_other": "PDF'yi dışa aktar ({{count}} şarkı)"
+  },
+  "capo": {
+    "title": "Kapo Hesaplayıcı",
+    "songKey": "ŞARKININ TONU",
+    "playIn": "ŞU TONDA ÇAL",
+    "result": "Kapo {{fret}}",
+    "resultNone": "Kapo yok",
+    "hint": "{{key}} tonunda duyulması için {{shape}} akorlarını çal.",
+    "hintNone": "{{key}} tonunda çal — kapo gerekmez."
   }
 }

--- a/apps/mobile/src/screens/CapoCalculatorScreen.tsx
+++ b/apps/mobile/src/screens/CapoCalculatorScreen.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import { router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTranslation } from 'react-i18next'
+import { KEYS, formatKeyDisplay, stepsBetween } from '@gracechords/core'
+import Card from '../components/Card'
+import Chip from '../components/Chip'
+import GlassSurface from '../components/GlassSurface'
+import Screen from '../components/Screen'
+import SectionHeader from '../components/SectionHeader'
+import SymbolIcon from '../components/SymbolIcon'
+import { useAppDefaults } from '../lib/defaults'
+import { useTheme } from '../theme/ThemeProvider'
+
+// Capo Calculator (Utilities) — pick the key a song sounds in and the open-chord
+// key you'd rather play; the readout gives the capo fret that raises those
+// shapes into the sounding key. A capo only raises pitch, so the fret is the
+// number of semitones UP from the played shapes to the song's key
+// (stepsBetween, mod 12). Equal keys mean no capo. All key math reuses
+// @gracechords/core — nothing musical is reimplemented here.
+//
+// `embedded`: rendered inside the Utilities tab's tablet split (right pane) —
+// hides the back link and swaps the bar's safe-area padding for regular
+// spacing, mirroring the other tool screens.
+
+function KeyGrid({
+  selected,
+  onSelect,
+  chordStyle,
+}: {
+  selected: string
+  onSelect: (key: string) => void
+  chordStyle: 'letters' | 'solfege'
+}) {
+  const t = useTheme()
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: t.spacing.sm, paddingHorizontal: t.spacing.xs }}>
+      {KEYS.map((key) => (
+        <Chip
+          key={key}
+          label={formatKeyDisplay(key, chordStyle)}
+          selected={key === selected}
+          onPress={() => onSelect(key)}
+        />
+      ))}
+    </View>
+  )
+}
+
+export default function CapoCalculatorScreen({ embedded }: { embedded?: boolean }) {
+  const t = useTheme()
+  const { t: tx } = useTranslation(['utilities', 'common', 'nav'])
+  const insets = useSafeAreaInsets()
+  const { chordStyle } = useAppDefaults()
+  const [barH, setBarH] = useState(0)
+
+  const [songKey, setSongKey] = useState('C')
+  const [playKey, setPlayKey] = useState('C')
+
+  const fret = stepsBetween(playKey, songKey)
+  const songDisplay = formatKeyDisplay(songKey, chordStyle)
+  const playDisplay = formatKeyDisplay(playKey, chordStyle)
+
+  return (
+    <Screen edges={['left', 'right']}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingTop: barH + t.spacing.lg,
+          paddingHorizontal: t.spacing.lg,
+          paddingBottom: insets.bottom + t.spacing.xxl,
+        }}
+      >
+        {/* Result readout */}
+        <Card style={{ alignItems: 'center', paddingVertical: t.spacing.xl, paddingHorizontal: t.spacing.lg }}>
+          <Text
+            style={{
+              fontSize: 44,
+              fontWeight: '700',
+              letterSpacing: -0.5,
+              color: fret === 0 ? t.colors.muted : t.colors.accent,
+            }}
+          >
+            {fret === 0 ? tx('capo.resultNone') : tx('capo.result', { fret })}
+          </Text>
+          <Text
+            style={{
+              marginTop: t.spacing.xs,
+              fontSize: t.typography.body.fontSize,
+              color: t.colors.muted,
+              textAlign: 'center',
+            }}
+          >
+            {fret === 0
+              ? tx('capo.hintNone', { key: songDisplay })
+              : tx('capo.hint', { shape: playDisplay, key: songDisplay })}
+          </Text>
+        </Card>
+
+        <View style={{ marginTop: t.spacing.lg }}>
+          <SectionHeader label={tx('capo.songKey')} />
+          <KeyGrid selected={songKey} onSelect={setSongKey} chordStyle={chordStyle} />
+        </View>
+
+        <View style={{ marginTop: t.spacing.lg }}>
+          <SectionHeader label={tx('capo.playIn')} />
+          <KeyGrid selected={playKey} onSelect={setPlayKey} chordStyle={chordStyle} />
+        </View>
+      </ScrollView>
+
+      {/* Scroll-behind top bar, same pattern as the other tools. */}
+      <GlassSurface
+        fallbackColor={t.colors.bg}
+        fallbackHairline
+        onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          paddingTop: embedded ? t.spacing.sm : insets.top,
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        {embedded ? (
+          <View style={{ width: 70 }} />
+        ) : (
+          <Pressable
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel={tx('common:back')}
+            hitSlop={8}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+          >
+            <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+          </Pressable>
+        )}
+        <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('capo.title')}</Text>
+        <View style={{ width: 70 }} />
+      </GlassSurface>
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/UtilitiesScreen.tsx
+++ b/apps/mobile/src/screens/UtilitiesScreen.tsx
@@ -11,17 +11,17 @@ import SymbolIcon from '../components/SymbolIcon'
 import TunerScreen from './TunerScreen'
 import MetronomeScreen from './MetronomeScreen'
 import PitchPipeScreen from './PitchPipeScreen'
+import CapoCalculatorScreen from './CapoCalculatorScreen'
 import SongbookBuilderScreen from './SongbookBuilderScreen'
 import { useTheme } from '../theme/ThemeProvider'
 import { useIsTabletWidth } from '../lib/useIsTabletWidth'
 import type { Tokens } from '@gracechords/tokens/native'
 
 // The Utilities tab landing page: musician's tools as a grouped list. Every
-// row is a live feature (Tuner, Tap Tempo / Metronome, Pitch Pipe). Capo
-// math lives inline in the Song Viewer's capo chip, not as a tool here. Built
-// entirely from the shared primitives (Screen / SectionHeader / Card /
-// ListRow / SymbolIcon) and theme tokens, mirroring the grouped-list layout
-// used by Settings.
+// row is a live feature (Tuner, Tap Tempo / Metronome, Pitch Pipe, Capo
+// Calculator). Built entirely from the shared primitives (Screen /
+// SectionHeader / Card / ListRow / SymbolIcon) and theme tokens, mirroring the
+// grouped-list layout used by Settings.
 //
 // Phones push each tool as its own route. At regular (tablet) width the tab
 // becomes a list-detail split (tokens layout.split, ~1/3 · 2/3): the tool
@@ -46,7 +46,7 @@ function RowIcon({ name, t }: { name: Parameters<typeof SymbolIcon>[0]['name']; 
   )
 }
 
-type ToolRoute = '/tuner' | '/metronome' | '/pitch-pipe' | '/songbook'
+type ToolRoute = '/tuner' | '/metronome' | '/pitch-pipe' | '/capo' | '/songbook'
 
 const UTILITIES: {
   icon: Parameters<typeof SymbolIcon>[0]['name']
@@ -57,6 +57,7 @@ const UTILITIES: {
   { icon: 'metronome', titleKey: 'tools.metronome', route: '/metronome' },
   { icon: 'pianokeys', titleKey: 'tools.pitchPipe', route: '/pitch-pipe' },
   { icon: 'book', titleKey: 'tools.songbook', route: '/songbook' },
+  { icon: 'music.note', titleKey: 'tools.capo', route: '/capo' },
 ]
 
 export default function UtilitiesScreen() {
@@ -139,6 +140,8 @@ export default function UtilitiesScreen() {
             <PitchPipeScreen embedded />
           ) : tool === '/songbook' ? (
             <SongbookBuilderScreen embedded />
+          ) : tool === '/capo' ? (
+            <CapoCalculatorScreen embedded />
           ) : (
             <View
               style={{


### PR DESCRIPTION
Adds a new Capo Calculator utility tool that helps musicians determine the capo fret needed to transpose chord shapes into a song's key.

## Summary
Introduces a dedicated Capo Calculator screen accessible from the Utilities tab, replacing the previous inline capo math that lived only in the Song Viewer. The tool allows users to select a song key and the open-chord key they prefer to play, then displays the required capo fret (or "no capo" if the keys match).

## Changes
- **New screen**: `CapoCalculatorScreen` component with:
  - Two key selection grids (song key and play shapes key)
  - Real-time capo fret calculation using `stepsBetween()` from `@gracechords/core`
  - Result readout with contextual messaging
  - Support for both embedded (tablet split pane) and standalone (phone route) layouts
  - Scroll-behind glass top bar matching other tool screens

- **Integration**: Added capo route (`/capo`) to Utilities tab with:
  - New route file `apps/mobile/app/capo.tsx`
  - Tool listing in `UtilitiesScreen` with music note icon
  - Conditional rendering for tablet split-pane mode

- **Localization**: Added capo calculator strings to all supported locales (en, es, ko, tr):
  - Tool title and section headers
  - Result messages (with/without capo)
  - Hint text with key/shape interpolation

## Implementation Details
- Reuses existing `@gracechords/core` utilities (`KEYS`, `formatKeyDisplay`, `stepsBetween`) — no musical logic reimplemented
- Follows established patterns from other tool screens (Tuner, Metronome, Pitch Pipe)
- Respects user's chord style preference (letters vs. solfege) for key display
- Accent color applied to result when capo is needed; muted color when no capo required

https://claude.ai/code/session_01UTD5kRhRSUdNMcJ6FHyNYy