### PR TITLE
Mobile: open session menu before share sheet; rename to participant link

### DIFF
--- a/apps/mobile/src/i18n/locales/en/setlist.json
+++ b/apps/mobile/src/i18n/locales/en/setlist.json
@@ -76,9 +76,8 @@
     "starting": "Starting…",
     "live": "Live",
     "manageTitle": "Live session",
-    "manageMessage": "Followers are watching. Share a link or end the session.",
     "shareTeam": "Share team link (chords)",
-    "shareEveryone": "Share everyone link (lyrics)",
+    "shareEveryone": "Share participant link (lyrics)",
     "end": "End session",
     "startFailed": "Could not start session",
     "endFailed": "Could not end session"

--- a/apps/mobile/src/i18n/locales/es/setlist.json
+++ b/apps/mobile/src/i18n/locales/es/setlist.json
@@ -76,9 +76,8 @@
     "starting": "Iniciando…",
     "live": "En vivo",
     "manageTitle": "Sesión en vivo",
-    "manageMessage": "Los seguidores están viendo. Comparte un enlace o finaliza la sesión.",
     "shareTeam": "Compartir enlace del equipo (acordes)",
-    "shareEveryone": "Compartir enlace para todos (letra)",
+    "shareEveryone": "Compartir enlace para participantes (letra)",
     "end": "Finalizar sesión",
     "startFailed": "No se pudo iniciar la sesión",
     "endFailed": "No se pudo finalizar la sesión"

--- a/apps/mobile/src/i18n/locales/ko/setlist.json
+++ b/apps/mobile/src/i18n/locales/ko/setlist.json
@@ -76,9 +76,8 @@
     "starting": "시작하는 중…",
     "live": "라이브",
     "manageTitle": "라이브 세션",
-    "manageMessage": "참여자들이 보고 있습니다. 링크를 공유하거나 세션을 종료하세요.",
     "shareTeam": "팀 링크 공유 (코드 포함)",
-    "shareEveryone": "모두를 위한 링크 공유 (가사)",
+    "shareEveryone": "참가자 링크 공유 (가사)",
     "end": "세션 종료",
     "startFailed": "세션을 시작할 수 없습니다",
     "endFailed": "세션을 종료할 수 없습니다"

--- a/apps/mobile/src/i18n/locales/tr/setlist.json
+++ b/apps/mobile/src/i18n/locales/tr/setlist.json
@@ -76,9 +76,8 @@
     "starting": "Başlatılıyor…",
     "live": "Canlı",
     "manageTitle": "Canlı oturum",
-    "manageMessage": "Takipçiler izliyor. Bir bağlantı paylaşın veya oturumu sonlandırın.",
     "shareTeam": "Ekip bağlantısını paylaş (akorlar)",
-    "shareEveryone": "Herkes için bağlantıyı paylaş (sözler)",
+    "shareEveryone": "Katılımcı bağlantısını paylaş (sözler)",
     "end": "Oturumu sonlandır",
     "startFailed": "Oturum başlatılamadı",
     "endFailed": "Oturum sonlandırılamadı"

--- a/apps/mobile/src/lib/useSessionController.ts
+++ b/apps/mobile/src/lib/useSessionController.ts
@@ -79,9 +79,8 @@ export function useSessionController(setlistId: string) {
         const items = buildSnapshot(entries)
         const row = await createSession(supabase, { setlistId, items })
         setSession({ id: row.id, code: row.code, chordCode: row.chord_code ?? null })
-        // Share the lyric (everyone) link on start; the leader can share the
-        // team/chord link from the manage sheet.
-        await Share.share({ message: buildSessionShareUrl(row.code) }).catch(() => {})
+        // Don't auto-open the share sheet here; the Performer surfaces the
+        // share menu (team / participant link) once the session is live.
       } finally {
         setBusy(false)
       }

--- a/apps/mobile/src/screens/PerformerScreen.tsx
+++ b/apps/mobile/src/screens/PerformerScreen.tsx
@@ -266,23 +266,29 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
     } else Alert.alert(title, msg)
   }
 
+  // The live-session menu: pick which link to share (team/chords vs
+  // participant/lyrics) via the native share sheet, or end the session.
+  function showSessionMenu() {
+    Alert.alert(tx('setlist:session.manageTitle'), undefined, [
+      { text: tx('setlist:session.shareTeam'), onPress: () => { void sessionCtl.reshareChords() } },
+      { text: tx('setlist:session.shareEveryone'), onPress: () => { void sessionCtl.reshareLyrics() } },
+      {
+        text: tx('setlist:session.end'),
+        style: 'destructive',
+        onPress: () => {
+          sessionCtl.end().catch((err) => reportError(tx('setlist:session.endFailed'), err))
+        },
+      },
+      { text: tx('common:cancel'), style: 'cancel' },
+    ])
+  }
+
   // Start / manage the live session from the header. Starting builds the frozen
-  // snapshot from the current entries and opens the native share sheet with the
-  // /s/{code} follower link; managing an active session offers re-share or end.
+  // snapshot from the current entries; both starting and managing surface the
+  // session menu, from which the leader shares a link or ends the session.
   function onSessionButton() {
     if (sessionCtl.session) {
-      Alert.alert(tx('setlist:session.manageTitle'), tx('setlist:session.manageMessage'), [
-        { text: tx('setlist:session.shareTeam'), onPress: () => { void sessionCtl.reshareChords() } },
-        { text: tx('setlist:session.shareEveryone'), onPress: () => { void sessionCtl.reshareLyrics() } },
-        {
-          text: tx('setlist:session.end'),
-          style: 'destructive',
-          onPress: () => {
-            sessionCtl.end().catch((err) => reportError(tx('setlist:session.endFailed'), err))
-          },
-        },
-        { text: tx('common:cancel'), style: 'cancel' },
-      ])
+      showSessionMenu()
       return
     }
     if (!count) {
@@ -291,6 +297,7 @@ export default function PerformerScreen({ setlistId }: { setlistId: string }) {
     }
     sessionCtl
       .start(items.map((it) => ({ songId: it.songId, toKey: it.toKey, song: it.song })))
+      .then(() => showSessionMenu())
       .catch((err) => reportError(tx('setlist:session.startFailed'), err))
   }
 


### PR DESCRIPTION
Previously the first tap of the Performer's live-session button created the session and immediately opened the native share sheet with the lyric link, so the leader never got to choose which link to share.

Now starting a session no longer auto-shares. Both starting and managing an active session surface the same menu, and the share sheet opens only when the leader picks "team link" or "participant link". Also drop the "Followers are watching…" message from the menu.

Rename the lyric/everyone option to "participant link" across all locales (en/es/ko/tr) and remove the now-unused manageMessage key, keeping i18n parity.


Claude-Session: https://claude.ai/code/session_01Ay82KP3uYTVA4WfgY4dzJF