### PR TITLE
Align CSS variable names with design system tokens

### DIFF
--- a/apps/web/src/components/SiteDisclaimer.jsx
+++ b/apps/web/src/components/SiteDisclaimer.jsx
@@ -8,8 +8,12 @@ export default function SiteDisclaimer(){
   const { pathname, hash } = useLocation()
   const inWorship = (pathname && pathname.startsWith('/worship')) || (hash && hash.includes('/worship'))
   const inReading = (pathname && pathname.startsWith('/reading')) || (hash && hash.includes('/reading'))
+  // Live Session follower (/s/:code) is a standalone full-screen fixed overlay
+  // like Worship Mode; the disclaimer footer would otherwise paint over it.
+  const inSession = (pathname && pathname.startsWith('/s/')) || (hash && hash.includes('/s/'))
   if (inWorship) return null
   if (inReading) return null
+  if (inSession) return null
   if (!isDisclaimerEnabled()) return null
   const year = new Date().getFullYear()
   const base = 2023

--- a/apps/web/src/pages/SessionViewerPage.jsx
+++ b/apps/web/src/pages/SessionViewerPage.jsx
@@ -351,26 +351,26 @@ export default function SessionViewer() {
 // route with no NavBar, like Worship Mode). ---
 const SHELL = {
   position: 'fixed', inset: 0, display: 'flex', flexDirection: 'column',
-  background: 'var(--gc-bg, #fff)', color: 'var(--gc-ink, #111)',
+  background: 'var(--gc-bg, #fff)', color: 'var(--gc-text, #111)',
 }
 const HEADER = {
   display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-  padding: '10px 16px', borderBottom: '1px solid var(--gc-border, rgba(0,0,0,.1))', gap: 12,
+  padding: '10px 16px', borderBottom: '1px solid var(--gc-separator, rgba(0,0,0,.1))', gap: 12,
 }
 const CONTENT = { flex: 1, overflowY: 'auto', padding: '16px 18px 96px' }
 const CENTER = { minHeight: '60%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: 24 }
 const SECTION = { fontWeight: 700, opacity: 0.7, margin: '10px 0 4px' }
 const COMMENT = { fontStyle: 'italic', opacity: 0.75, marginBottom: 8 }
-const KEY_PILL = { background: 'var(--gc-accent-soft, rgba(0,0,0,.06))', borderRadius: 999, padding: '4px 12px', fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap' }
+const KEY_PILL = { background: 'var(--gc-surface-2, rgba(0,0,0,.06))', borderRadius: 999, padding: '4px 12px', fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap' }
 const LIVE_DOT = { width: 9, height: 9, borderRadius: 999, background: '#e0245e', flexShrink: 0 }
-const RECONNECT = { textAlign: 'center', padding: '6px 12px', fontSize: 13, background: 'var(--gc-accent-soft, rgba(0,0,0,.06))', opacity: 0.85 }
+const RECONNECT = { textAlign: 'center', padding: '6px 12px', fontSize: 13, background: 'var(--gc-surface-2, rgba(0,0,0,.06))', opacity: 0.85 }
 const BANNER = {
   display: 'flex', alignItems: 'center', gap: 10, padding: '8px 12px',
-  background: 'var(--gc-accent-soft, rgba(0,0,0,.06))', fontSize: 14,
-  borderBottom: '1px solid var(--gc-border, rgba(0,0,0,.1))',
+  background: 'var(--gc-surface-2, rgba(0,0,0,.06))', fontSize: 14,
+  borderBottom: '1px solid var(--gc-separator, rgba(0,0,0,.1))',
 }
 const BANNER_BTN = {
-  background: 'var(--gc-accent, #2563eb)', color: '#fff', border: 'none', borderRadius: 999,
+  background: 'var(--gc-primary, #2563eb)', color: '#fff', border: 'none', borderRadius: 999,
   padding: '6px 14px', fontSize: 14, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap', flexShrink: 0,
 }
 const BANNER_X = {
@@ -379,7 +379,7 @@ const BANNER_X = {
 }
 const PILL = {
   position: 'fixed', left: '50%', bottom: 24, transform: 'translateX(-50%)',
-  background: 'var(--gc-accent, #2563eb)', color: '#fff', border: 'none', borderRadius: 999,
+  background: 'var(--gc-primary, #2563eb)', color: '#fff', border: 'none', borderRadius: 999,
   padding: '12px 20px', fontSize: 15, fontWeight: 600, cursor: 'pointer', boxShadow: '0 6px 20px rgba(0,0,0,.25)',
 }
-const LINK = { color: 'var(--gc-accent, #2563eb)', fontWeight: 600, textDecoration: 'none' }
+const LINK = { color: 'var(--gc-primary, #2563eb)', fontWeight: 600, textDecoration: 'none' }


### PR DESCRIPTION
Updates CSS custom property references across the codebase to match the standardized design system token naming convention.

## Summary
This change standardizes CSS variable names used in the SessionViewer and SiteDisclaimer components to align with the design system's token naming scheme. The updates ensure consistent theming across the application.

## Key Changes
- **SessionViewerPage.jsx**: Updated CSS variable references in style objects:
  - `--gc-ink` → `--gc-text` (text color)
  - `--gc-border` → `--gc-separator` (border/divider color)
  - `--gc-accent-soft` → `--gc-surface-2` (soft background surfaces)
  - `--gc-accent` → `--gc-primary` (primary action color)

- **SiteDisclaimer.jsx**: Added logic to hide the disclaimer footer when viewing live session follower pages (`/s/:code`), preventing the footer from overlaying the full-screen session viewer (similar to existing behavior for Worship Mode and Reading Mode)

## Implementation Details
All fallback values remain unchanged, ensuring backward compatibility if the CSS variables are not defined. The session viewer exclusion in SiteDisclaimer follows the existing pattern for other full-screen overlay routes.

https://claude.ai/code/session_01Ay82KP3uYTVA4WfgY4dzJF