### PR TITLE
fix(mobile): add bottom scroll clearance for floating tab bar and cop…

### DIFF
--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -50,6 +50,11 @@ import {
 
 type Sheet = 'none' | 'translations' | 'settings' | 'date'
 
+// Copy FAB is 56px tall, floated at the same bottom offset as the ScrollView's
+// tab-bar-clearance padding — without extra room the FAB overlaps the last
+// verse instead of floating below it.
+const COPY_FAB_CLEARANCE = 56 + 16
+
 // Stable empty set for passages with no selection (never mutated).
 const EMPTY_SELECTION: ReadonlySet<number> = new Set<number>()
 
@@ -356,8 +361,9 @@ export default function DailyWordScreen({ showBackToLanding = false }: { showBac
               paddingHorizontal: 18,
               paddingTop: t.spacing.xs,
               // Clear the floating native tab bar (insets.bottom includes its
-              // height under native tabs) so the last verse scrolls fully above it.
-              paddingBottom: insets.bottom + t.spacing.xl,
+              // height under native tabs) so the last verse scrolls fully above
+              // it, plus the copy FAB's own height while a selection is active.
+              paddingBottom: insets.bottom + t.spacing.xl + (selection.size > 0 ? COPY_FAB_CLEARANCE : 0),
             }}
           >
               {settings.layout === 'prose' ? (

--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import * as Crypto from 'expo-crypto'
 import { BLANK_SONG_FORM } from '@gracechords/core'
 import Screen from '../components/Screen'
@@ -108,6 +109,7 @@ export default function SongLibraryScreen() {
   const { t: tx } = useTranslation(['song', 'common'])
   const router = useRouter()
   const { songs, loading, error } = useSongList()
+  const insets = useSafeAreaInsets()
   const isTablet = useIsTabletWidth()
   const { width, height } = useWindowDimensions()
   // Grid columns: tablet-only (tokens layout.libraryColumns), 1 on phones —
@@ -439,6 +441,9 @@ export default function SongLibraryScreen() {
           sections={[{ key: '__results', title: '', letter: null, data: resultRows }]}
           keyExtractor={keyForRow}
           keyboardShouldPersistTaps="handled"
+          // Clear the floating native tab bar (insets.bottom includes its
+          // height under native tabs) so the last row scrolls fully above it.
+          contentContainerStyle={{ paddingBottom: insets.bottom + t.spacing.xl }}
           renderSectionHeader={() => (
             <View style={{ backgroundColor: t.colors.bg, paddingHorizontal: t.spacing.xl, paddingVertical: 6 }}>
               <Text
@@ -489,7 +494,9 @@ export default function SongLibraryScreen() {
               })
             }, 60)
           }}
-          contentContainerStyle={{ paddingBottom: t.spacing.sm }}
+          // Clear the floating native tab bar (insets.bottom includes its
+          // height under native tabs) so the last row scrolls fully above it.
+          contentContainerStyle={{ paddingBottom: insets.bottom + t.spacing.xl }}
         />
         {showScrubber ? (
           <AlphaScrubber present={presentLetters} onSelect={scrollToLetter} />


### PR DESCRIPTION
…y FAB

Song Library's SectionList only padded 8px below the last row, so on Liquid Glass devices the floating tab bar covered it and users couldn't scroll it fully into view. The Daily Word reader's copy FAB floated at the same bottom offset as the ScrollView's padding, so its 56px height covered the last verse whenever a selection was active.