### PR TITLE
Fix Android tab bar layout with always-visible labels

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import { NativeTabs } from 'expo-router/unstable-native-tabs'
+import { Platform } from 'react-native'
 import { ThemeProvider as NavThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '../../src/theme/ThemeProvider'
@@ -28,13 +29,29 @@ import { useTheme } from '../../src/theme/ThemeProvider'
 // color scheme) is required to prevent the known iOS 26 dark-mode glass flicker
 // on header buttons when switching tabs. It is aliased so it does not shadow the
 // app's own token ThemeProvider.
+//
+// Android bar tuning (Material 3): `labelVisibilityMode="labeled"` keeps every
+// tab's label visible. The NativeTabs default is `auto`, which — with five tabs
+// (>3) — collapses labels to the selected tab only, leaving the other four as
+// lone icons floating in the 80dp Material bar. That sparse, top-heavy layout is
+// the "lots of blank space / bulky" feel; always-on labels fill the bar so it
+// reads as balanced and intentional, and matches Material 3's own guidance that
+// navigation-bar labels stay visible. `labelVisibilityMode` is an Android-only
+// NativeTabs prop (`@platform android`) — iOS ignores it, so the iOS Liquid-Glass
+// and standard bars are untouched. The small label-size nudge goes through the
+// cross-platform `labelStyle`, so it is gated to Android to leave iOS labels
+// exactly as the system draws them.
 
 export default function TabsLayout() {
   const t = useTheme()
   const { t: tx } = useTranslation('nav')
   return (
     <NavThemeProvider value={t.mode === 'dark' ? DarkTheme : DefaultTheme}>
-      <NativeTabs tintColor={t.colors.accent}>
+      <NativeTabs
+        tintColor={t.colors.accent}
+        labelVisibilityMode="labeled"
+        labelStyle={Platform.OS === 'android' ? { fontSize: 13 } : undefined}
+      >
         <NativeTabs.Trigger name="index">
           <NativeTabs.Trigger.Icon
             sf={{ default: 'house', selected: 'house.fill' }}


### PR DESCRIPTION
## Summary
Improves the Android tab navigation bar layout by ensuring tab labels remain always visible, creating a more balanced and intentional appearance that aligns with Material 3 design guidance.

## Changes
- Added `Platform` import from `react-native` to enable platform-specific styling
- Set `labelVisibilityMode="labeled"` on `NativeTabs` to keep all tab labels visible on Android (prevents the default `auto` mode from collapsing labels to the selected tab only when there are more than 3 tabs)
- Added platform-gated `labelStyle` with slightly reduced font size (13px) for Android to optimize label spacing in the 80dp Material navigation bar
- Expanded code comments to document the Android Material 3 tuning rationale and clarify that these changes are Android-only (iOS behavior remains unchanged)

## Implementation Details
The `labelVisibilityMode` prop is Android-only (`@platform android`), so iOS ignores it and preserves the existing Liquid-Glass and standard bar appearance. The `labelStyle` font-size adjustment is also gated to Android via `Platform.OS` check to ensure iOS labels render exactly as the system draws them.

https://claude.ai/code/session_01LqWLrhNv5sVJFur5gf4HeV