### PR TITLE
Add public delete account instructions and OAuth confirmation flow

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -11,6 +11,7 @@ const About = React.lazy(() => import('./pages/AboutPage'))
 const PrivacyPage = React.lazy(() => import('./pages/PrivacyPage'))
 const TermsPage = React.lazy(() => import('./pages/TermsPage'))
 const LicensesPage = React.lazy(() => import('./pages/LicensesPage'))
+const DeleteAccountPage = React.lazy(() => import('./pages/DeleteAccountPage'))
 const LoginPage = React.lazy(() => import('./pages/LoginPage'))
 const SignupPage = React.lazy(() => import('./pages/SignupPage'))
 const ProfilePage = React.lazy(() => import('./pages/ProfilePage'))
@@ -47,6 +48,7 @@ export default function App(){
             <Route path="/privacy" element={<PrivacyPage />} />
             <Route path="/terms" element={<TermsPage />} />
             <Route path="/licenses" element={<LicensesPage />} />
+            <Route path="/delete-account" element={<DeleteAccountPage />} />
             <Route path="/song/:id" element={<SongView />} />
             <Route path="/songs/:id" element={<SongView />} />
             <Route path="/setlist" element={<Setlist />} />

--- a/apps/web/src/__tests__/routing.smoke.test.jsx
+++ b/apps/web/src/__tests__/routing.smoke.test.jsx
@@ -29,6 +29,20 @@ describe('Routing smoke', () => {
     expect(await screen.findByRole('button', { name: /download pdf/i })).toBeInTheDocument()
   })
 
+  test('delete-account route renders publicly (no sign-in)', async () => {
+    // This URL is referenced by the Google Play store listing, so it must render
+    // for anonymous visitors. The page shows the deletion instructions heading.
+    window.location.hash = '#/delete-account'
+    render(
+      <HelmetProvider>
+        <HashRouter>
+          <App />
+        </HashRouter>
+      </HelmetProvider>
+    )
+    expect(await screen.findByRole('heading', { level: 1, name: /delete your account/i })).toBeInTheDocument()
+  })
+
   test('admin route is gated — anonymous users are redirected home', async () => {
     // /admin is wrapped in <RoleGuard minRole="admin">. With no authenticated
     // session the guard redirects to "/" instead of rendering the admin page,

--- a/apps/web/src/content/delete-account.md
+++ b/apps/web/src/content/delete-account.md
@@ -1,0 +1,81 @@
+# Delete Your Account
+
+**Applies to:** GraceChords, operated by Ryan Moore — the GraceChords website ([https://gracechords.com](https://gracechords.com)) and the GraceChords mobile app (collectively, the "Service").
+
+You can delete your GraceChords account and all of its associated data at any
+time. Account deletion is **immediate** and **permanent** — there is no waiting
+period or grace period, and a deleted account cannot be recovered.
+
+---
+
+## How to delete your account
+
+You can delete your account yourself in either the app or the website, or by
+emailing us.
+
+### On the website
+
+1. Go to [https://gracechords.com](https://gracechords.com) and **sign in**.
+2. Open your **Profile** (your account icon in the top navigation, or
+   [https://gracechords.com/profile](https://gracechords.com/profile)).
+3. Scroll to the **Account** section and select **Delete account**.
+4. Confirm in the dialog that appears. If you signed up with an email and
+   password, you'll confirm your password; if you signed in with Google or
+   Apple, you'll confirm by typing **DELETE**.
+5. Your account and data are deleted immediately and you're signed out.
+
+### In the mobile app
+
+1. Open the app and go to **Profile & Settings**.
+2. Select **Delete Account**.
+3. Confirm when prompted. Your account and data are deleted immediately and you
+   are signed out.
+
+### By email
+
+If you can't sign in, email **ryan@gracechords.com** from the address on your
+account and ask us to delete it. We'll verify your identity and delete your
+account.
+
+---
+
+## What data is deleted
+
+When you delete your account, we permanently remove all personal information and
+content associated with it, including:
+
+- Your **account identity** — email address and name
+- Your **sign-in credentials** and any linked sign-in providers (Google or Apple)
+- Your **starred songs**
+- Your **setlists**, key preferences, view settings, and reading-plan progress
+- Any **reflections** you have saved
+- Any **contributor-access requests** you have submitted
+- Any **linked Telegram account** connection
+
+Deletion cascades across our systems so that no personal profile or content
+tied to your account remains in the active Service.
+
+## What data is kept, and for how long
+
+- **Active systems:** nothing personal to you is retained in the active Service
+  after deletion.
+- **Backups:** routine encrypted backups may briefly contain your data and are
+  purged on a regular cycle, after which no copy remains.
+- **Legal records:** in rare cases we may retain limited records where we are
+  legally required to do so; these are kept only as long as the law requires and
+  are not used for any other purpose.
+
+The public songs, Scripture texts, and other library content in GraceChords are
+not personal to you and are unaffected by deleting your account.
+
+---
+
+## Questions
+
+For anything related to your account or data, contact:
+
+**Ryan Moore — GraceChords**
+Email: **ryan@gracechords.com**
+Location: Georgia, USA
+
+See also our [Privacy Policy](/privacy) and [Terms of Use](/terms).

--- a/apps/web/src/pages/DeleteAccountPage.jsx
+++ b/apps/web/src/pages/DeleteAccountPage.jsx
@@ -1,0 +1,31 @@
+import React, { useMemo } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
+import deleteAccountMarkdown from '../content/delete-account.md?raw'
+import '../styles/posts.css'
+
+// Renders the public Delete Account instructions at /delete-account from the
+// markdown source in src/content/. Same marked → DOMPurify → .gc-prose pipeline
+// as PrivacyPage/TermsPage. This URL is referenced by the Google Play store
+// listing, so it must stay publicly reachable without signing in. Edit the .md
+// to update.
+export default function DeleteAccountPage() {
+  const html = useMemo(
+    () => DOMPurify.sanitize(marked.parse(deleteAccountMarkdown, { async: false })),
+    []
+  )
+
+  return (
+    <div className="container gc-post-detail">
+      <Helmet>
+        <title>Delete Your Account · GraceChords</title>
+        <meta name="description" content="How to delete your GraceChords account and the data that is removed." />
+      </Helmet>
+      <div
+        className="gc-post-detail__content gc-prose"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/pages/ProfilePage.jsx
+++ b/apps/web/src/pages/ProfilePage.jsx
@@ -34,8 +34,17 @@ export default function ProfilePage() {
 
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [deletePassword, setDeletePassword] = useState('')
+  const [deleteConfirmText, setDeleteConfirmText] = useState('')
   const [deleteError, setDeleteError] = useState('')
   const [deleting, setDeleting] = useState(false)
+
+  // Whether this account can sign in with an email + password. OAuth-only
+  // accounts (Google / Apple) have no password to confirm, so the delete flow
+  // falls back to a typed confirmation for them.
+  const hasPasswordLogin =
+    (session?.user?.identities || []).some(i => i.provider === 'email') ||
+    (session?.user?.app_metadata?.providers || []).includes('email') ||
+    session?.user?.app_metadata?.provider === 'email'
 
   // Telegram link state
   const [telegramState, setTelegramState] = useState({ linked: false, telegram_user_id: null, telegram_linked_at: null })
@@ -246,15 +255,18 @@ export default function ProfilePage() {
   async function deleteAccount() {
     setDeleteError('')
     setDeleting(true)
-    // Verify password before deletion
-    const { error: authError } = await supabase.auth.signInWithPassword({
-      email: session.user.email,
-      password: deletePassword,
-    })
-    if (authError) {
-      setDeleteError('Incorrect password. Please try again.')
-      setDeleting(false)
-      return
+    // Verify password before deletion for password accounts. OAuth-only accounts
+    // have no password, so the modal requires typing "DELETE" instead.
+    if (hasPasswordLogin) {
+      const { error: authError } = await supabase.auth.signInWithPassword({
+        email: session.user.email,
+        password: deletePassword,
+      })
+      if (authError) {
+        setDeleteError('Incorrect password. Please try again.')
+        setDeleting(false)
+        return
+      }
     }
     // Delete account via RPC (SECURITY DEFINER function removes from auth.users + cascades)
     const { error: deleteError } = await supabase.rpc('delete_user')
@@ -453,7 +465,7 @@ export default function ProfilePage() {
           </div>
           <button
             className="gc-btn gc-btn--danger"
-            onClick={() => { setDeletePassword(''); setDeleteError(''); setShowDeleteModal(true) }}
+            onClick={() => { setDeletePassword(''); setDeleteConfirmText(''); setDeleteError(''); setShowDeleteModal(true) }}
             style={{ width: 'fit-content', flexShrink: 0 }}
           >
             Delete account
@@ -470,18 +482,33 @@ export default function ProfilePage() {
               This will permanently delete your account and all your data, including starred songs
               and any contributor requests. <strong style={{ color: 'var(--gc-danger)' }}>This cannot be undone.</strong>
             </p>
-            <div className="gc-form-field">
-              <label htmlFor="deletePassword">Confirm your password</label>
-              <input
-                id="deletePassword"
-                type="password"
-                value={deletePassword}
-                onChange={e => { setDeletePassword(e.target.value); setDeleteError('') }}
-                placeholder="Enter your password"
-                autoComplete="current-password"
-                disabled={deleting}
-              />
-            </div>
+            {hasPasswordLogin ? (
+              <div className="gc-form-field">
+                <label htmlFor="deletePassword">Confirm your password</label>
+                <input
+                  id="deletePassword"
+                  type="password"
+                  value={deletePassword}
+                  onChange={e => { setDeletePassword(e.target.value); setDeleteError('') }}
+                  placeholder="Enter your password"
+                  autoComplete="current-password"
+                  disabled={deleting}
+                />
+              </div>
+            ) : (
+              <div className="gc-form-field">
+                <label htmlFor="deleteConfirmText">Type DELETE to confirm</label>
+                <input
+                  id="deleteConfirmText"
+                  type="text"
+                  value={deleteConfirmText}
+                  onChange={e => { setDeleteConfirmText(e.target.value); setDeleteError('') }}
+                  placeholder="DELETE"
+                  autoComplete="off"
+                  disabled={deleting}
+                />
+              </div>
+            )}
             {deleteError && (
               <p className="gc-auth-error" style={{ margin: 0 }}>{deleteError}</p>
             )}
@@ -489,7 +516,12 @@ export default function ProfilePage() {
               <button
                 className="gc-btn gc-btn--danger"
                 onClick={deleteAccount}
-                disabled={deleting || !deletePassword}
+                disabled={
+                  deleting ||
+                  (hasPasswordLogin
+                    ? !deletePassword
+                    : deleteConfirmText.trim().toUpperCase() !== 'DELETE')
+                }
               >
                 {deleting ? 'Deleting…' : 'Delete my account'}
               </button>


### PR DESCRIPTION
## Summary
Adds a public-facing delete account instructions page and updates the account deletion flow to support OAuth-only accounts (Google/Apple sign-in) that don't have passwords.

## Changes

- **New public page** (`DeleteAccountPage.jsx`): Renders delete account instructions from markdown at `/delete-account`. This URL is referenced by the Google Play store listing and must be publicly accessible without authentication.

- **Delete account instructions** (`delete-account.md`): Comprehensive markdown guide covering:
  - How to delete via website, mobile app, or email
  - What data is deleted (account identity, credentials, starred songs, setlists, reflections, etc.)
  - What data is retained (backups, legal records)
  - Contact information for support

- **OAuth account deletion support** (`ProfilePage.jsx`):
  - Detects whether account uses password login or OAuth-only (Google/Apple)
  - For password accounts: confirms deletion with password (existing flow)
  - For OAuth accounts: confirms deletion by typing "DELETE" (new flow)
  - Updated modal UI to conditionally show password or text confirmation field
  - Button disabled state now validates the appropriate confirmation method

- **Routing**: Added `/delete-account` route to `App.jsx` with lazy loading

- **Tests**: Added smoke test verifying the delete account page renders publicly without authentication

## Implementation Details

The OAuth detection logic checks multiple identity provider fields to determine if an account has email/password sign-in capability, falling back to a typed confirmation for OAuth-only accounts. The confirmation text is case-insensitive and trimmed before validation.

https://claude.ai/code/session_01TB1JSYfxRVJUYofuHYMwtC