### PR TITLE
Rename Utilities menu items: Tuner -> Guitar Tuner, Songbook -> Songb…

### DIFF
--- a/apps/mobile/src/i18n/locales/en/utilities.json
+++ b/apps/mobile/src/i18n/locales/en/utilities.json
@@ -4,14 +4,14 @@
   "sectionTools": "TOOLS",
   "pickTool": "Pick a tool to get started",
   "tools": {
-    "tuner": "Tuner",
+    "tuner": "Guitar Tuner",
     "metronome": "Tap Tempo / Metronome",
     "pitchPipe": "Pitch Pipe",
-    "songbook": "Songbook",
+    "songbook": "Songbook Maker",
     "capo": "Capo Calculator"
   },
   "tuner": {
-    "title": "Tuner",
+    "title": "Guitar Tuner",
     "permissionDenied": "The tuner needs microphone access to hear your guitar. Audio is analyzed on this device only — never recorded or sent anywhere.",
     "enableInSettings": "Enable in Settings",
     "inTune": "In tune",
@@ -45,7 +45,7 @@
     "holdNote": "Hold note"
   },
   "songbook": {
-    "title": "Songbook",
+    "title": "Songbook Maker",
     "defaultTitle": "Songbook",
     "addSongs": "Add songs",
     "selectedCount_one": "{{count}} song selected",

--- a/apps/mobile/src/i18n/locales/es/utilities.json
+++ b/apps/mobile/src/i18n/locales/es/utilities.json
@@ -4,14 +4,14 @@
   "sectionTools": "HERRAMIENTAS",
   "pickTool": "Elige una herramienta para empezar",
   "tools": {
-    "tuner": "Afinador",
+    "tuner": "Afinador de guitarra",
     "metronome": "Marca tempo / Metrónomo",
     "pitchPipe": "Diapasón",
-    "songbook": "Cancionero",
+    "songbook": "Creador de cancioneros",
     "capo": "Calculadora de cejilla"
   },
   "tuner": {
-    "title": "Afinador",
+    "title": "Afinador de guitarra",
     "permissionDenied": "El afinador necesita acceso al micrófono para escuchar tu guitarra. El audio se analiza solo en este dispositivo, nunca se graba ni se envía a ningún lugar.",
     "enableInSettings": "Activar en Ajustes",
     "inTune": "Afinado",
@@ -45,7 +45,7 @@
     "holdNote": "Mantener nota"
   },
   "songbook": {
-    "title": "Cancionero",
+    "title": "Creador de cancioneros",
     "defaultTitle": "Cancionero",
     "addSongs": "Añadir canciones",
     "selectedCount_one": "{{count}} canción seleccionada",

--- a/apps/mobile/src/i18n/locales/ko/utilities.json
+++ b/apps/mobile/src/i18n/locales/ko/utilities.json
@@ -4,14 +4,14 @@
   "sectionTools": "도구",
   "pickTool": "시작하려면 도구를 선택하세요",
   "tools": {
-    "tuner": "튜너",
+    "tuner": "기타 튜너",
     "metronome": "탭 템포 / 메트로놈",
     "pitchPipe": "피치 파이프",
-    "songbook": "노래책",
+    "songbook": "노래책 제작기",
     "capo": "카포 계산기"
   },
   "tuner": {
-    "title": "튜너",
+    "title": "기타 튜너",
     "permissionDenied": "튜너가 기타 소리를 들으려면 마이크 접근 권한이 필요합니다. 오디오는 이 기기에서만 분석되며, 절대 녹음되거나 어디에도 전송되지 않습니다.",
     "enableInSettings": "설정에서 사용 설정",
     "inTune": "정확함",
@@ -45,7 +45,7 @@
     "holdNote": "음 유지"
   },
   "songbook": {
-    "title": "노래책",
+    "title": "노래책 제작기",
     "defaultTitle": "노래책",
     "addSongs": "노래 추가",
     "selectedCount_one": "{{count}}곡 선택됨",

--- a/apps/mobile/src/i18n/locales/tr/utilities.json
+++ b/apps/mobile/src/i18n/locales/tr/utilities.json
@@ -4,14 +4,14 @@
   "sectionTools": "ARAÇLAR",
   "pickTool": "Başlamak için bir araç seçin",
   "tools": {
-    "tuner": "Akort Aleti",
+    "tuner": "Gitar Akort Aleti",
     "metronome": "Tempo / Metronom",
     "pitchPipe": "Nota Düdüğü",
-    "songbook": "Şarkı Kitabı",
+    "songbook": "Şarkı Kitabı Oluşturucu",
     "capo": "Kapo Hesaplayıcı"
   },
   "tuner": {
-    "title": "Akort Aleti",
+    "title": "Gitar Akort Aleti",
     "permissionDenied": "Akort aleti gitarınızı duymak için mikrofon erişimine ihtiyaç duyar. Ses yalnızca bu cihazda analiz edilir — asla kaydedilmez veya bir yere gönderilmez.",
     "enableInSettings": "Ayarlar'dan etkinleştir",
     "inTune": "Akortlu",
@@ -45,7 +45,7 @@
     "holdNote": "Notayı tut"
   },
   "songbook": {
-    "title": "Şarkı Kitabı",
+    "title": "Şarkı Kitabı Oluşturucu",
     "defaultTitle": "Şarkı Kitabı",
     "addSongs": "Şarkı ekle",
     "selectedCount_one": "{{count}} şarkı seçildi",


### PR DESCRIPTION
…ook Maker

Updates the tools.tuner/tuner.title and tools.songbook/songbook.title keys across all four locales (en, es, ko, tr) so the Utilities menu and each screen's header stay in sync.


Claude-Session: https://claude.ai/code/session_01BvtefH6LMYwotBzF4oi1A4