### PR TITLE
Diagnose Android Google sign-in DEVELOPER_ERROR distinctly

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -20,12 +20,22 @@ EXPO_PUBLIC_API_BASE_URL=https://www.gracechords.com
 EXPO_PUBLIC_R2_PUBLIC_URL=https://assets.gracechords.com
 
 # Native Google Sign-In (id-token flow -> supabase.auth.signInWithIdToken).
-# Create BOTH OAuth clients in Google Cloud Console -> APIs & Services ->
-# Credentials:
+# Create ALL THREE OAuth clients in Google Cloud Console -> APIs & Services ->
+# Credentials (they must all live in the SAME Google Cloud project):
 #  - a "Web application" client: its id is the token audience Supabase
 #    validates (also add it to Supabase -> Auth -> Providers -> Google ->
-#    Authorized Client IDs, alongside the iOS client id).
+#    Authorized Client IDs, alongside the iOS client id). This is the ONLY
+#    client id the JS code passes (as webClientId, used on both platforms).
 #  - an "iOS" client bound to bundle id com.gracechords.app.
+#  - an "Android" client bound to package name com.gracechords.app AND the
+#    signing certificate's SHA-1 fingerprint. REQUIRED for Android sign-in even
+#    though its id never appears in code — Google matches the running app to it
+#    by package + SHA-1. Without it the account picker still appears, then
+#    sign-in fails with DEVELOPER_ERROR (surfaced as errors.googleConfigError).
+#    Register the SHA-1 of EVERY signing key you ship: the local debug keystore
+#    (~/.android/debug.keystore) for `expo run:android`, and the EAS / Play
+#    App Signing key for release builds
+#    (get them with `eas credentials` or from Play Console -> App integrity).
 # ALSO enable Supabase -> Auth -> Providers -> Google -> "Skip nonce checks".
 # On iOS the native Google SDK embeds a nonce in the id_token, but the free
 # google-signin library cannot supply the matching raw nonce (custom nonce is a

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -249,7 +249,14 @@ duplicate logic here and never edit core internals to suit mobile.
   `src/lib/authDeps.ts`. Google client ids come from
   `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` / `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID`, and the
   reversed iOS client id must be set in `app.json` → google-signin plugin
-  `iosUrlScheme`. Supabase's Google provider must have **"Skip nonce checks"**
+  `iosUrlScheme`. **Android additionally needs its own "Android"-type OAuth
+  client** (package `com.gracechords.app` + the signing SHA-1) in the same
+  Google Cloud project — its id never appears in code, Google matches the app by
+  package + SHA-1. Without it the account picker shows and then sign-in fails
+  with `DEVELOPER_ERROR` (code 10), which `googleSignIn` maps to
+  `errors.googleConfigError` (register the SHA-1 of every signing key you ship —
+  local debug keystore and the EAS/Play App Signing key). Supabase's Google
+  provider must have **"Skip nonce checks"**
   enabled: iOS embeds a nonce in the id-token that the free google-signin lib
   can't reproduce, so otherwise `signInWithIdToken` rejects it ("Passed nonce and
   nonce in id_token should either both exist or not"). Apple is unaffected — it
@@ -480,6 +487,8 @@ downloads for songs** (Bible-translation downloads ship — see the downloads
 module above — but on-device song/setlist persistence does not), the Song Library
 **"Add song"** button (a no-op), **password reset / email-confirmation** screens (the login "Forgot?"
 link is an informational alert only), tablet master-detail, EAS Build /
-TestFlight, Android (auth code is cross-platform-safe, but Android OAuth config —
-SHA-1, google-services — is not set up), GraceTracks, and migrating web's
+TestFlight, Android (auth code is cross-platform-safe, but native Google
+sign-in needs an Android-type OAuth client — package + signing SHA-1 — in the
+Google Cloud project; without it the picker shows then fails with
+DEVELOPER_ERROR → `errors.googleConfigError`), GraceTracks, and migrating web's
 `features/readings` onto core's `bible` module.

--- a/apps/mobile/src/i18n/locales/en/auth.json
+++ b/apps/mobile/src/i18n/locales/en/auth.json
@@ -38,6 +38,7 @@
     "appleNoCredential": "Apple did not return a credential.",
     "googlePlayUnavailable": "Google Play Services is unavailable on this device.",
     "googleFailed": "Google sign-in failed. Please try again.",
+    "googleConfigError": "Google sign-in isn't set up correctly for this app. Please use another sign-in method or contact support.",
     "googleNoCredential": "Google did not return a credential."
   },
   "spritePicker": {

--- a/apps/mobile/src/i18n/locales/es/auth.json
+++ b/apps/mobile/src/i18n/locales/es/auth.json
@@ -38,6 +38,7 @@
     "appleNoCredential": "Apple no devolvió una credencial.",
     "googlePlayUnavailable": "Los servicios de Google Play no están disponibles en este dispositivo.",
     "googleFailed": "El inicio de sesión con Google falló. Inténtalo de nuevo.",
+    "googleConfigError": "El inicio de sesión con Google no está configurado correctamente para esta app. Usa otro método de inicio de sesión o contacta con soporte.",
     "googleNoCredential": "Google no devolvió una credencial."
   },
   "spritePicker": {

--- a/apps/mobile/src/i18n/locales/ko/auth.json
+++ b/apps/mobile/src/i18n/locales/ko/auth.json
@@ -38,6 +38,7 @@
     "appleNoCredential": "Apple에서 자격 증명을 반환하지 않았습니다.",
     "googlePlayUnavailable": "이 기기에서 Google Play 서비스를 사용할 수 없습니다.",
     "googleFailed": "Google 로그인에 실패했습니다. 다시 시도해 주세요.",
+    "googleConfigError": "이 앱에서 Google 로그인이 올바르게 설정되지 않았습니다. 다른 로그인 방법을 사용하거나 지원팀에 문의하세요.",
     "googleNoCredential": "Google에서 자격 증명을 반환하지 않았습니다."
   },
   "spritePicker": {

--- a/apps/mobile/src/i18n/locales/tr/auth.json
+++ b/apps/mobile/src/i18n/locales/tr/auth.json
@@ -38,6 +38,7 @@
     "appleNoCredential": "Apple bir kimlik bilgisi döndürmedi.",
     "googlePlayUnavailable": "Bu cihazda Google Play Hizmetleri kullanılamıyor.",
     "googleFailed": "Google ile giriş başarısız oldu. Lütfen tekrar deneyin.",
+    "googleConfigError": "Google ile giriş bu uygulama için doğru şekilde yapılandırılmamış. Lütfen başka bir giriş yöntemi kullanın veya destek ekibiyle iletişime geçin.",
     "googleNoCredential": "Google bir kimlik bilgisi döndürmedi."
   },
   "spritePicker": {

--- a/apps/mobile/src/lib/__tests__/authFlows.test.ts
+++ b/apps/mobile/src/lib/__tests__/authFlows.test.ts
@@ -140,6 +140,7 @@ function googleDeps(overrides: Partial<GoogleDeps> = {}): GoogleDeps {
     signIn: vi.fn().mockResolvedValue({ idToken: 'google-jwt' }),
     isCancelError: (e) => (e as { code?: string })?.code === 'CANCELED',
     isPlayServicesError: (e) => (e as { code?: string })?.code === 'NO_PLAY_SERVICES',
+    isConfigError: (e) => (e as { code?: string })?.code === '10',
     ...overrides,
   }
 }
@@ -186,6 +187,19 @@ describe('googleSignIn', () => {
 
     const result = await googleSignIn(deps)
     expect(result.ok).toBe(false)
+    expect(supabase.auth.signInWithIdToken).not.toHaveBeenCalled()
+  })
+
+  it('reports a DEVELOPER_ERROR (code 10) distinctly, not as a generic failure', async () => {
+    const supabase = fakeSupabase()
+    // The Android native module rejects an unregistered SHA-1 / OAuth client
+    // with CommonStatusCodes.DEVELOPER_ERROR ("10") — the account picker shows,
+    // then sign-in fails right after selection.
+    const err = Object.assign(new Error('DEVELOPER_ERROR'), { code: '10' })
+    const deps = googleDeps({ supabase, signIn: vi.fn().mockRejectedValue(err) })
+
+    const result = await googleSignIn(deps)
+    expect(result).toEqual({ ok: false, error: 'errors.googleConfigError' })
     expect(supabase.auth.signInWithIdToken).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/lib/authDeps.ts
+++ b/apps/mobile/src/lib/authDeps.ts
@@ -54,5 +54,10 @@ export function makeGoogleDeps(): GoogleDeps {
       (e.code === statusCodes.SIGN_IN_CANCELLED || e.code === statusCodes.IN_PROGRESS),
     isPlayServicesError: (e) =>
       isErrorWithCode(e) && e.code === statusCodes.PLAY_SERVICES_NOT_AVAILABLE,
+    // DEVELOPER_ERROR is not part of the public `statusCodes`; the Android
+    // native module rejects with the raw CommonStatusCodes.DEVELOPER_ERROR
+    // value ("10"). It means the app's package + signing SHA-1 aren't registered
+    // against an Android OAuth client in webClientId's Google Cloud project.
+    isConfigError: (e) => isErrorWithCode(e) && e.code === '10',
   }
 }

--- a/apps/mobile/src/lib/authFlows.ts
+++ b/apps/mobile/src/lib/authFlows.ts
@@ -81,6 +81,11 @@ export type GoogleDeps = {
   signIn: () => Promise<{ idToken: string | null }>
   isCancelError: (e: unknown) => boolean
   isPlayServicesError: (e: unknown) => boolean
+  // True for the native DEVELOPER_ERROR (Android status code 10): the app's
+  // package name + signing SHA-1 are not registered against an Android OAuth
+  // client in the same Google Cloud project as webClientId. The account picker
+  // still appears, then sign-in fails right after selection.
+  isConfigError: (e: unknown) => boolean
 }
 
 export async function googleSignIn(deps: GoogleDeps): Promise<AuthResult> {
@@ -92,6 +97,12 @@ export async function googleSignIn(deps: GoogleDeps): Promise<AuthResult> {
     if (deps.isCancelError(e)) return { ok: false, canceled: true }
     if (deps.isPlayServicesError(e)) {
       return { ok: false, error: 'errors.googlePlayUnavailable' }
+    }
+    // A misconfigured Android OAuth client (missing SHA-1) surfaces here rather
+    // than as a network/cancel error; report it distinctly so the failure is
+    // diagnosable instead of the generic "please try again".
+    if (deps.isConfigError(e)) {
+      return { ok: false, error: 'errors.googleConfigError' }
     }
     return { ok: false, error: 'errors.googleFailed' }
   }


### PR DESCRIPTION
On Android the account picker appears and then sign-in fails with the generic "Google sign-in failed. Please try again." The underlying cause is a Google Cloud misconfiguration: there is no Android-type OAuth client (package com.gracechords.app + signing SHA-1) in the same project as the web client id, so the native SDK rejects with CommonStatusCodes. DEVELOPER_ERROR (code "10") right after account selection.

The flow previously funneled that rejection into errors.googleFailed, which reads as a transient error and hides the real (config) problem.

- authFlows.googleSignIn: add an isConfigError branch that maps the DEVELOPER_ERROR to a new errors.googleConfigError message.
- authDeps.makeGoogleDeps: detect it via the raw code "10" (DEVELOPER_ERROR is not part of the public statusCodes object).
- Add errors.googleConfigError to en/es/ko/tr auth locales.
- Cover the new branch in authFlows.test.ts.
- Document the required Android OAuth client + SHA-1 setup in .env.example and AGENTS.md (the actual manual fix that makes sign-in work).


Claude-Session: https://claude.ai/code/session_01Czwbm4UY8ptTA4KkqchGp7