### PR TITLE
Replace logo images with text wordmark for SEO and OAuth compliance

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,6 +6,27 @@
     <meta name="robots" content="index,follow" />
     <meta name="description" content="GraceChords provides free worship chord sheets and lyrics for churches, worship teams, and believers." />
     <title>GraceChords</title>
+    <!-- App name in the raw HTML head so crawlers and Google's OAuth branding
+         review read "GraceChords" without executing JS. og:site_name and the
+         WebSite/Organization JSON-LD declare the name explicitly; the React app
+         (react-helmet) refines these per route after mount. -->
+    <meta property="og:site_name" content="GraceChords" />
+    <meta property="og:title" content="GraceChords" />
+    <meta property="application-name" content="GraceChords" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "GraceChords",
+        "alternateName": "GraceChords.com",
+        "url": "https://gracechords.com/",
+        "publisher": {
+          "@type": "Organization",
+          "name": "GraceChords",
+          "url": "https://gracechords.com/"
+        }
+      }
+    </script>
     <!-- Preconnect to Supabase so DNS + TLS happen in parallel with HTML parsing -->
     <link rel="preconnect" href="https://tndnjetevtgohunqpzbi.supabase.co" crossorigin />
     <link rel="dns-prefetch" href="https://tndnjetevtgohunqpzbi.supabase.co" />

--- a/apps/web/src/components/ui/Navbar.tsx
+++ b/apps/web/src/components/ui/Navbar.tsx
@@ -8,7 +8,6 @@ import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
 import SpriteAvatar from './SpriteAvatar'
 import SettingsCluster from './SettingsCluster'
-import { useSettings } from '../../hooks/useSettings'
 import '../../styles/auth.css'
 
 export default function Navbar(){
@@ -23,8 +22,6 @@ export default function Navbar(){
   const [portalNode, setPortalNode] = useState<HTMLDivElement | null>(null)
   const [open, setOpen] = React.useState(false)
   const { isLoggedIn, loading: authLoading, session, profile, hasMinRole, role } = useAuth()
-  const { theme } = useSettings()
-  const isDark = theme === 'dark'
   const [userMenuOpen, setUserMenuOpen] = React.useState(false)
   const userMenuRef = React.useRef<HTMLDivElement | null>(null)
   const [settingsOpen, setSettingsOpen] = React.useState(false)
@@ -134,23 +131,11 @@ export default function Navbar(){
     <>
       <nav className="gc-navbar" ref={navRef as any}>
         <div className="gc-navbar__inner">
+        {/* Readable text wordmark instead of an embedded-image logo, so the
+            app name "GraceChords" is present as real text for crawlers and
+            OAuth branding review (matches the app name on the consent screen). */}
         <Link to="/" className="gc-brand" aria-label={t('graceChordsHome')}>
-          {/* Wide logo for tablet/desktop */}
-          <img
-            src={isDark ? '/gc-brand-wide-dark.svg' : '/gc-brand-wide-light.svg'}
-            alt="GraceChords"
-            className="gc-brand__logo gc-brand__logo--wide"
-            width={240}
-            height={42}
-          />
-          {/* Square logo for mobile */}
-          <img
-            src={isDark ? '/gc-brand-square-dark.svg' : '/gc-brand-square-light.svg'}
-            alt="GraceChords"
-            className="gc-brand__logo gc-brand__logo--square"
-            width={60}
-            height={42}
-          />
+          <span className="gc-brand__wordmark">GraceChords</span>
         </Link>
         {/* Hamburger on mobile/tablet */}
         <button

--- a/apps/web/src/components/ui/ui.css
+++ b/apps/web/src/components/ui/ui.css
@@ -69,30 +69,20 @@
     cursor:pointer;
   }
 
-  .gc-brand__logo{
+  /* Text wordmark for the brand/home link. Rendered as real, selectable text
+     (not an image) so the app name is readable by search crawlers and Google's
+     OAuth branding review. */
+  .gc-brand__wordmark{
     display:block;
-    height:100%;
-    -webkit-user-drag:none;
-    -webkit-user-select:none;
-    user-select:none;
-    pointer-events:none;
+    line-height:1;
+    white-space:nowrap;
+    font-size:1.25rem;
   }
 
-  /* Default: square logo on small screens */
-  .gc-brand__logo--square{
-    display:block;
-  }
-  .gc-brand__logo--wide{
-    display:none;
-  }
-
-  /* Tablet/desktop: show wide logo, hide square logo */
+  /* Tablet/desktop: give the wordmark a little more presence */
   @media (min-width: 640px){
-    .gc-brand__logo--wide{
-      display:block;
-    }
-    .gc-brand__logo--square{
-      display:none;
+    .gc-brand__wordmark{
+      font-size:1.4rem;
     }
   }
   .gc-navlinks{ display:flex; gap:var(--space-2); align-items:center; }


### PR DESCRIPTION
## Summary
Replace the embedded SVG logo images in the navbar with a text-based wordmark ("GraceChords") to improve search engine crawlability and comply with Google's OAuth branding review requirements, which expect the app name to be present as real, selectable text.

## Changes
- **Navbar component**: Removed dual image logos (square for mobile, wide for tablet/desktop) and replaced with a simple `<span>` containing the text "GraceChords"
  - Removed `useSettings` hook and theme-based image switching logic
  - Removed responsive image display logic
- **UI styles**: Refactored `.gc-brand__logo` classes to `.gc-brand__wordmark` with typography-focused styling
  - Added `line-height: 1`, `white-space: nowrap`, and `font-size: 1.25rem` for text rendering
  - Removed image-specific properties (`-webkit-user-drag`, `user-select`, `pointer-events`)
  - Simplified responsive behavior: increased font size to `1.4rem` on tablet/desktop (640px+)
- **HTML head**: Added structured metadata and JSON-LD schema to declare the app name in raw HTML
  - Added `og:site_name`, `og:title`, and `application-name` meta tags
  - Added WebSite/Organization JSON-LD schema with explicit name declaration
  - Included comments explaining the purpose for crawlers and OAuth review

## Implementation Details
The text wordmark approach ensures "GraceChords" is readable by search crawlers and present on the OAuth consent screen without requiring JavaScript execution. The metadata additions in `index.html` provide explicit name declarations for both social sharing and structured data consumers.

https://claude.ai/code/session_01TgWfmgdQfKmJyngyEUyF3A