### PR TITLE
Extract song search logic into reusable utility

### DIFF
--- a/apps/mobile/src/components/setlist/AddSongsModal.tsx
+++ b/apps/mobile/src/components/setlist/AddSongsModal.tsx
@@ -6,6 +6,7 @@ import ListRow from '../ListRow'
 import SymbolIcon from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
 import { useKeyboardHeight } from '../../lib/useKeyboardHeight'
+import { songMatchRank } from '../../lib/songSearch'
 import type { Song } from '../../lib/useSongList'
 
 // Full-screen "Add songs" picker (slides up over the builder): the Song
@@ -38,14 +39,13 @@ export default function AddSongsModal({
 
   const trimmed = query.trim().toLowerCase()
   const results = useMemo(() => {
-    const base = trimmed
-      ? songs.filter(
-          (s) =>
-            s.title.toLowerCase().includes(trimmed) ||
-            (s.artist ?? '').toLowerCase().includes(trimmed),
-        )
-      : songs
-    return base.slice().sort((a, b) => a.title.localeCompare(b.title))
+    if (!trimmed) return songs.slice().sort((a, b) => a.title.localeCompare(b.title))
+    // Rank title matches above tag-only matches, then alphabetically within each.
+    return songs
+      .map((s) => ({ s, rank: songMatchRank(s, trimmed) }))
+      .filter((x) => x.rank !== null)
+      .sort((a, b) => a.rank! - b.rank! || a.s.title.localeCompare(b.s.title))
+      .map((x) => x.s)
   }, [songs, trimmed])
 
   return (

--- a/apps/mobile/src/components/setlist/LibraryPane.tsx
+++ b/apps/mobile/src/components/setlist/LibraryPane.tsx
@@ -6,6 +6,7 @@ import ListRow from '../ListRow'
 import SymbolIcon from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
 import { useKeyboardHeight } from '../../lib/useKeyboardHeight'
+import { songMatchRank } from '../../lib/songSearch'
 import type { Song } from '../../lib/useSongList'
 
 // The tablet Setlist Builder's left pane: a searchable, single-column library
@@ -34,14 +35,13 @@ export default function LibraryPane({
 
   const trimmed = query.trim().toLowerCase()
   const results = useMemo(() => {
-    const base = trimmed
-      ? songs.filter(
-          (s) =>
-            s.title.toLowerCase().includes(trimmed) ||
-            (s.artist ?? '').toLowerCase().includes(trimmed),
-        )
-      : songs
-    return base.slice().sort((a, b) => a.title.localeCompare(b.title))
+    if (!trimmed) return songs.slice().sort((a, b) => a.title.localeCompare(b.title))
+    // Rank title matches above tag-only matches, then alphabetically within each.
+    return songs
+      .map((s) => ({ s, rank: songMatchRank(s, trimmed) }))
+      .filter((x) => x.rank !== null)
+      .sort((a, b) => a.rank! - b.rank! || a.s.title.localeCompare(b.s.title))
+      .map((x) => x.s)
   }, [songs, trimmed])
 
   return (

--- a/apps/mobile/src/lib/__tests__/songSearch.test.ts
+++ b/apps/mobile/src/lib/__tests__/songSearch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { TAG_MATCH, TITLE_MATCH, songMatchRank, songMatchesQuery } from '../songSearch'
+import type { Song } from '../useSongList'
+
+function song(partial: Partial<Song>): Song {
+  return {
+    id: '1',
+    slug: 'song',
+    title: 'Untitled',
+    artist: null,
+    default_key: null,
+    time_signature: null,
+    tags: null,
+    tempo: null,
+    created_at: null,
+    source: 'published',
+    ...partial,
+  } as Song
+}
+
+describe('songMatchRank', () => {
+  it('ranks a title match highest (0)', () => {
+    expect(songMatchRank(song({ title: 'Amazing Grace' }), 'grace')).toBe(TITLE_MATCH)
+  })
+
+  it('ranks a tag-only match below a title match (1)', () => {
+    expect(songMatchRank(song({ title: 'Silent Night', tags: ['Christmas', 'Advent'] }), 'advent')).toBe(TAG_MATCH)
+  })
+
+  it('prefers the title when the query hits both title and a tag', () => {
+    expect(songMatchRank(song({ title: 'Christmas Morning', tags: ['Christmas'] }), 'christmas')).toBe(TITLE_MATCH)
+  })
+
+  it('does NOT match on artist', () => {
+    expect(songMatchRank(song({ title: 'Doxology', artist: 'Chris Tomlin' }), 'tomlin')).toBeNull()
+  })
+
+  it('returns null when the query is absent from title and tags', () => {
+    expect(songMatchRank(song({ title: 'Silent Night', tags: ['Christmas'] }), 'easter')).toBeNull()
+  })
+
+  it('tolerates null tags', () => {
+    expect(songMatchRank(song({ title: 'Solo', tags: null }), 'solo')).toBe(TITLE_MATCH)
+    expect(songMatchRank(song({ title: 'Solo', tags: null }), 'zzz')).toBeNull()
+  })
+})
+
+describe('songMatchesQuery', () => {
+  it('is true for a title or tag match, false otherwise', () => {
+    expect(songMatchesQuery(song({ title: 'Grace' }), 'grace')).toBe(true)
+    expect(songMatchesQuery(song({ title: 'Grace', tags: ['Hymn'] }), 'hymn')).toBe(true)
+    expect(songMatchesQuery(song({ title: 'Grace', artist: 'Tomlin' }), 'tomlin')).toBe(false)
+  })
+})

--- a/apps/mobile/src/lib/songSearch.ts
+++ b/apps/mobile/src/lib/songSearch.ts
@@ -1,0 +1,33 @@
+import type { Song } from './useSongList'
+
+// Shared free-text matcher for the song pickers (Setlist builder, Songbook
+// builder, tablet LibraryPane, Song Library). A song matches when the query is
+// a substring of its title or any of its tags — so typing a theme like
+// "advent" or "communion" surfaces songs even when the word never appears in
+// the title. Artist is intentionally NOT searched.
+//
+// `query` is expected pre-trimmed and lower-cased by the caller (each picker
+// already derives it once per keystroke). A blank query never reaches here.
+
+// Ordering rank: title matches outrank tag-only matches so an exact title stays
+// at the top even when the same word also appears as a tag on other songs.
+export const TITLE_MATCH = 0
+export const TAG_MATCH = 1
+
+/**
+ * Match rank for ordering results, or `null` when the song does not match.
+ * Lower is higher priority: title (0) before tag-only (1).
+ */
+export function songMatchRank(song: Song, query: string): number | null {
+  if (song.title.toLowerCase().includes(query)) return TITLE_MATCH
+  const tags = song.tags ?? []
+  for (const tag of tags) {
+    if (tag.toLowerCase().includes(query)) return TAG_MATCH
+  }
+  return null
+}
+
+/** Whether a song matches the query at all (title or tag). */
+export function songMatchesQuery(song: Song, query: string): boolean {
+  return songMatchRank(song, query) !== null
+}

--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -24,6 +24,7 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useIsTabletWidth } from '../lib/useIsTabletWidth'
 import { chunkRows } from '../lib/gridRows'
 import { useSongList, type Song } from '../lib/useSongList'
+import { songMatchRank } from '../lib/songSearch'
 import { upsertDraft } from '../lib/drafts/draftsStore'
 
 // A list entry is one song (phone, single-column) or a grid row of songs
@@ -162,14 +163,12 @@ export default function SongLibraryScreen() {
   const trimmedQuery = query.trim().toLowerCase()
   const results = useMemo(() => {
     if (!trimmedQuery) return []
+    // Rank title matches above tag-only matches, then alphabetically within each.
     return tagFiltered
-      .filter(
-        (s) =>
-          s.title.toLowerCase().includes(trimmedQuery) ||
-          (s.artist ?? '').toLowerCase().includes(trimmedQuery),
-      )
-      .slice()
-      .sort(byTitle)
+      .map((s) => ({ s, rank: songMatchRank(s, trimmedQuery) }))
+      .filter((x) => x.rank !== null)
+      .sort((a, b) => a.rank! - b.rank! || byTitle(a.s, b.s))
+      .map((x) => x.s)
   }, [tagFiltered, trimmedQuery])
 
   const resultRows: LibraryRow[] = useMemo(

--- a/apps/mobile/src/screens/SpritePickerScreen.tsx
+++ b/apps/mobile/src/screens/SpritePickerScreen.tsx
@@ -36,8 +36,12 @@ export default function SpritePickerScreen() {
     if (isEdit && !touched && currentSprite) setSelected(currentSprite)
   }, [isEdit, touched, currentSprite])
 
+  // Always lay the avatars out in 3 columns, sizing each tile to the viewport.
+  // Floor the width so the three tiles + two gaps never exceed the row's content
+  // width — an exact fit is prone to sub-pixel rounding that wraps the third
+  // tile and collapses the grid to 2 columns.
   const gridGap = t.spacing.lg
-  const tileSize = (width - t.spacing.lg * 2 - gridGap * 2) / 3
+  const tileSize = Math.floor((width - t.spacing.lg * 2 - gridGap * 2) / 3)
 
   async function finish(sprite: SpriteId | null) {
     setBusy(true)


### PR DESCRIPTION
## Summary
Extracts the song search and filtering logic used across multiple song picker components into a centralized, tested utility module. This eliminates code duplication and ensures consistent search behavior (title and tag matching, with title matches ranked higher than tag-only matches) across the app.

## Key Changes
- **New module `songSearch.ts`**: Exports `songMatchRank()` and `songMatchesQuery()` functions that implement unified song search logic
  - Matches queries against song titles and tags (case-insensitive substring matching)
  - Intentionally excludes artist from search
  - Ranks title matches (0) above tag-only matches (1) for result ordering
  - Handles null tags gracefully

- **New test suite `songSearch.test.ts`**: Comprehensive test coverage for both search functions, including edge cases (null tags, query in both title and tags, no matches)

- **Updated song picker components**: Refactored `AddSongsModal`, `LibraryPane`, and `SongLibraryScreen` to use the new `songMatchRank()` utility
  - Removes duplicate search logic from each component
  - Improves result ordering: title matches appear first, then tag matches, both sorted alphabetically within their rank
  - Removes artist search (was inconsistent with tag-based search intent)

- **Minor fix in `SpritePickerScreen`**: Added `Math.floor()` to grid tile sizing calculation to prevent sub-pixel rounding issues that could collapse the 3-column layout to 2 columns. Includes clarifying comment.

## Implementation Details
The search utility is designed to be called with pre-trimmed, lowercased queries (each picker already derives this once per keystroke), avoiding redundant string operations. The ranking system enables intuitive result ordering where exact title matches stay at the top even when the same word appears as a tag on other songs.

https://claude.ai/code/session_01PFCaZLP4P7wU28oSU2sDaw