### PR TITLE
fix(supabase): add personal_song_id at top level in verse migration

### DIFF
--- a/supabase/migrations/20260721000100_setlist_songs_verse.sql
+++ b/supabase/migrations/20260721000100_setlist_songs_verse.sql
@@ -23,18 +23,24 @@
 ALTER TABLE public.setlist_songs ADD COLUMN IF NOT EXISTS verse_ref text;
 
 -- Re-assert the personal-songs setup (mirrors 20260708000300) so this migration
--- is self-contained. All statements are no-ops if that migration already ran.
+-- is self-contained. Each statement is a no-op if that migration already ran.
+--
+-- The column is added with a plain top-level statement first, guaranteeing it
+-- exists before the index and CHECK below reference it. The foreign key to
+-- public.personal_songs is then attached separately, guarded so it is skipped
+-- when that table is absent or the FK is already present.
+ALTER TABLE public.setlist_songs ADD COLUMN IF NOT EXISTS personal_song_id uuid;
+
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM information_schema.tables
-             WHERE table_schema = 'public' AND table_name = 'personal_songs') THEN
+             WHERE table_schema = 'public' AND table_name = 'personal_songs')
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint
+             WHERE conname = 'setlist_songs_personal_song_id_fkey'
+               AND conrelid = 'public.setlist_songs'::regclass) THEN
     ALTER TABLE public.setlist_songs
-      ADD COLUMN IF NOT EXISTS personal_song_id uuid
-        REFERENCES public.personal_songs(id) ON DELETE CASCADE;
-  ELSE
-    -- personal_songs is absent too; still add the column so the three-way CHECK
-    -- can reference it. The FK is added later once personal_songs exists.
-    ALTER TABLE public.setlist_songs ADD COLUMN IF NOT EXISTS personal_song_id uuid;
+      ADD CONSTRAINT setlist_songs_personal_song_id_fkey
+      FOREIGN KEY (personal_song_id) REFERENCES public.personal_songs(id) ON DELETE CASCADE;
   END IF;
 END $$;
 


### PR DESCRIPTION
Ensure the personal_song_id column is created by a plain top-level statement before the index and CHECK reference it, and attach the FK to personal_songs separately (guarded on the table existing and the FK not already being present). This removes any dependency on the column being added from inside a DO block and keeps the migration self-contained.


Claude-Session: https://claude.ai/code/session_013h6mr1CxSGPSZdjaw7qf5Z