### PR TITLE
Enable Android App Links and credential autofill

### DIFF
--- a/apps/web/public/.well-known/README.md
+++ b/apps/web/public/.well-known/README.md
@@ -19,12 +19,17 @@ App ID `J7Y8NYZ48Q.com.gracechords.app`. Claims:
   `packages/core/src/setlists/setcode.js` `decodeSet`. When the app isn't
   installed these paths open the web app as usual (Universal Links fallback).
 
-## `assetlinks.json` (Android — inert scaffold)
-### TODO(android)
-Wired ahead of an Android release but **inert**: `sha256_cert_fingerprints`
-holds a placeholder. No Android app is published, so verification cannot
-succeed yet. When an Android signing key exists, replace
-`TODO_ANDROID_RELEASE_SHA256_FINGERPRINT` with the release key's SHA-256
-fingerprint (e.g. from `keytool -list -v` or the Play Console app-signing page)
-and add the same song paths to `android.intentFilters` in
-`apps/mobile/app.json`.
+## `assetlinks.json` (Android — active)
+Package `com.gracechords.app`. Declares the Digital Asset Links statements
+that let the app claim `https://gracechords.com/...` links (App Links) and
+autofill saved credentials:
+
+- `delegate_permission/common.handle_all_urls` — verified App Links.
+- `delegate_permission/common.get_login_creds` — Credential Manager /
+  Smart Lock login-credential sharing.
+
+`sha256_cert_fingerprints` lists both accepted release-key SHA-256
+fingerprints (e.g. from `keytool -list -v` or the Play Console app-signing
+page); keep them in sync with the keys actually used to sign shipping builds.
+The claimed song/setlist paths must also be present in
+`android.intentFilters` in `apps/mobile/app.json`.

--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -1,10 +1,16 @@
 [
   {
-    "relation": ["delegate_permission/common.handle_all_urls"],
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
     "target": {
       "namespace": "android_app",
       "package_name": "com.gracechords.app",
-      "sha256_cert_fingerprints": ["E6:4E:8D:A6:4E:C4:6C:12:8B:5D:A2:E4:3E:47:74:5B:9A:73:C4:81:F3:89:EE:97:E8:5F:17:93:FF:92:81:B6"]
+      "sha256_cert_fingerprints": [
+        "E6:4E:8D:A6:4E:C4:6C:12:8B:5D:A2:E4:3E:47:74:5B:9A:73:C4:81:F3:89:EE:97:E8:5F:17:93:FF:92:81:B6",
+        "8B:C8:78:72:96:1F:08:1B:D0:1E:6B:D4:A7:9F:7E:11:7C:19:E3:66:F8:07:F8:29:1C:37:DD:1D:14:69:5C:A7"
+      ]
     }
   }
 ]


### PR DESCRIPTION
Activates Digital Asset Links configuration for the Android app to support App Links and Credential Manager integration.

## Summary
Updates `assetlinks.json` to declare active Digital Asset Links statements for the Android app (`com.gracechords.app`), enabling verified App Links for gracechords.com URLs and credential autofill via Credential Manager / Smart Lock.

## Changes
- **Added credential autofill permission**: Includes `delegate_permission/common.get_login_creds` alongside the existing `delegate_permission/common.handle_all_urls` to enable login-credential sharing with Credential Manager.
- **Added second release key fingerprint**: Expands `sha256_cert_fingerprints` to accept both release-key SHA-256 fingerprints, allowing flexibility across signing keys used for shipping builds.
- **Updated documentation**: Revised README to reflect the active status of `assetlinks.json`, clarifying the purpose of each permission and maintenance requirements (keeping fingerprints and intent filters in sync with actual signing keys and claimed paths).

## Notes
The claimed song/setlist paths must be present in `android.intentFilters` in `apps/mobile/app.json` for the configuration to be complete.

https://claude.ai/code/session_019VEzp3AvwdZRawupAPUq37