### PR TITLE
fix(mobile): make DeclaredAgeRange native module compile on iOS 26

### DIFF
--- a/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRangeModule.swift
+++ b/apps/mobile/modules/declared-age-range/ios/DeclaredAgeRangeModule.swift
@@ -11,9 +11,11 @@ import DeclaredAgeRange
 //
 // Requires the `com.apple.developer.declared-age-range` entitlement (wired via
 // app.json → ios.entitlements) AND the "Declared Age Range" capability enabled on
-// the App ID in the Apple Developer portal. Verify the exact symbol names in
-// Xcode 26 Quick Help before shipping — this is written from Apple's published
-// docs but has not been compiled here.
+// the App ID in the Apple Developer portal. Symbols verified against the
+// DeclaredAgeRange.framework .swiftinterface in the iOS 26.5 SDK (Xcode 26):
+// AgeRangeService.shared.requestAgeRange(ageGates:_:_:in:) -> Response, with
+// Response.sharing(range:)/.declinedSharing and AgeRange.lowerBound/upperBound (Int?).
+// Not testable on Simulator — the API only resolves on a real device.
 public class DeclaredAgeRangeModule: Module {
   public func definition() -> ModuleDefinition {
     Name("DeclaredAgeRange")
@@ -40,12 +42,16 @@ public class DeclaredAgeRangeModule: Module {
     }
     do {
       let response = try await AgeRangeService.shared.requestAgeRange(
-        ageGates: 13, nil, nil, in: viewController
+        ageGates: 13, in: viewController
       )
       switch response {
       case .sharing(let range):
+        // Apple returns a half-open bracket around the gate: 13+ is [13, nil)
+        // (lowerBound == 13), under-13 is [nil, 13) (upperBound == 13). Use `<= 13`
+        // so the exclusive upper bound of the under-13 bracket still resolves to
+        // "under_13"; the 13+ bracket has upperBound == nil so it never matches here.
         if let lower = range.lowerBound, lower >= 13 { return "over_13" }
-        if let upper = range.upperBound, upper < 13 { return "under_13" }
+        if let upper = range.upperBound, upper <= 13 { return "under_13" }
         return "unknown"
       case .declinedSharing:
         return "unknown"

--- a/apps/mobile/modules/declared-age-range/ios/GCDeclaredAgeRange.podspec
+++ b/apps/mobile/modules/declared-age-range/ios/GCDeclaredAgeRange.podspec
@@ -1,5 +1,9 @@
 Pod::Spec.new do |s|
-  s.name           = 'DeclaredAgeRange'
+  # Pod/clang-module name MUST NOT be 'DeclaredAgeRange' — that is Apple's system
+  # framework. A collision makes `import DeclaredAgeRange` resolve to this pod
+  # instead of Apple's, so `AgeRangeService` is not in scope. Prefixed to stay
+  # distinct; the JS-facing name stays "DeclaredAgeRange" via Name() in the module.
+  s.name           = 'GCDeclaredAgeRange'
   s.version        = '1.0.0'
   s.summary        = 'Bridges Apple’s iOS 26 Declared Age Range API to JS.'
   s.description    = 'Local Expo module calling AgeRangeService for privacy-preserving age assurance.'


### PR DESCRIPTION
Two build/correctness fixes to the local Declared Age Range module so the iOS app builds and the age gate behaves as designed:

- Rename the pod from `DeclaredAgeRange` to `GCDeclaredAgeRange`. The old name collided with Apple's iOS 26 system framework of the same name, so `import DeclaredAgeRange` / `canImport(DeclaredAgeRange)` resolved to our own module instead of Apple's — `AgeRangeService` was never in scope and the build failed with "cannot find 'AgeRangeService' in scope". The JS-facing name stays "DeclaredAgeRange" (via Name() in the module), so nothing on the RN side changes.
- Fix the under-13 bound check. Apple returns a half-open bracket around the gate, so the under-13 range is [nil, 13) with upperBound == 13. The old `upper < 13` never matched, so a confident under-13 user fell through to "unknown" instead of "under_13". Use `upper <= 13`.

Verified by compiling the GCDeclaredAgeRange scheme against the iOS 26.5 SDK (Xcode 26): BUILD SUCCEEDED. Symbols checked against the framework .swiftinterface. typecheck + 263 vitest tests stay green.