### PR TITLE
fix(android): give expo-splash-screen an image so splashscreen_logo i…

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -40,8 +40,11 @@
       [
         "expo-splash-screen",
         {
+          "image": "./assets/icon.png",
+          "imageWidth": 180,
           "backgroundColor": "#F5F7F9",
           "dark": {
+            "image": "./assets/icon.png",
             "backgroundColor": "#14171A"
           }
         }


### PR DESCRIPTION
…s generated

The Android build failed resource linking with:
  error: resource drawable/splashscreen_logo not found

Root cause: the expo-splash-screen config plugin always writes `windowSplashScreenAnimatedIcon -> @drawable/splashscreen_logo` into the generated styles.xml, but only generates that drawable when a splash `image` is configured. The app's splash config was background-color-only, so it relied on the bare template's default splashscreen_logo.png assets; those were absent from the generated android/ resources, leaving a dangling reference.

Point the splash at the existing app icon (assets/icon.png, the same asset iOS uses) with a light/dark variant. Expo now generates splashscreen_logo on every prebuild, so the resource always exists and the splash shows the app mark. Config-driven, so it survives native regeneration.


Claude-Session: https://claude.ai/code/session_01PZZwyFnojfotRZFDqsEnsp