### PR TITLE
Add fallback content to root HTML element

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -28,7 +28,10 @@
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#14171A">
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <h1>GraceChords</h1>
+      <p>GraceChords is a free, open-source worship tool for churches and worship teams to browse chord charts, build service setlists, and create printable songbooks.</p>
+    </div>
     <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Added fallback HTML content to the root div element in the main HTML file. This provides a basic description of GraceChords that will be visible if the React application fails to load or initialize.

## Changes
- Added an `<h1>` heading with the project name "GraceChords"
- Added a `<p>` description explaining the purpose of GraceChords as a free, open-source worship tool for churches and worship teams

## Implementation Details
The fallback content is placed directly in the `#root` div before the main React script loads. This ensures users see meaningful information about the application even if JavaScript fails to execute or the React app encounters initialization errors.

https://claude.ai/code/session_01VUZnWPbgoQCnjMf3yX8MUP