### PR TITLE
Add age assurance for Shared Reflections feed

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,6 +14,9 @@
       "supportsTablet": true,
       "usesAppleSignIn": true,
       "associatedDomains": ["applinks:gracechords.com"],
+      "entitlements": {
+        "com.apple.developer.declared-age-range": true
+      },
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -34,6 +34,8 @@ import {
 } from '../src/lib/readerReminderService'
 import { hydrateViewerPrefs } from '../src/lib/viewerPrefs'
 import { hydrateHiddenPosts } from '../src/lib/hiddenPosts'
+import { startAccessibilityFlags } from '../src/lib/accessibilityFlagsService'
+import { useAccessibilityFlags } from '../src/lib/accessibilityFlags'
 
 // Keep the native splash up past first render so we can resolve the persisted
 // session and route to the right screen before anything is shown — the app is
@@ -142,6 +144,7 @@ export default function RootLayout() {
   const router = useRouter()
   const { t: tx } = useTranslation(['setlist', 'common'])
   const resumeChecked = useRef(false)
+  const { reduceMotion } = useAccessibilityFlags()
 
   useEffect(() => {
     // Missing public config: skip the session read entirely (the supabase client
@@ -151,6 +154,11 @@ export default function RootLayout() {
     // Install the notification foreground handler / Android channel once, before
     // any reminder is (re)scheduled below.
     initReaderReminders()
+    // Begin tracking the OS accessibility settings (Reduce Motion / Increase
+    // Contrast / Differentiate Without Color). `ready` joins the splash hold
+    // below so the first paint already reflects any enabled setting; `stop`
+    // removes the OS listeners on unmount.
+    const a11y = startAccessibilityFlags()
     // Load app-wide defaults (theme/chord style) before the splash lifts so the
     // resolved theme is applied on first paint — no light→dark flash. Runs in
     // parallel with the session read; both must resolve before `ready`.
@@ -179,6 +187,9 @@ export default function RootLayout() {
             MaterialSymbolsFilled: require('../assets/fonts/MaterialSymbolsFilled.ttf'),
           })
         : Promise.resolve(),
+      // Resolve the initial accessibility-flag query before the splash lifts so
+      // the contrast overlay (if enabled) is applied on first paint — no flash.
+      a11y.ready,
     ]).then(([session, defaults]) => {
       // Apply the stored language pick (null = follow device) while the splash
       // is still up, so a non-device language never flashes on first paint.
@@ -207,6 +218,7 @@ export default function RootLayout() {
     return () => {
       sub.subscription.unsubscribe()
       stopAutoRefresh?.()
+      a11y.stop()
     }
   }, [])
 
@@ -265,7 +277,15 @@ export default function RootLayout() {
       <ThemeProvider>
         <SafeAreaProvider>
           <ThemedStatusBar />
-          <Stack screenOptions={{ headerShown: false }}>
+          {/* Reduce Motion: swap the default slide push for a cross-fade
+              (the HIG-preferred reduced-motion transition). Default settings
+              keep the standard push animation. */}
+          <Stack
+            screenOptions={{
+              headerShown: false,
+              animation: reduceMotion ? 'fade' : 'default',
+            }}
+          >
             <Stack.Screen name="(tabs)" />
             <Stack.Screen name="login" />
             <Stack.Screen name="choose-icon" />

--- a/apps/mobile/modules/declared-age-range/expo-module.config.json
+++ b/apps/mobile/modules/declared-age-range/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["DeclaredAgeRangeModule"]
+  }
+}

--- a/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRange.podspec
+++ b/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRange.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name           = 'DeclaredAgeRange'
+  s.version        = '1.0.0'
+  s.summary        = 'Bridges Apple’s iOS 26 Declared Age Range API to JS.'
+  s.description    = 'Local Expo module calling AgeRangeService for privacy-preserving age assurance.'
+  s.author         = 'GraceChords'
+  s.homepage       = 'https://gracechords.com'
+  s.license        = 'MIT'
+  s.platforms      = { :ios => '15.1' }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # The DeclaredAgeRange system framework only exists on iOS 26+. Weak-link it so
+  # the app still launches on older iOS (the Swift is guarded by #available).
+  s.weak_frameworks = 'DeclaredAgeRange'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
+end

--- a/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRangeModule.swift
+++ b/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRangeModule.swift
@@ -1,0 +1,40 @@
+import ExpoModulesCore
+import UIKit
+
+// Bridges Apple's iOS 26+ Declared Age Range API to JS. `requestAgeRange` returns
+// one of "over_13" / "under_13" / "unknown" (relative to the single age gate at
+// 13). The JS wrapper (src/lib/declaredAgeRange.ts) treats "unknown" as
+// "fall back to self-declaration", so any uncertainty degrades safely.
+//
+// ┌─ IMPLEMENTATION NOTE ──────────────────────────────────────────────────────┐
+// │ The concrete call into the `DeclaredAgeRange` framework must be completed    │
+// │ and verified against the iOS 26 SDK on a Mac (this cannot be compiled in a   │
+// │ Linux CI/agent). Until then this returns "unknown" on every platform/OS so   │
+// │ the app builds and simply relies on the self-declaration gate. Fill in the   │
+// │ `#available(iOS 26.0, *)` branch with the real request:                      │
+// │                                                                              │
+// │   import DeclaredAgeRange                                                     │
+// │   let response = try await AgeRangeService.shared                             │
+// │       .requestAgeRange(ageGates: 13)                                          │
+// │   switch response {                                                           │
+// │   case .sharing(let range):                                                   │
+// │     // range.lowerBound / range.upperBound relative to 13                     │
+// │     return (range.lowerBound ?? 0) >= 13 ? "over_13" : "under_13"             │
+// │   case .declinedSharing, .notAvailable: return "unknown"                      │
+// │   @unknown default: return "unknown"                                          │
+// │   }                                                                           │
+// │                                                                              │
+// │ Verify the exact type/case names against the shipping SDK before enabling.   │
+// └──────────────────────────────────────────────────────────────────────────────┘
+public class DeclaredAgeRangeModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("DeclaredAgeRange")
+
+    AsyncFunction("requestAgeRange") { () -> String in
+      // TODO(ios26): replace with the real DeclaredAgeRange request (see note
+      // above). Returning "unknown" keeps the build green and falls back to the
+      // self-declaration gate until the API call is verified on-device.
+      return "unknown"
+    }
+  }
+}

--- a/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRangeModule.swift
+++ b/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRangeModule.swift
@@ -1,40 +1,60 @@
 import ExpoModulesCore
 import UIKit
+#if canImport(DeclaredAgeRange)
+import DeclaredAgeRange
+#endif
 
 // Bridges Apple's iOS 26+ Declared Age Range API to JS. `requestAgeRange` returns
-// one of "over_13" / "under_13" / "unknown" (relative to the single age gate at
-// 13). The JS wrapper (src/lib/declaredAgeRange.ts) treats "unknown" as
-// "fall back to self-declaration", so any uncertainty degrades safely.
+// one of "over_13" / "under_13" / "unknown" (relative to a single age gate at 13).
+// The JS wrapper (src/lib/declaredAgeRange.ts) treats "unknown" as "fall back to
+// self-declaration", so a decline / error / unavailable OS all degrade safely.
 //
-// ┌─ IMPLEMENTATION NOTE ──────────────────────────────────────────────────────┐
-// │ The concrete call into the `DeclaredAgeRange` framework must be completed    │
-// │ and verified against the iOS 26 SDK on a Mac (this cannot be compiled in a   │
-// │ Linux CI/agent). Until then this returns "unknown" on every platform/OS so   │
-// │ the app builds and simply relies on the self-declaration gate. Fill in the   │
-// │ `#available(iOS 26.0, *)` branch with the real request:                      │
-// │                                                                              │
-// │   import DeclaredAgeRange                                                     │
-// │   let response = try await AgeRangeService.shared                             │
-// │       .requestAgeRange(ageGates: 13)                                          │
-// │   switch response {                                                           │
-// │   case .sharing(let range):                                                   │
-// │     // range.lowerBound / range.upperBound relative to 13                     │
-// │     return (range.lowerBound ?? 0) >= 13 ? "over_13" : "under_13"             │
-// │   case .declinedSharing, .notAvailable: return "unknown"                      │
-// │   @unknown default: return "unknown"                                          │
-// │   }                                                                           │
-// │                                                                              │
-// │ Verify the exact type/case names against the shipping SDK before enabling.   │
-// └──────────────────────────────────────────────────────────────────────────────┘
+// Requires the `com.apple.developer.declared-age-range` entitlement (wired via
+// app.json → ios.entitlements) AND the "Declared Age Range" capability enabled on
+// the App ID in the Apple Developer portal. Verify the exact symbol names in
+// Xcode 26 Quick Help before shipping — this is written from Apple's published
+// docs but has not been compiled here.
 public class DeclaredAgeRangeModule: Module {
   public func definition() -> ModuleDefinition {
     Name("DeclaredAgeRange")
 
-    AsyncFunction("requestAgeRange") { () -> String in
-      // TODO(ios26): replace with the real DeclaredAgeRange request (see note
-      // above). Returning "unknown" keeps the build green and falls back to the
-      // self-declaration gate until the API call is verified on-device.
+    AsyncFunction("requestAgeRange") { () async -> String in
+      #if canImport(DeclaredAgeRange)
+      if #available(iOS 26.0, *) {
+        return await self.resolveAgeRange()
+      }
+      #endif
       return "unknown"
     }
   }
+
+  #if canImport(DeclaredAgeRange)
+  // Presents the system age-range sheet (main actor) and maps Apple's response to
+  // our coarse over/under-13 result. ageGates:13 splits the answer into either an
+  // upper-bounded range below 13 or a lower-bounded range at/above 13.
+  @available(iOS 26.0, *)
+  @MainActor
+  private func resolveAgeRange() async -> String {
+    guard let viewController = appContext?.utilities?.currentViewController() else {
+      return "unknown"
+    }
+    do {
+      let response = try await AgeRangeService.shared.requestAgeRange(
+        ageGates: 13, nil, nil, in: viewController
+      )
+      switch response {
+      case .sharing(let range):
+        if let lower = range.lowerBound, lower >= 13 { return "over_13" }
+        if let upper = range.upperBound, upper < 13 { return "under_13" }
+        return "unknown"
+      case .declinedSharing:
+        return "unknown"
+      @unknown default:
+        return "unknown"
+      }
+    } catch {
+      return "unknown"
+    }
+  }
+  #endif
 }

--- a/apps/mobile/modules/differentiate-without-color/expo-module.config.json
+++ b/apps/mobile/modules/differentiate-without-color/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["DifferentiateWithoutColorModule"]
+  }
+}

--- a/apps/mobile/modules/differentiate-without-color/ios/DifferentiateWithoutColor.podspec
+++ b/apps/mobile/modules/differentiate-without-color/ios/DifferentiateWithoutColor.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name           = 'DifferentiateWithoutColor'
+  s.version        = '1.0.0'
+  s.summary        = 'Reads the iOS "Differentiate Without Color" accessibility setting.'
+  s.description    = 'Local Expo module exposing UIAccessibility.shouldDifferentiateWithoutColor.'
+  s.author         = 'GraceChords'
+  s.homepage       = 'https://gracechords.com'
+  s.license        = 'MIT'
+  s.platforms      = { :ios => '15.1' }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
+end

--- a/apps/mobile/modules/differentiate-without-color/ios/DifferentiateWithoutColorModule.swift
+++ b/apps/mobile/modules/differentiate-without-color/ios/DifferentiateWithoutColorModule.swift
@@ -1,0 +1,41 @@
+import ExpoModulesCore
+import UIKit
+
+// Exposes iOS's "Differentiate Without Color" accessibility setting to JS.
+// React Native does not surface `UIAccessibility.shouldDifferentiateWithoutColor`,
+// so this small local module reads it and emits `onChange` from the system
+// `differentiateWithoutColorDidChangeNotification`. iOS-only (Apple platform);
+// the JS wrapper (src/lib/differentiateWithoutColor.ts) degrades to "off" wherever
+// the module is not linked.
+public class DifferentiateWithoutColorModule: Module {
+  private var observer: NSObjectProtocol?
+
+  public func definition() -> ModuleDefinition {
+    Name("DifferentiateWithoutColor")
+
+    Events("onChange")
+
+    AsyncFunction("getShouldDifferentiateWithoutColor") { () -> Bool in
+      UIAccessibility.shouldDifferentiateWithoutColor
+    }
+
+    OnStartObserving {
+      self.observer = NotificationCenter.default.addObserver(
+        forName: UIAccessibility.differentiateWithoutColorDidChangeNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        self?.sendEvent("onChange", [
+          "value": UIAccessibility.shouldDifferentiateWithoutColor
+        ])
+      }
+    }
+
+    OnStopObserving {
+      if let observer = self.observer {
+        NotificationCenter.default.removeObserver(observer)
+        self.observer = nil
+      }
+    }
+  }
+}

--- a/apps/mobile/src/components/Chip.tsx
+++ b/apps/mobile/src/components/Chip.tsx
@@ -1,9 +1,13 @@
-import { Pressable, Text } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import { useTheme } from '../theme/ThemeProvider'
+import { useAccessibilityFlags } from '../lib/accessibilityFlags'
+import SymbolIcon from './SymbolIcon'
 
 // A pill-shaped, toggleable chip — used for the tag filters in the Filter & sort
 // sheet. Selected chips fill with the accent; unselected chips are a bordered
-// surface.
+// surface. When iOS "Differentiate Without Color" is on, a selected chip also
+// shows a checkmark so selection is not conveyed by fill color alone; default
+// settings render exactly as before (no icon).
 
 export default function Chip({
   label,
@@ -15,12 +19,17 @@ export default function Chip({
   onPress?: () => void
 }) {
   const t = useTheme()
+  const { differentiateWithoutColor } = useAccessibilityFlags()
+  const showCue = selected && differentiateWithoutColor
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
       accessibilityState={{ selected }}
       style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: showCue ? t.spacing.xs : 0,
         paddingVertical: t.spacing.sm,
         paddingHorizontal: t.spacing.lg,
         borderRadius: t.radii.pill,
@@ -30,6 +39,9 @@ export default function Chip({
         opacity: pressed ? 0.85 : 1,
       })}
     >
+      {showCue ? (
+        <SymbolIcon name="checkmark" size={13} color={t.colors.onAccent} />
+      ) : null}
       <Text
         style={{
           fontSize: 14,

--- a/apps/mobile/src/components/LoadingSkeleton.tsx
+++ b/apps/mobile/src/components/LoadingSkeleton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { ActivityIndicator, Animated, Text, View } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '../theme/ThemeProvider'
+import { useAccessibilityFlags } from '../lib/accessibilityFlags'
 
 // The "Loading · spinner · skeleton" component from [DOC] Components &
 // Foundations: a syncing label with a spinner over shimmering placeholder
@@ -23,8 +24,14 @@ export default function LoadingSkeleton({ label }: { label?: string }) {
   const { t: tx } = useTranslation('common')
   const displayLabel = label ?? tx('loading')
   const pulse = useRef(new Animated.Value(0.45)).current
+  // Reduce Motion: hold the placeholders at a steady opacity instead of pulsing.
+  const { reduceMotion } = useAccessibilityFlags()
 
   useEffect(() => {
+    if (reduceMotion) {
+      pulse.setValue(0.7)
+      return
+    }
     const loop = Animated.loop(
       Animated.sequence([
         Animated.timing(pulse, { toValue: 1, duration: 700, useNativeDriver: true }),
@@ -33,7 +40,7 @@ export default function LoadingSkeleton({ label }: { label?: string }) {
     )
     loop.start()
     return () => loop.stop()
-  }, [pulse])
+  }, [pulse, reduceMotion])
 
   const bar = (width: string, height: number) => (
     <Animated.View

--- a/apps/mobile/src/components/reflections/UgcTermsSheet.tsx
+++ b/apps/mobile/src/components/reflections/UgcTermsSheet.tsx
@@ -7,6 +7,7 @@ import { useFormSheet } from '../../lib/formSheetHost'
 import { useTheme } from '../../theme/ThemeProvider'
 import { errMessage } from '../../lib/errors'
 import { acceptUgcTerms } from '../../lib/ugc'
+import { recordAgeRange, useAgeGate, type AgeRange } from '../../lib/ageGate'
 import { supabase } from '../../lib/supabase'
 import {
   TERMS_URL,
@@ -17,15 +18,27 @@ import {
   UGC_GATE_SUBHEAD,
 } from '../../lib/ugcTerms'
 
-// The Apple 1.2 UGC acceptance gate, shown before a user's FIRST public post.
-// "Agree & Share" records acceptance (accept_ugc_terms RPC) and is itself the
-// explicit public-post confirm, then calls onAgreed() to proceed with the post.
-// The legal body copy is fixed English (ugcTerms.ts); only labels are i18n.
+// The Apple 1.2 UGC acceptance gate, extended to also capture age assurance for
+// the public Shared Reflections feed. It serves as the one-time unlock gate for
+// the whole public section (view + post):
+//   • When the user's age isn't known yet, it asks a neutral Under-13 / 13+
+//     question. "Under 13" records the range and closes — public stays hidden.
+//   • When age is already known (a prior attestation, or a Declared Age Range API
+//     seed passed via `seededAgeRange`), it shows the terms only.
+// "Agree & Share" records 13+ (if needed) + terms acceptance, then calls
+// onAgreed() to proceed (post, or simply reveal the feed at the landing gate).
 type UgcProps = {
   visible: boolean
   onClose: () => void
-  /** Called after acceptance is recorded — proceed with the pending public post. */
+  /** Called after 13+ age + terms are recorded — proceed (post / reveal feed). */
   onAgreed: () => void
+  /**
+   * Age already determined by Apple's Declared Age Range API. When set, the sheet
+   * skips the age question and records this range (source 'declared_api') on agree.
+   */
+  seededAgeRange?: AgeRange
+  /** Called after "Under 13" is recorded (public stays hidden). */
+  onDeclined?: () => void
 }
 
 export default function UgcTermsSheet(props: UgcProps) {
@@ -33,15 +46,84 @@ export default function UgcTermsSheet(props: UgcProps) {
   return null
 }
 
-function UgcContent({ onClose, onAgreed }: UgcProps) {
+function AgeOption({
+  label,
+  selected,
+  onPress,
+}: {
+  label: string
+  selected: boolean
+  onPress: () => void
+}) {
+  const t = useTheme()
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
+      style={({ pressed }) => ({
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: t.spacing.md,
+        paddingVertical: t.spacing.md,
+        paddingHorizontal: t.spacing.lg,
+        borderRadius: t.radii.md,
+        borderWidth: 1,
+        borderColor: selected ? t.colors.accent : t.colors.border,
+        backgroundColor: selected ? t.colors.accentSoft : t.colors.surface,
+        opacity: pressed ? 0.85 : 1,
+      })}
+    >
+      <View
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: 11,
+          borderWidth: 2,
+          borderColor: selected ? t.colors.accent : t.colors.border,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {selected ? (
+          <View
+            style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: t.colors.accent }}
+          />
+        ) : null}
+      </View>
+      <Text style={{ flex: 1, fontSize: 15, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
+    </Pressable>
+  )
+}
+
+function UgcContent({ onClose, onAgreed, onDeclined, seededAgeRange }: UgcProps) {
   const t = useTheme()
   const { t: tx } = useTranslation('reader')
+  const age = useAgeGate()
   const [busy, setBusy] = useState(false)
+  const [picked, setPicked] = useState<AgeRange | null>(null)
 
-  const agree = async () => {
-    if (busy) return
+  // Ask for age only when it isn't already known (no seed, and none stored). At
+  // the compose gate the user is already 13+, so this shows terms only.
+  const askAge = seededAgeRange == null && age.ready && age.range == null
+  const effectiveRange: AgeRange | null = seededAgeRange ?? (askAge ? picked : age.range ?? '13_plus')
+  const isUnder13 = effectiveRange === 'under_13'
+  const canConfirm = !busy && (!askAge || picked != null)
+
+  const record = async () => {
+    if (!canConfirm) return
     setBusy(true)
     try {
+      if (isUnder13) {
+        await recordAgeRange(supabase, 'under_13', 'self')
+        onDeclined?.()
+        onClose()
+        return
+      }
+      // 13+ path: record the range (unless already stored) then accept terms.
+      if (age.range !== '13_plus') {
+        await recordAgeRange(supabase, '13_plus', seededAgeRange ? 'declared_api' : 'self')
+      }
       await acceptUgcTerms(supabase)
       onAgreed()
     } catch (err: unknown) {
@@ -50,37 +132,68 @@ function UgcContent({ onClose, onAgreed }: UgcProps) {
     }
   }
 
+  const confirmLabel = isUnder13 ? tx('ugc.ageUnder13Confirm') : tx('ugc.agree')
+
   return (
     <FormSheetShell title={tx('ugc.title')} actionLabel={tx('ugc.cancel')} onAction={onClose}>
       <ScrollView
-        style={{ maxHeight: 460 }}
+        style={{ maxHeight: 480 }}
         contentContainerStyle={{ padding: t.spacing.lg, gap: t.spacing.md }}
       >
-        <Text style={{ fontSize: 15, lineHeight: 22, color: t.colors.sec }}>{UGC_GATE_INTRO}</Text>
-        <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.ink }}>{UGC_GATE_SUBHEAD}</Text>
-        <View style={{ gap: 8 }}>
-          {UGC_GATE_RULES.map((rule, i) => (
-            <View key={i} style={{ flexDirection: 'row', gap: 8 }}>
-              <SymbolIcon name="checkmark.circle.fill" size={16} color={t.colors.accent} />
-              <Text style={{ flex: 1, fontSize: 14.5, lineHeight: 21, color: t.colors.ink }}>{rule}</Text>
+        {askAge ? (
+          <View style={{ gap: t.spacing.sm }}>
+            <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.ink }}>
+              {tx('ugc.ageHeading')}
+            </Text>
+            <AgeOption
+              label={tx('ugc.age13Plus')}
+              selected={picked === '13_plus'}
+              onPress={() => setPicked('13_plus')}
+            />
+            <AgeOption
+              label={tx('ugc.ageUnder13')}
+              selected={picked === 'under_13'}
+              onPress={() => setPicked('under_13')}
+            />
+            {isUnder13 ? (
+              <Text style={{ fontSize: 13.5, lineHeight: 20, color: t.colors.muted }}>
+                {tx('ugc.ageUnder13Notice')}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        {/* Terms are hidden once the user has said they're under 13 — there's
+            nothing to agree to. */}
+        {!isUnder13 ? (
+          <>
+            <Text style={{ fontSize: 15, lineHeight: 22, color: t.colors.sec }}>{UGC_GATE_INTRO}</Text>
+            <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.ink }}>{UGC_GATE_SUBHEAD}</Text>
+            <View style={{ gap: 8 }}>
+              {UGC_GATE_RULES.map((rule, i) => (
+                <View key={i} style={{ flexDirection: 'row', gap: 8 }}>
+                  <SymbolIcon name="checkmark.circle.fill" size={16} color={t.colors.accent} />
+                  <Text style={{ flex: 1, fontSize: 14.5, lineHeight: 21, color: t.colors.ink }}>{rule}</Text>
+                </View>
+              ))}
             </View>
-          ))}
-        </View>
-        <Text style={{ fontSize: 13.5, lineHeight: 20, color: t.colors.muted }}>{UGC_GATE_ENFORCEMENT}</Text>
-        <Text style={{ fontSize: 13.5, lineHeight: 20, color: t.colors.muted }}>
-          {UGC_GATE_CONFIRM_PREFIX}
-          <Text
-            style={{ color: t.colors.accent, fontWeight: '600' }}
-            onPress={() => void Linking.openURL(TERMS_URL)}
-          >
-            {tx('ugc.termsLink')}
-          </Text>
-          .
-        </Text>
+            <Text style={{ fontSize: 13.5, lineHeight: 20, color: t.colors.muted }}>{UGC_GATE_ENFORCEMENT}</Text>
+            <Text style={{ fontSize: 13.5, lineHeight: 20, color: t.colors.muted }}>
+              {UGC_GATE_CONFIRM_PREFIX}
+              <Text
+                style={{ color: t.colors.accent, fontWeight: '600' }}
+                onPress={() => void Linking.openURL(TERMS_URL)}
+              >
+                {tx('ugc.termsLink')}
+              </Text>
+              .
+            </Text>
+          </>
+        ) : null}
 
         <Pressable
-          onPress={agree}
-          disabled={busy}
+          onPress={record}
+          disabled={!canConfirm}
           accessibilityRole="button"
           style={{
             height: 50,
@@ -89,14 +202,14 @@ function UgcContent({ onClose, onAgreed }: UgcProps) {
             alignItems: 'center',
             justifyContent: 'center',
             marginTop: t.spacing.sm,
-            opacity: busy ? 0.6 : 1,
+            opacity: canConfirm ? 1 : 0.6,
           }}
         >
           {busy ? (
             <ActivityIndicator color={t.colors.onAccent} />
           ) : (
             <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.onAccent }}>
-              {tx('ugc.agree')}
+              {confirmLabel}
             </Text>
           )}
         </Pressable>

--- a/apps/mobile/src/i18n/locales/en/reader.json
+++ b/apps/mobile/src/i18n/locales/en/reader.json
@@ -86,7 +86,17 @@
     "agree": "Agree & Share",
     "cancel": "Cancel",
     "termsLink": "Terms of Use",
-    "errorTitle": "Couldn’t save your acceptance"
+    "errorTitle": "Couldn’t save your acceptance",
+    "ageHeading": "How old are you?",
+    "age13Plus": "I’m 13 or older",
+    "ageUnder13": "I’m under 13",
+    "ageUnder13Notice": "Sharing and viewing community reflections isn’t available under 13. You can still write private reflections and read each day’s passage.",
+    "ageUnder13Confirm": "Continue"
+  },
+  "publicLocked": {
+    "title": "Community reflections",
+    "body": "Confirm your age to view and share reflections with the community.",
+    "cta": "Continue"
   },
   "copyVerses_one": "Copy {{count}} verse",
   "copyVerses_other": "Copy {{count}} verses",

--- a/apps/mobile/src/i18n/locales/es/reader.json
+++ b/apps/mobile/src/i18n/locales/es/reader.json
@@ -86,7 +86,17 @@
     "agree": "Aceptar y compartir",
     "cancel": "Cancelar",
     "termsLink": "Términos de uso",
-    "errorTitle": "No se pudo guardar tu aceptación"
+    "errorTitle": "No se pudo guardar tu aceptación",
+    "ageHeading": "¿Cuántos años tienes?",
+    "age13Plus": "Tengo 13 años o más",
+    "ageUnder13": "Soy menor de 13 años",
+    "ageUnder13Notice": "Compartir y ver reflexiones de la comunidad no está disponible para menores de 13 años. Aún puedes escribir reflexiones privadas y leer el pasaje de cada día.",
+    "ageUnder13Confirm": "Continuar"
+  },
+  "publicLocked": {
+    "title": "Reflexiones de la comunidad",
+    "body": "Confirma tu edad para ver y compartir reflexiones con la comunidad.",
+    "cta": "Continuar"
   },
   "copyVerses_one": "Copiar {{count}} versículo",
   "copyVerses_other": "Copiar {{count}} versículos",

--- a/apps/mobile/src/i18n/locales/ko/reader.json
+++ b/apps/mobile/src/i18n/locales/ko/reader.json
@@ -86,7 +86,17 @@
     "agree": "동의하고 나누기",
     "cancel": "취소",
     "termsLink": "이용약관",
-    "errorTitle": "동의를 저장할 수 없습니다"
+    "errorTitle": "동의를 저장할 수 없습니다",
+    "ageHeading": "나이가 어떻게 되나요?",
+    "age13Plus": "만 13세 이상입니다",
+    "ageUnder13": "만 13세 미만입니다",
+    "ageUnder13Notice": "커뮤니티 묵상을 나누거나 보는 기능은 만 13세 미만은 이용할 수 없습니다. 개인 묵상을 작성하고 매일의 본문을 읽는 것은 계속할 수 있습니다.",
+    "ageUnder13Confirm": "계속"
+  },
+  "publicLocked": {
+    "title": "커뮤니티 묵상",
+    "body": "커뮤니티와 묵상을 보고 나누려면 나이를 확인하세요.",
+    "cta": "계속"
   },
   "copyVerses_one": "{{count}}개 구절 복사",
   "copyVerses_other": "{{count}}개 구절 복사",

--- a/apps/mobile/src/i18n/locales/tr/reader.json
+++ b/apps/mobile/src/i18n/locales/tr/reader.json
@@ -86,7 +86,17 @@
     "agree": "Kabul et ve paylaş",
     "cancel": "İptal",
     "termsLink": "Kullanım Şartları",
-    "errorTitle": "Onayın kaydedilemedi"
+    "errorTitle": "Onayın kaydedilemedi",
+    "ageHeading": "Kaç yaşındasın?",
+    "age13Plus": "13 yaşında veya daha büyüğüm",
+    "ageUnder13": "13 yaşından küçüğüm",
+    "ageUnder13Notice": "Topluluk düşüncelerini paylaşmak ve görüntülemek 13 yaşından küçükler için kullanılamaz. Yine de özel düşünceler yazabilir ve her günün pasajını okuyabilirsin.",
+    "ageUnder13Confirm": "Devam et"
+  },
+  "publicLocked": {
+    "title": "Topluluk düşünceleri",
+    "body": "Topluluğun düşüncelerini görüntülemek ve paylaşmak için yaşını onayla.",
+    "cta": "Devam et"
   },
   "copyVerses_one": "{{count}} ayeti kopyala",
   "copyVerses_other": "{{count}} ayeti kopyala",

--- a/apps/mobile/src/lib/__tests__/accessibilityFlags.test.ts
+++ b/apps/mobile/src/lib/__tests__/accessibilityFlags.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  __resetAccessibilityFlagsForTest,
+  DEFAULT_ACCESSIBILITY_FLAGS,
+  getAccessibilityFlagsSnapshot,
+  initAccessibilityFlags,
+  type AccessibilityBackend,
+} from '../accessibilityFlags'
+
+// A controllable fake OS backend: the test captures each change/foreground
+// callback and can fire it, and can flip the contrast value the foreground
+// re-query reads.
+function makeBackend(initial: { rm?: boolean; ic?: boolean; dwc?: boolean } = {}) {
+  let ic = initial.ic ?? false
+  const cbs: {
+    rm?: (v: boolean) => void
+    dwc?: (v: boolean) => void
+    fg?: () => void
+  } = {}
+  const removed = { rm: false, dwc: false, fg: false }
+  const backend: AccessibilityBackend = {
+    isReduceMotionEnabled: async () => initial.rm ?? false,
+    isIncreaseContrastEnabled: async () => ic,
+    isDifferentiateWithoutColorEnabled: async () => initial.dwc ?? false,
+    onReduceMotionChanged: (cb) => {
+      cbs.rm = cb
+      return { remove: () => void (removed.rm = true) }
+    },
+    onDifferentiateWithoutColorChanged: (cb) => {
+      cbs.dwc = cb
+      return { remove: () => void (removed.dwc = true) }
+    },
+    onForeground: (cb) => {
+      cbs.fg = cb
+      return { remove: () => void (removed.fg = true) }
+    },
+  }
+  return { backend, cbs, removed, setContrast: (v: boolean) => void (ic = v) }
+}
+
+describe('accessibility flags store', () => {
+  afterEach(() => __resetAccessibilityFlagsForTest())
+
+  it('is all-false before init (vanilla device behavior)', () => {
+    expect(getAccessibilityFlagsSnapshot()).toEqual(DEFAULT_ACCESSIBILITY_FLAGS)
+    expect(getAccessibilityFlagsSnapshot()).toEqual({
+      reduceMotion: false,
+      increaseContrast: false,
+      differentiateWithoutColor: false,
+    })
+  })
+
+  it('seeds every flag from the backend once ready resolves', async () => {
+    const { backend } = makeBackend({ rm: true, ic: true, dwc: true })
+    const { ready, stop } = initAccessibilityFlags(backend)
+    await ready
+    expect(getAccessibilityFlagsSnapshot()).toEqual({
+      reduceMotion: true,
+      increaseContrast: true,
+      differentiateWithoutColor: true,
+    })
+    stop()
+  })
+
+  it('reacts to reduce-motion and differentiate change events', async () => {
+    const { backend, cbs } = makeBackend()
+    const { ready, stop } = initAccessibilityFlags(backend)
+    await ready
+    cbs.rm?.(true)
+    expect(getAccessibilityFlagsSnapshot().reduceMotion).toBe(true)
+    cbs.dwc?.(true)
+    expect(getAccessibilityFlagsSnapshot().differentiateWithoutColor).toBe(true)
+    cbs.rm?.(false)
+    expect(getAccessibilityFlagsSnapshot().reduceMotion).toBe(false)
+    stop()
+  })
+
+  it('re-queries contrast on foreground (it has no change event)', async () => {
+    const { backend, cbs, setContrast } = makeBackend({ ic: false })
+    const { ready, stop } = initAccessibilityFlags(backend)
+    await ready
+    expect(getAccessibilityFlagsSnapshot().increaseContrast).toBe(false)
+    // User turns Increase Contrast on while backgrounded; the flag updates only
+    // after the app returns to the foreground re-queries it.
+    setContrast(true)
+    cbs.fg?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(getAccessibilityFlagsSnapshot().increaseContrast).toBe(true)
+    stop()
+  })
+
+  it('stop() removes every subscription and halts further updates', async () => {
+    const { backend, cbs, removed } = makeBackend()
+    const { ready, stop } = initAccessibilityFlags(backend)
+    await ready
+    stop()
+    expect(removed).toEqual({ rm: true, dwc: true, fg: true })
+    // A late event after stop() must not mutate the store.
+    cbs.rm?.(true)
+    expect(getAccessibilityFlagsSnapshot().reduceMotion).toBe(false)
+  })
+
+  it('keeps a stable snapshot reference when nothing changes', async () => {
+    const { backend, cbs } = makeBackend({ rm: true })
+    const { ready, stop } = initAccessibilityFlags(backend)
+    await ready
+    const before = getAccessibilityFlagsSnapshot()
+    cbs.rm?.(true) // same value — no-op
+    expect(getAccessibilityFlagsSnapshot()).toBe(before)
+    stop()
+  })
+})

--- a/apps/mobile/src/lib/accessibilityFlags.ts
+++ b/apps/mobile/src/lib/accessibilityFlags.ts
@@ -1,0 +1,144 @@
+import { useSyncExternalStore } from 'react'
+
+// Live OS accessibility settings the app reacts to. The guiding rule: on a
+// device with default settings every flag is `false`, so the app behaves exactly
+// as it did before — enhanced behavior engages ONLY when the matching system
+// setting is turned on (iOS Reduce Motion / Increase Contrast / Differentiate
+// Without Color; the first two map to Android equivalents, the third is iOS-only).
+//
+// Like defaults.ts this is a module store read through useSyncExternalStore, but
+// its source is the OS (via an INJECTED backend) rather than AsyncStorage — so it
+// stays RN-free and unit-testable headless. The app root calls the service
+// wrapper (accessibilityFlagsService.ts) once, awaiting `ready` during the splash
+// hold so the first paint already reflects any enabled setting (no flash), and
+// keeps `stop` for cleanup.
+
+export type AccessibilityFlags = {
+  /** iOS Reduce Motion / Android "Remove animations". */
+  reduceMotion: boolean
+  /** iOS Increase Contrast (darker system colors). Android has no equivalent. */
+  increaseContrast: boolean
+  /** iOS Differentiate Without Color. iOS-only (no Android/JS equivalent). */
+  differentiateWithoutColor: boolean
+}
+
+export const DEFAULT_ACCESSIBILITY_FLAGS: AccessibilityFlags = {
+  reduceMotion: false,
+  increaseContrast: false,
+  differentiateWithoutColor: false,
+}
+
+/** A removable subscription — matches RN's EmitterSubscription shape. */
+export type FlagSubscription = { remove: () => void }
+
+/**
+ * The OS-facing surface the store depends on, injected so the store is testable.
+ * `increaseContrast` has no native change event, so it is re-queried whenever
+ * `onForeground` fires (app returns to the foreground).
+ */
+export type AccessibilityBackend = {
+  isReduceMotionEnabled: () => Promise<boolean>
+  isIncreaseContrastEnabled: () => Promise<boolean>
+  isDifferentiateWithoutColorEnabled: () => Promise<boolean>
+  onReduceMotionChanged: (cb: (value: boolean) => void) => FlagSubscription
+  onDifferentiateWithoutColorChanged: (cb: (value: boolean) => void) => FlagSubscription
+  onForeground: (cb: () => void) => FlagSubscription
+}
+
+// Replaced with a NEW object on every real change so getSnapshot returns a stable
+// reference between changes (required by useSyncExternalStore).
+let cache: AccessibilityFlags = DEFAULT_ACCESSIBILITY_FLAGS
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function patch(next: Partial<AccessibilityFlags>): void {
+  let changed = false
+  const merged = { ...cache }
+  for (const key of Object.keys(next) as (keyof AccessibilityFlags)[]) {
+    const value = next[key]
+    if (value !== undefined && merged[key] !== value) {
+      merged[key] = value
+      changed = true
+    }
+  }
+  if (!changed) return
+  cache = merged
+  emit()
+}
+
+/** Synchronous read of the current flags (safe before init — returns all-false). */
+export function getAccessibilityFlagsSnapshot(): AccessibilityFlags {
+  return cache
+}
+
+/** Test seam: drive the store directly without a backend. */
+export function __setAccessibilityFlagsForTest(next: Partial<AccessibilityFlags>): void {
+  patch(next)
+}
+
+/** Test seam: reset the store to defaults between tests. */
+export function __resetAccessibilityFlagsForTest(): void {
+  cache = DEFAULT_ACCESSIBILITY_FLAGS
+  emit()
+}
+
+/**
+ * Seed the store from the backend, subscribe to change events, and re-query the
+ * contrast flag on foreground. Returns `ready` (resolves once the initial query
+ * settles — await it during the splash hold) and `stop` (removes every
+ * subscription). The backend is injected to keep this module RN-free.
+ */
+export function initAccessibilityFlags(backend: AccessibilityBackend): {
+  ready: Promise<void>
+  stop: () => void
+} {
+  let alive = true
+
+  const ready = Promise.all([
+    backend.isReduceMotionEnabled().catch(() => false),
+    backend.isIncreaseContrastEnabled().catch(() => false),
+    backend.isDifferentiateWithoutColorEnabled().catch(() => false),
+  ]).then(([reduceMotion, increaseContrast, differentiateWithoutColor]) => {
+    if (alive) patch({ reduceMotion, increaseContrast, differentiateWithoutColor })
+  })
+
+  const subs: FlagSubscription[] = [
+    backend.onReduceMotionChanged((value) => {
+      if (alive) patch({ reduceMotion: value })
+    }),
+    backend.onDifferentiateWithoutColorChanged((value) => {
+      if (alive) patch({ differentiateWithoutColor: value })
+    }),
+    backend.onForeground(() => {
+      backend
+        .isIncreaseContrastEnabled()
+        .then((value) => {
+          if (alive) patch({ increaseContrast: value })
+        })
+        .catch(() => {})
+    }),
+  ]
+
+  return {
+    ready,
+    stop: () => {
+      alive = false
+      for (const sub of subs) sub.remove()
+    },
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Subscribing hook — re-renders when any OS accessibility flag changes. */
+export function useAccessibilityFlags(): AccessibilityFlags {
+  return useSyncExternalStore(subscribe, getAccessibilityFlagsSnapshot, getAccessibilityFlagsSnapshot)
+}

--- a/apps/mobile/src/lib/accessibilityFlagsService.ts
+++ b/apps/mobile/src/lib/accessibilityFlagsService.ts
@@ -1,0 +1,45 @@
+import { AccessibilityInfo, AppState, Platform } from 'react-native'
+import {
+  initAccessibilityFlags,
+  type AccessibilityBackend,
+  type FlagSubscription,
+} from './accessibilityFlags'
+import {
+  addDifferentiateWithoutColorListener,
+  getShouldDifferentiateWithoutColor,
+} from './differentiateWithoutColor'
+
+// The real RN backend for the accessibility-flags store. Kept separate from the
+// pure store (accessibilityFlags.ts) so the store stays RN-free and unit-testable
+// with an injected fake, mirroring the readerReminder / readerReminderService
+// split.
+
+// `isDarkerSystemColorsEnabled` maps to iOS "Increase Contrast". Access it
+// defensively so a stale RN type definition can't break typecheck and Android
+// (no equivalent setting) simply reports off.
+const Info = AccessibilityInfo as typeof AccessibilityInfo & {
+  isDarkerSystemColorsEnabled?: () => Promise<boolean>
+}
+
+const backend: AccessibilityBackend = {
+  isReduceMotionEnabled: () => AccessibilityInfo.isReduceMotionEnabled(),
+  isIncreaseContrastEnabled: () =>
+    Platform.OS === 'ios' && typeof Info.isDarkerSystemColorsEnabled === 'function'
+      ? Info.isDarkerSystemColorsEnabled()
+      : Promise.resolve(false),
+  isDifferentiateWithoutColorEnabled: () => getShouldDifferentiateWithoutColor(),
+  onReduceMotionChanged: (cb) =>
+    AccessibilityInfo.addEventListener('reduceMotionChanged', cb) as FlagSubscription,
+  onDifferentiateWithoutColorChanged: (cb) => addDifferentiateWithoutColorListener(cb),
+  onForeground: (cb) => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') cb()
+    })
+    return { remove: () => sub.remove() }
+  },
+}
+
+/** Wire the accessibility-flags store to the OS. Call once at the app root. */
+export function startAccessibilityFlags(): { ready: Promise<void>; stop: () => void } {
+  return initAccessibilityFlags(backend)
+}

--- a/apps/mobile/src/lib/ageGate.ts
+++ b/apps/mobile/src/lib/ageGate.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { supabase } from './supabase'
+
+// Age assurance for Shared Reflections. Users under 13 are kept out of the public
+// feed (Apple "Social Media" + "Disabled for Under 13"). The coarse age RANGE is
+// recorded server-side (users.age_range) via the record_age_range() SECURITY
+// DEFINER RPC and read back from the caller's own row, so it persists across
+// launches/devices. No birthdate is stored. Mirrors ugc.ts.
+
+export type AgeRange = 'under_13' | '13_plus'
+/** How the range was determined: user self-declaration, or Apple's Declared Age Range API. */
+export type AgeSource = 'self' | 'declared_api'
+
+/** The caller's stored age range, or null if they've never been asked. Never throws. */
+export async function fetchAgeRange(client: SupabaseClient, uid: string): Promise<AgeRange | null> {
+  const { data, error } = await client
+    .from('users')
+    .select('age_range')
+    .eq('id', uid)
+    .maybeSingle()
+  if (error || !data) return null
+  const value = (data as { age_range?: string | null }).age_range
+  return value === 'under_13' || value === '13_plus' ? value : null
+}
+
+/** Record the current user's age range (idempotent; overwrites on re-attestation). */
+export async function recordAgeRange(
+  client: SupabaseClient,
+  range: AgeRange,
+  source: AgeSource = 'self',
+): Promise<void> {
+  const { error } = await client.rpc('record_age_range', { p_range: range, p_source: source })
+  if (error) throw error
+}
+
+/**
+ * Reactive age-gate state for the current session. `ready` gates rendering (so the
+ * public section never flashes before we know the age), `range` is null until the
+ * user is asked, `isThirteenPlus` drives whether the public feed/compose may show,
+ * and `record()` writes + updates local state so the gate resolves without a
+ * refetch.
+ */
+export function useAgeGate() {
+  const [range, setRange] = useState<AgeRange | null>(null)
+  const [ready, setReady] = useState(false)
+
+  const refresh = useCallback(async () => {
+    const { data } = await supabase.auth.getSession()
+    const uid = data.session?.user?.id
+    if (!uid) {
+      setRange(null)
+      setReady(true)
+      return
+    }
+    const stored = await fetchAgeRange(supabase, uid)
+    setRange(stored)
+    setReady(true)
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const record = useCallback(async (next: AgeRange, source: AgeSource = 'self') => {
+    await recordAgeRange(supabase, next, source)
+    setRange(next)
+  }, [])
+
+  return { range, isThirteenPlus: range === '13_plus', ready, refresh, record }
+}

--- a/apps/mobile/src/lib/autoHideChrome.ts
+++ b/apps/mobile/src/lib/autoHideChrome.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Animated } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useAccessibilityFlags } from './accessibilityFlags'
 
 // "Hide controls when idle" — shared by the Song Viewer and the Setlist
 // Performer. Unlike the other view options (transpose, font, chord style),
@@ -43,6 +44,9 @@ export function useAutoHideChrome(enabled: boolean) {
   const [visible, setVisible] = useState(true)
   const opacity = useRef(new Animated.Value(1)).current
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Reduce Motion: snap chrome in/out instead of fading. Default settings keep
+  // the 260ms fade.
+  const { reduceMotion } = useAccessibilityFlags()
 
   const clearTimer = useCallback(() => {
     if (timer.current) {
@@ -64,10 +68,10 @@ export function useAutoHideChrome(enabled: boolean) {
   useEffect(() => {
     Animated.timing(opacity, {
       toValue: visible ? 1 : 0,
-      duration: 260,
+      duration: reduceMotion ? 0 : 260,
       useNativeDriver: true,
     }).start()
-  }, [visible, opacity])
+  }, [visible, opacity, reduceMotion])
 
   // Enabling starts the hide countdown; disabling pins chrome visible.
   useEffect(() => {

--- a/apps/mobile/src/lib/declaredAgeRange.ts
+++ b/apps/mobile/src/lib/declaredAgeRange.ts
@@ -1,0 +1,39 @@
+import { requireOptionalNativeModule } from 'expo'
+
+// Wrapper over the local `DeclaredAgeRange` native module
+// (apps/mobile/modules/declared-age-range), which calls Apple's iOS 26+ Declared
+// Age Range API to check the age range the user's Family Sharing / Screen Time
+// setup declares — real age assurance without collecting a birthdate.
+//
+// The module is optional: on Android, older iOS, or a Metro-only export bundle,
+// `requireOptionalNativeModule` returns null and this resolves to 'unknown', so
+// the caller falls back to self-declaration. A result of 'over_13' / 'under_13'
+// is only ever returned when Apple confidently reports it against the 13 gate.
+
+type DeclaredAgeRangeResult = 'over_13' | 'under_13' | 'unknown'
+
+type NativeDeclaredAgeRange = {
+  /** Ask Apple whether the user is above/below 13. Resolves 'unknown' if declined/unavailable. */
+  requestAgeRange: () => Promise<DeclaredAgeRangeResult>
+}
+
+const Native = requireOptionalNativeModule<NativeDeclaredAgeRange>('DeclaredAgeRange')
+
+/** True on platforms/OS versions where the Declared Age Range API is available. */
+export function isDeclaredAgeRangeAvailable(): boolean {
+  return Native != null
+}
+
+/**
+ * Ask Apple's Declared Age Range API whether the user is 13+. Returns 'unknown'
+ * (never throws) whenever the API is unavailable, declined, or withheld — the
+ * caller then falls back to self-declaration.
+ */
+export async function requestDeclaredAgeRange(): Promise<DeclaredAgeRangeResult> {
+  if (!Native) return 'unknown'
+  try {
+    return await Native.requestAgeRange()
+  } catch {
+    return 'unknown'
+  }
+}

--- a/apps/mobile/src/lib/differentiateWithoutColor.ts
+++ b/apps/mobile/src/lib/differentiateWithoutColor.ts
@@ -1,0 +1,47 @@
+import { requireOptionalNativeModule } from 'expo'
+
+// JS wrapper over the local `DifferentiateWithoutColor` native module
+// (apps/mobile/modules/differentiate-without-color) which reads iOS's
+// `UIAccessibility.shouldDifferentiateWithoutColor` and emits `onChange` from
+// `differentiateWithoutColorDidChangeNotification`. React Native does not expose
+// this flag, so the native module is the only way to read it.
+//
+// The module is iOS-only and only present after `expo prebuild` + a native
+// rebuild. `requireOptionalNativeModule` returns null when it isn't linked
+// (Android, or a Metro-only `expo export` bundle), so everything degrades
+// cleanly to "off" — never a crash.
+
+type NativeDifferentiate = {
+  getShouldDifferentiateWithoutColor: () => Promise<boolean>
+  addListener: (
+    event: 'onChange',
+    listener: (payload: { value: boolean }) => void,
+  ) => { remove: () => void }
+}
+
+const Native = requireOptionalNativeModule<NativeDifferentiate>('DifferentiateWithoutColor')
+
+export type DifferentiateSubscription = { remove: () => void }
+
+/** Current OS "Differentiate Without Color" state (false when unavailable). */
+export async function getShouldDifferentiateWithoutColor(): Promise<boolean> {
+  if (!Native) return false
+  try {
+    return await Native.getShouldDifferentiateWithoutColor()
+  } catch {
+    return false
+  }
+}
+
+/** Subscribe to OS changes. No-op subscription when the module is unavailable. */
+export function addDifferentiateWithoutColorListener(
+  cb: (value: boolean) => void,
+): DifferentiateSubscription {
+  if (!Native) return { remove: () => {} }
+  try {
+    const sub = Native.addListener('onChange', (payload) => cb(!!payload?.value))
+    return { remove: () => sub.remove() }
+  } catch {
+    return { remove: () => {} }
+  }
+}

--- a/apps/mobile/src/screens/DailyWordLandingScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordLandingScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { ActivityIndicator, Alert, Image, Pressable, ScrollView, Text, View } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useFocusEffect, useRouter } from 'expo-router'
@@ -14,8 +14,11 @@ import { currentStreak, useReadingStreak } from '../lib/readingStreak'
 import { useProfileSprite } from '../lib/useProfileSprite'
 import { useTodayReflection } from '../lib/useReflections'
 import { usePublicReflectionsEnabled } from '../lib/usePublicReflections'
+import { useAgeGate, type AgeRange } from '../lib/ageGate'
+import { requestDeclaredAgeRange } from '../lib/declaredAgeRange'
 import SharedReflectionsFeed from '../components/reflections/SharedReflectionsFeed'
 import PublicComposeSlot from '../components/reflections/PublicComposeSlot'
+import UgcTermsSheet from '../components/reflections/UgcTermsSheet'
 
 // The Daily Word landing hub (design: [UI] Daily Word Landing). Reached as the
 // Daily Word tab root when the "Daily Word opens" preference is "Landing page"
@@ -63,7 +66,29 @@ export default function DailyWordLandingScreen() {
   // Kill-switch: the community feed + public compose only render when the flag is
   // on. When off (or not yet resolved), the private experience below is unchanged.
   const { enabled: publicEnabled, ready: publicReady } = usePublicReflectionsEnabled()
-  const showPublic = publicReady && publicEnabled
+  // Age assurance: the public section (view + share) is kept from under-13 users.
+  // It shows only once the user is known to be 13+. When their age isn't known
+  // yet, an unlock card takes the feed's place; the private experience is never
+  // gated.
+  const age = useAgeGate()
+  const showPublic = publicReady && publicEnabled && age.ready && age.isThirteenPlus
+  const showAgeUnlock = publicReady && publicEnabled && age.ready && age.range == null
+  const [ugcVisible, setUgcVisible] = useState(false)
+  const [seededAge, setSeededAge] = useState<AgeRange | undefined>(undefined)
+
+  // User-initiated unlock: try Apple's Declared Age Range API first (real age
+  // assurance, no birthdate). A confident "under 13" hides the section with no
+  // popup; otherwise open the age + terms gate (seeded with 13+ when the API
+  // confirmed it, else asking the user to self-declare).
+  const beginAgeUnlock = useCallback(async () => {
+    const result = await requestDeclaredAgeRange()
+    if (result === 'under_13') {
+      await age.record('under_13', 'declared_api')
+      return
+    }
+    setSeededAge(result === 'over_13' ? '13_plus' : undefined)
+    setUgcVisible(true)
+  }, [age])
 
   // Re-read the reflection when the landing regains focus so a just-composed or
   // just-deleted entry (on the pushed compose/journal screens) shows correctly.
@@ -229,8 +254,28 @@ export default function DailyWordLandingScreen() {
         ) : null}
 
         {/* Shared Reflections — anonymous community feed (flag-gated, above the
-            user's own reflection per the design decision). */}
-        {showPublic ? <SharedReflectionsFeed /> : null}
+            user's own reflection per the design decision). Under-13 users see
+            neither the feed nor the compose slot; a user whose age isn't known
+            yet gets a one-time unlock card in the feed's place. */}
+        {showPublic ? (
+          <SharedReflectionsFeed />
+        ) : showAgeUnlock ? (
+          <Card style={{ marginTop: t.spacing.xl }}>
+            <View style={{ padding: t.spacing.lg, gap: t.spacing.sm }}>
+              <Text style={{ fontSize: 15, fontWeight: '700', color: t.colors.ink }}>
+                {tx('publicLocked.title')}
+              </Text>
+              <Text style={{ fontSize: 13.5, lineHeight: 20, color: t.colors.sec }}>
+                {tx('publicLocked.body')}
+              </Text>
+              <Button
+                title={tx('publicLocked.cta')}
+                onPress={() => void beginAgeUnlock()}
+                style={{ marginTop: t.spacing.xs }}
+              />
+            </View>
+          </Card>
+        ) : null}
 
         {/* Your reflection */}
         <Text
@@ -378,6 +423,22 @@ export default function DailyWordLandingScreen() {
           <SymbolIcon name="chevron.right" size={12} color={t.colors.accent} weight="semibold" />
         </Pressable>
       </ScrollView>
+
+      {/* Age + terms unlock gate for the public section. Refreshing the age gate
+          on close lets showPublic / showAgeUnlock recompute immediately. */}
+      <UgcTermsSheet
+        visible={ugcVisible}
+        seededAgeRange={seededAge}
+        onClose={() => setUgcVisible(false)}
+        onAgreed={() => {
+          setUgcVisible(false)
+          void age.refresh()
+        }}
+        onDeclined={() => {
+          setUgcVisible(false)
+          void age.refresh()
+        }}
+      />
     </Screen>
   )
 }

--- a/apps/mobile/src/screens/TunerScreen.tsx
+++ b/apps/mobile/src/screens/TunerScreen.tsx
@@ -14,6 +14,7 @@ import Button from '../components/Button'
 import GlassSurface from '../components/GlassSurface'
 import SymbolIcon from '../components/SymbolIcon'
 import { useTheme } from '../theme/ThemeProvider'
+import { useAccessibilityFlags } from '../lib/accessibilityFlags'
 import type { Tokens } from '@gracechords/tokens/native'
 import { STANDARD_TUNING, type TunerString } from '../lib/tuner/notes'
 import { useTuner, type TunerFrame, type TunerReading } from '../lib/tuner/useTuner'
@@ -112,6 +113,7 @@ function StringKey({
 export default function TunerScreen({ embedded }: { embedded?: boolean }) {
   const t = useTheme()
   const { t: tx } = useTranslation(['utilities', 'common', 'nav'])
+  const { differentiateWithoutColor } = useAccessibilityFlags()
   const insets = useSafeAreaInsets()
   const { width } = useWindowDimensions()
   const [barH, setBarH] = useState(0)
@@ -278,16 +280,24 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
                   {reading ? reading.string.name.slice(-1) : ''}
                 </Text>
               </View>
-              <Text
-                style={{
-                  fontSize: 22,
-                  fontWeight: '600',
-                  color: inTune ? t.colors.success : t.colors.ink,
-                  fontVariant: ['tabular-nums'],
-                }}
-              >
-                {centsText}
-              </Text>
+              {/* "In tune" already reads as text; when Differentiate Without
+                  Color is on, add a checkmark so the in-tune state never relies
+                  on the green color alone. */}
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: t.spacing.xs }}>
+                {inTune && differentiateWithoutColor ? (
+                  <SymbolIcon name="checkmark.circle.fill" size={20} color={t.colors.success} />
+                ) : null}
+                <Text
+                  style={{
+                    fontSize: 22,
+                    fontWeight: '600',
+                    color: inTune ? t.colors.success : t.colors.ink,
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {centsText}
+                </Text>
+              </View>
               <Text
                 style={{
                   fontSize: t.typography.rowSubtitle.fontSize,

--- a/apps/mobile/src/theme/ThemeProvider.tsx
+++ b/apps/mobile/src/theme/ThemeProvider.tsx
@@ -3,6 +3,7 @@ import { Appearance, useColorScheme } from 'react-native'
 import { StatusBar } from 'expo-status-bar'
 import { getTokens, lightTokens, type Tokens } from '@gracechords/tokens/native'
 import { resolveThemeMode, useAppDefaults } from '../lib/defaults'
+import { useAccessibilityFlags } from '../lib/accessibilityFlags'
 
 // ThemeProvider is the single source of truth for the app's color scheme. It
 // resolves the user's theme preference (Settings → Appearance, stored in the
@@ -16,6 +17,9 @@ const ThemeContext = createContext<Tokens>(lightTokens)
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const scheme = useColorScheme()
   const { theme } = useAppDefaults()
+  // Increase Contrast (iOS): merge the contrast-boost overlay over the palette.
+  // Off by default, so vanilla devices get the exact base tokens.
+  const { increaseContrast } = useAccessibilityFlags()
   // Push the preference down to the native color scheme so RN-managed surfaces
   // (keyboard, share/action sheets, alerts) match a forced light/dark override
   // instead of tracking the OS. 'system' clears the override ('unspecified' →
@@ -23,7 +27,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     Appearance.setColorScheme(theme === 'system' ? 'unspecified' : theme)
   }, [theme])
-  const tokens = useMemo(() => getTokens(resolveThemeMode(theme, scheme)), [theme, scheme])
+  const tokens = useMemo(
+    () => getTokens(resolveThemeMode(theme, scheme), increaseContrast),
+    [theme, scheme, increaseContrast],
+  )
   return <ThemeContext.Provider value={tokens}>{children}</ThemeContext.Provider>
 }
 

--- a/packages/tokens/native.ts
+++ b/packages/tokens/native.ts
@@ -111,6 +111,34 @@ export const darkColors: ThemeColors = {
   heroGlow: 'rgba(78,166,230,0.18)',
 }
 
+/**
+ * Increase-Contrast overlays — merged over the palette ONLY when iOS "Increase
+ * Contrast" is enabled (see the mobile ThemeProvider). They strengthen the few
+ * tokens that sit near the WCAG contrast floor: secondary/muted text and the
+ * hairline separators, plus a deeper accent-text tone. Every other token is
+ * inherited unchanged, and on a device with the setting OFF these are never
+ * applied — the app renders the exact base palette above.
+ */
+export const lightContrastBoost: Partial<ThemeColors> = {
+  sec: '#454C54',
+  muted: '#5A626B',
+  textAccent: '#0F5088',
+  border: '#C4CCD3',
+  off: 'rgba(90,98,107,0.7)',
+}
+
+export const darkContrastBoost: Partial<ThemeColors> = {
+  sec: '#C7CED5',
+  muted: '#9AA2AA',
+  textAccent: '#8AC4EE',
+  border: '#3C444C',
+  off: 'rgba(154,162,170,0.75)',
+}
+
+export function getContrastBoost(mode: ThemeMode): Partial<ThemeColors> {
+  return mode === 'dark' ? darkContrastBoost : lightContrastBoost
+}
+
 /** 4-pt spacing scale (shared across modes). */
 export const spacing = {
   xs: 4,
@@ -215,6 +243,10 @@ export const darkTokens: Tokens = {
   typography,
 }
 
-export function getTokens(mode: ThemeMode): Tokens {
-  return mode === 'dark' ? darkTokens : lightTokens
+export function getTokens(mode: ThemeMode, increaseContrast = false): Tokens {
+  const base = mode === 'dark' ? darkTokens : lightTokens
+  // Default settings return the base object unchanged (stable reference). Only
+  // when Increase Contrast is on do we build a boosted variant.
+  if (!increaseContrast) return base
+  return { ...base, colors: { ...base.colors, ...getContrastBoost(mode) } }
 }

--- a/supabase/migrations/20260721000200_age_range.sql
+++ b/supabase/migrations/20260721000200_age_range.sql
@@ -1,0 +1,75 @@
+-- =============================================================================
+-- GraceChords: age assurance for Shared Reflections (2026-07-21)
+--
+-- Records the user's self-declared / OS-declared age RANGE so the client can keep
+-- users under 13 out of the public Shared Reflections feed (Apple "Social Media"
+-- + "Disabled for Under 13" declarations). No birthdate is stored — only a coarse
+-- range bucket and when/how it was attested.
+--
+-- Written through a SECURITY DEFINER RPC (never a raw client UPDATE) for the same
+-- reason as accept_ugc_terms: the base public.users table + its column
+-- grants/policies are provisioned out-of-band, so the RPC is the verifiable write
+-- path. It only ever touches the caller's own row and validates its inputs.
+-- Reading age_range is a normal own-row select via the existing users_select
+-- policy.
+--
+-- Enforcement is client-side this pass (the feed/compose surfaces gate on the
+-- stored range); the moderated submit endpoint + feed RLS are intentionally left
+-- unchanged. Forward-only + idempotent. Documented rollback at the bottom.
+-- =============================================================================
+
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS age_range text;
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS age_attested_at timestamptz;
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS age_source text;
+
+-- Constrain to the known buckets/sources without failing on legacy NULLs.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_age_range_check'
+  ) THEN
+    ALTER TABLE public.users
+      ADD CONSTRAINT users_age_range_check
+      CHECK (age_range IS NULL OR age_range IN ('under_13', '13_plus'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_age_source_check'
+  ) THEN
+    ALTER TABLE public.users
+      ADD CONSTRAINT users_age_source_check
+      CHECK (age_source IS NULL OR age_source IN ('self', 'declared_api'));
+  END IF;
+END $$;
+
+-- Set the caller's age range + attestation metadata and return the stored range.
+-- Unlike accept_ugc_terms this OVERWRITES on each call (a correction, or a child
+-- who has since turned 13, should update). auth.uid() scopes it to the caller.
+CREATE OR REPLACE FUNCTION public.record_age_range(p_range text, p_source text DEFAULT 'self')
+  RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF p_range NOT IN ('under_13', '13_plus') THEN
+    RAISE EXCEPTION 'invalid age range: %', p_range;
+  END IF;
+  IF p_source NOT IN ('self', 'declared_api') THEN
+    RAISE EXCEPTION 'invalid age source: %', p_source;
+  END IF;
+  UPDATE public.users
+    SET age_range = p_range,
+        age_source = p_source,
+        age_attested_at = now()
+    WHERE id = auth.uid();
+  RETURN (SELECT age_range FROM public.users WHERE id = auth.uid());
+END $$;
+REVOKE ALL ON FUNCTION public.record_age_range(text, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.record_age_range(text, text) TO authenticated;
+
+-- =============================================================================
+-- DOWN MIGRATION (rollback) — run manually to reverse this migration.
+--
+--   DROP FUNCTION IF EXISTS public.record_age_range(text, text);
+--   ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_age_range_check;
+--   ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_age_source_check;
+--   ALTER TABLE public.users DROP COLUMN IF EXISTS age_source;
+--   ALTER TABLE public.users DROP COLUMN IF EXISTS age_attested_at;
+--   ALTER TABLE public.users DROP COLUMN IF EXISTS age_range;
+-- =============================================================================


### PR DESCRIPTION
Implements age gating for the public Shared Reflections feed to comply with Apple's "Social Media" + "Disabled for Under 13" declarations. Users under 13 are kept out of the public section (view and post), while 13+ users proceed normally.

## Summary

This change adds a complete age assurance system that:
- Captures age via Apple's Declared Age Range API (iOS 26+) when available, falling back to self-declaration
- Stores the coarse age range (`under_13` / `13_plus`) server-side with attestation metadata
- Gates the public feed and compose surfaces client-side until age is confirmed as 13+
- Integrates with the existing UGC terms acceptance flow as a unified unlock gate

## Key Changes

**Age Gating & Storage**
- New `ageGate.ts` module with `useAgeGate()` hook for reactive age state and `recordAgeRange()` RPC wrapper
- Database migration adding `age_range`, `age_attested_at`, `age_source` columns to `users` table
- `record_age_range()` SECURITY DEFINER RPC (idempotent, scoped to caller) for server-side recording

**Native Integration**
- Local Expo modules for iOS:
  - `DeclaredAgeRange`: bridges Apple's iOS 26+ Declared Age Range API
  - `DifferentiateWithoutColor`: exposes iOS accessibility setting (used by contrast boost)
- Graceful degradation on Android and older iOS (falls back to self-declaration)

**UGC Terms Sheet Enhancement**
- Extended `UgcTermsSheet` to conditionally show age question when age is unknown
- New `AgeOption` radio-button component for age selection
- Seeded age support for when Apple's API confirms 13+ (skips the question)
- Separate `onDeclined` callback for under-13 path (hides public, no terms shown)

**Accessibility Improvements**
- New `accessibilityFlags.ts` store (RN-free, testable) for OS accessibility settings
- `accessibilityFlagsService.ts` wires the store to React Native at app startup
- Contrast boost tokens applied when iOS "Increase Contrast" is enabled
- `differentiateWithoutColor.ts` wrapper for iOS-only setting
- Tuner and Chip components updated to respect "Differentiate Without Color"

**Landing Screen Integration**
- `DailyWordLandingScreen` now gates public section on `age.isThirteenPlus`
- Shows unlock card when age is unknown; calls `beginAgeUnlock()` to trigger API or self-declaration flow
- Private experience (Daily Word, journal) remains ungated

**Localization**
- Added age-related strings to all supported locales (en, es, ko, tr)
- Includes age question labels, under-13 notice, and confirmation button text

## Implementation Details

- Age range is coarse (no birthdate stored) and forward-only; corrections overwrite on re-attestation
- The Declared Age Range API result is mapped to a single 13-year gate (returns `over_13` / `under_13` / `unknown`)
- Accessibility flags use `useSyncExternalStore` for stable snapshots and efficient re-renders
- All native modules are optional and degrade cleanly when unavailable
- Database changes are backward-compatible (NULLs allowed for legacy users)

https://claude.ai/code/session_01PJKMTSMFFDrfkAVvohfoAp