### PR TITLE
fix(mobile): paint the sheet's bottom safe-area strip with the surfac…

### DIFF
--- a/apps/mobile/app/sheet.tsx
+++ b/apps/mobile/app/sheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { View } from 'react-native'
+import { Stack } from 'expo-router'
 import { notifyFormSheetRouteClosed, useFormSheetContent } from '../src/lib/formSheetHost'
 import { useTheme } from '../src/theme/ThemeProvider'
 
@@ -20,8 +21,17 @@ export default function SheetRoute() {
   // ScrollView expects at most 2 subviews"). Pinning the wrapper keeps the
   // container at exactly one native child.
   return (
-    <View collapsable={false} style={{ backgroundColor: t.colors.surface }}>
-      {content}
-    </View>
+    <>
+      {/* Paint the native sheet's own background with the themed surface color.
+          _layout.tsx sets it to 'transparent' (it can't read the live theme
+          there), which leaves the strip under the home indicator — the region a
+          fitToContents sheet still covers but the content view doesn't paint —
+          showing the OS's default grey. Overriding contentStyle here (theme-
+          aware) fills that strip for every sheet in the app, light and dark. */}
+      <Stack.Screen options={{ contentStyle: { backgroundColor: t.colors.surface } }} />
+      <View collapsable={false} style={{ backgroundColor: t.colors.surface }}>
+        {content}
+      </View>
+    </>
   )
 }


### PR DESCRIPTION
…e color

Every native formSheet showed a grey strip under the home indicator. With sheetAllowedDetents 'fitToContents', iOS sizes the sheet to its content but still extends it under the home indicator; that bottom region is painted by the screen's contentStyle background, which _layout.tsx sets to 'transparent' (it can't read the live theme there) — so the OS default grey showed through on every sheet, on device too.

Override contentStyle in the shared sheet route (which does have the live theme) to the surface color, filling the strip for all sheets in light and dark. Since every sheet renders through this one route, it fixes them all.


Claude-Session: https://claude.ai/code/session_01PFCaZLP4P7wU28oSU2sDaw