### PR TITLE
Fix Cloudflare deploy: remove postinstall-postinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,6 @@
       ],
       "dependencies": {
         "patch-package": "^8.0.1"
-      },
-      "devDependencies": {
-        "postinstall-postinstall": "^2.1.0"
       }
     },
     "apps/mobile": {
@@ -17017,14 +17014,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postinstall-postinstall": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
-      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/pptxgenjs": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   },
   "dependencies": {
     "patch-package": "^8.0.1"
-  },
-  "devDependencies": {
-    "postinstall-postinstall": "^2.1.0"
   }
 }


### PR DESCRIPTION
With the root postinstall fixed, the build progressed to the user build command (`npm ci && npm run build`), where `npm ci` failed inside node_modules/postinstall-postinstall:

    npm error command sh -c node ./run.js
    npm error Error: Command failed: yarn run postinstall
    Internal Error: gracechords-monorepo@workspace:.: This package doesn't
    seem to be present in your lockfile

postinstall-postinstall's own install hook shells out to `yarn run postinstall`; Yarn (berry) gets invoked in the npm-managed monorepo and errors on the missing yarn lockfile entry, aborting npm ci.

postinstall-postinstall is unused — the root postinstall now runs scripts/postinstall.mjs, which applies patches directly and does not need it. Remove the dependency. Verified with a clean `npm ci`: the install completes, the postinstall applies the mobile patch, and no yarn hook runs.


Claude-Session: https://claude.ai/code/session_01VUZnWPbgoQCnjMf3yX8MUP