### PR TITLE
Hide OAuth branding fallback to remove flash before hydration

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -29,8 +29,14 @@
   </head>
   <body>
     <div id="root">
-      <h1>GraceChords</h1>
-      <p>GraceChords is a free, open-source worship tool for churches and worship teams to browse chord charts, build service setlists, and create printable songbooks.</p>
+      <!-- Crawler-visible fallback for OAuth branding verification. Visually
+           hidden (no flash before React mounts) but present in the raw HTML
+           and accessibility tree. React replaces #root on mount. Uses inline
+           styles on each element rather than a wrapper <div>, because the
+           post-build SEO script matches #root with a non-greedy regex that
+           stops at the first </div>. -->
+      <h1 style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">GraceChords</h1>
+      <p style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">GraceChords is a free, open-source worship tool for churches and worship teams to browse chord charts, build service setlists, and create printable songbooks.</p>
     </div>
     <script type="module" src="./src/main.jsx"></script>
   </body>


### PR DESCRIPTION
The crawler-visible fallback inside #root painted as plain text before React mounted, causing a noticeable flash-of-fallback on load/reload. Apply the standard visually-hidden (sr-only) style inline to the <h1> and <p> so they occupy ~1px and are clipped: no visible flash or layout reflow, while the text stays in the raw HTML and accessibility tree for a non-JS crawler. React still replaces #root contents on mount.

Styles are inline on each element rather than a wrapper <div>, because the post-build SEO script matches #root with a non-greedy regex that stops at the first </div>; a nested div would corrupt the generated SEO pages.

Verified against the production build: fallback text is present in the DOM during load but its max visible area before mount is 1px (no visible flash), and React replaces it on mount.


Claude-Session: https://claude.ai/code/session_01VUZnWPbgoQCnjMf3yX8MUP