### PR TITLE
fix(mobile): repair botched merge that re-capped the UGC sheet height

### DIFF
--- a/apps/mobile/src/components/reflections/UgcTermsSheet.tsx
+++ b/apps/mobile/src/components/reflections/UgcTermsSheet.tsx
@@ -147,8 +147,6 @@ function UgcContent({ onClose, onAgreed, onDeclined, seededAgeRange }: UgcProps)
           paddingBottom: insets.bottom + t.spacing.lg,
           gap: t.spacing.md,
         }}
-        style={{ maxHeight: 480 }}
-        contentContainerStyle={{ padding: t.spacing.lg, gap: t.spacing.md }}
       >
         {askAge ? (
           <View style={{ gap: t.spacing.sm }}>


### PR DESCRIPTION
The age-gate merge into this file left a duplicate contentContainerStyle prop and reintroduced maxHeight: 480 on the ScrollView. Because the later JSX prop wins, the bottom safe-area padding was silently dropped and the 480pt cap returned — so the 'Agree & Share' button fell below the fold again and the sheet left a gap above the home indicator.

Remove the stray maxHeight cap and duplicate prop so the native fitToContents detent sizes to the full content (age question + terms + button) and the safe-area padding fills to the screen bottom.


Claude-Session: https://claude.ai/code/session_01PFCaZLP4P7wU28oSU2sDaw