### PR TITLE
Spike: reuse packages/core in Studio via JavaScriptCore

### DIFF
--- a/apps/studio/GraceChords Studio/GraceChords Studio/ContentView.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/ContentView.swift
@@ -4,18 +4,42 @@
 //
 //  Created by Ryan Moore on 7/24/26.
 //
+//  Plumbing spike only: runs the CoreBridge self-check once and prints the
+//  round-trip results. No design work here — this view is expected to be replaced
+//  wholesale by the real Studio UI.
+//
 
 import SwiftUI
 
 struct ContentView: View {
+    // `static let` so the context is built once, not on every view re-init.
+    private static let sharedReport = CoreBridgeSpike.run()
+    private var report: SpikeReport { Self.sharedReport }
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("packages/core → JavaScriptCore")
+                    .font(.headline)
+                Text(report.headline)
+                    .font(.subheadline)
+                    .foregroundStyle(report.allPassed ? .green : .red)
+
+                Divider()
+
+                ForEach(report.checks) { check in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(check.passed ? "✓" : "✗")
+                            .foregroundStyle(check.passed ? .green : .red)
+                        Text(check.text)
+                            .textSelection(.enabled)
+                    }
+                    .font(.system(.body, design: .monospaced))
+                }
+            }
+            .padding()
+            .frame(minWidth: 520, alignment: .leading)
         }
-        .padding()
     }
 }
 

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Core/CoreBridge.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Core/CoreBridge.swift
@@ -1,0 +1,174 @@
+//
+//  CoreBridge.swift
+//  GraceChords Studio
+//
+//  Thin wrapper around a JavaScriptCore context running packages/core.
+//
+//  The context is loaded from Resources/GraceChordsCore.js — the flat IIFE built
+//  by apps/studio/js/build-core-bundle.mjs, which assigns a GraceChordsCore
+//  global. Only specific, typed functions are exposed here; there is deliberately
+//  no general-purpose "evaluate this string" API.
+//
+//  Not thread-safe: a JSContext must not be used concurrently. Construct one
+//  CoreBridge and call it from a single thread (Studio uses the main thread).
+//
+
+import Foundation
+import JavaScriptCore
+
+enum CoreBridgeError: Error, LocalizedError {
+    /// GraceChordsCore.js was not found in the app bundle's Resources.
+    case bundleMissing(searchedIn: String)
+    case bundleUnreadable(path: String, reason: String)
+    /// Evaluating the bundle threw.
+    case evaluationFailed(String)
+    /// The bundle evaluated but did not expose the expected global/function.
+    case missingExport(String)
+    /// JavaScript threw while the call was running.
+    case jsException(String)
+    /// The call returned something other than the expected type.
+    case unexpectedResult(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .bundleMissing(let searchedIn):
+            return """
+            GraceChordsCore.js is not in the app bundle (searched \(searchedIn)). \
+            Run `node "apps/studio/js/build-core-bundle.mjs"` and confirm the file \
+            is in the target's Copy Bundle Resources phase.
+            """
+        case .bundleUnreadable(let path, let reason):
+            return "Could not read \(path): \(reason)"
+        case .evaluationFailed(let message):
+            return "Loading the core bundle failed: \(message)"
+        case .missingExport(let name):
+            return "The core bundle did not export \(name)."
+        case .jsException(let message):
+            return "JavaScript error: \(message)"
+        case .unexpectedResult(let message):
+            return "Unexpected result from the core bundle: \(message)"
+        }
+    }
+}
+
+final class CoreBridge {
+    private static let resourceName = "GraceChordsCore"
+    private static let globalName = "GraceChordsCore"
+
+    /// Collects the last uncaught JS exception. A reference box rather than a
+    /// stored property so `init` can install the handler before `self` exists.
+    private final class ExceptionSink {
+        var message: String?
+
+        func take() -> String? {
+            defer { message = nil }
+            return message
+        }
+    }
+
+    private let context: JSContext
+    private let transposeFunction: JSValue
+    private let sink: ExceptionSink
+
+    /// Path of the bundle that was actually loaded — used by the spike's
+    /// "is it really in Resources?" check.
+    let bundleURL: URL
+
+    init(bundle: Bundle = .main) throws {
+        guard let url = bundle.url(forResource: Self.resourceName, withExtension: "js") else {
+            throw CoreBridgeError.bundleMissing(searchedIn: bundle.bundlePath)
+        }
+
+        let source: String
+        do {
+            source = try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw CoreBridgeError.bundleUnreadable(path: url.path, reason: error.localizedDescription)
+        }
+
+        // JavaScriptCore's headers are inconsistently nullability-annotated across
+        // SDKs, so every JSC return value is widened to an Optional before being
+        // unwrapped. That compiles whether the API imports as T, T!, or T?.
+        let newContext: JSContext? = JSContext()
+        guard let context = newContext else {
+            throw CoreBridgeError.evaluationFailed("JSContext could not be created")
+        }
+
+        let sink = ExceptionSink()
+        context.name = Self.globalName
+        context.exceptionHandler = { _, exception in
+            sink.message = CoreBridge.describe(exception)
+        }
+
+        context.evaluateScript(source, withSourceURL: url)
+        if let message = sink.take() {
+            throw CoreBridgeError.evaluationFailed(message)
+        }
+
+        // A missing key yields a JSValue wrapping `undefined`, not nil.
+        let namespaceValue: JSValue? = context.objectForKeyedSubscript(Self.globalName)
+        guard let namespace = namespaceValue, !namespace.isUndefined, !namespace.isNull else {
+            throw CoreBridgeError.missingExport("the \(Self.globalName) global")
+        }
+        let functionValue: JSValue? = namespace.objectForKeyedSubscript("transpose")
+        guard let transposeFunction = functionValue, transposeFunction.isObject else {
+            throw CoreBridgeError.missingExport("\(Self.globalName).transpose")
+        }
+
+        self.bundleURL = url
+        self.context = context
+        self.transposeFunction = transposeFunction
+        self.sink = sink
+    }
+
+    /// Transpose a chord symbol through `packages/core`'s `transposeSymPrefer`.
+    ///
+    /// Matches apps/mobile exactly, including core's pass-through of symbols it
+    /// does not recognize: `transpose("H7", steps: 2)` returns `"H7"` rather than
+    /// throwing. Invalid *arguments* (an empty symbol) do throw.
+    func transpose(_ symbol: String, steps: Int, preferFlat: Bool = false) throws -> String {
+        _ = sink.take()
+
+        // Built explicitly rather than relying on Swift→NSNumber bridging, which
+        // could hand `preferFlat` to JS as a number instead of a boolean.
+        let symbolValue: JSValue? = JSValue(object: symbol, in: context)
+        let stepsValue: JSValue? = JSValue(double: Double(steps), in: context)
+        let preferFlatValue: JSValue? = JSValue(bool: preferFlat, in: context)
+        guard let symbolArgument = symbolValue,
+              let stepsArgument = stepsValue,
+              let preferFlatArgument = preferFlatValue else {
+            throw CoreBridgeError.unexpectedResult("arguments could not be converted to JSValues")
+        }
+
+        let returned: JSValue? = transposeFunction.call(
+            withArguments: [symbolArgument, stepsArgument, preferFlatArgument]
+        )
+
+        if let message = sink.take() {
+            throw CoreBridgeError.jsException(message)
+        }
+        guard let result = returned else {
+            throw CoreBridgeError.unexpectedResult("transpose returned no value")
+        }
+        guard result.isString else {
+            throw CoreBridgeError.unexpectedResult("expected a string, got \(result)")
+        }
+        let converted: String? = result.toString()
+        guard let string = converted else {
+            throw CoreBridgeError.unexpectedResult("result could not be read as a string")
+        }
+        return string
+    }
+
+    private static func describe(_ exception: JSValue?) -> String {
+        guard let exception = exception else { return "unknown JavaScript exception" }
+        // JSValue's description is its JS string representation, so this reads as
+        // e.g. "TypeError: transpose: sym must be a non-empty string, got ''".
+        var description = "\(exception)"
+        let lineValue: JSValue? = exception.objectForKeyedSubscript("line")
+        if let line = lineValue, !line.isUndefined, !line.isNull {
+            description += " (line \(line))"
+        }
+        return description
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Core/CoreBridgeSpike.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Core/CoreBridgeSpike.swift
@@ -1,0 +1,155 @@
+//
+//  CoreBridgeSpike.swift
+//  GraceChords Studio
+//
+//  Throwaway harness for the JavaScriptCore plumbing spike: runs a fixed table of
+//  transpose cases through CoreBridge and reports pass/fail. The same table is
+//  asserted against apps/mobile's resolved module by
+//  apps/studio/js/verify-bundle.mjs, so agreement here means Studio and mobile
+//  agree.
+//
+
+import Foundation
+
+struct SpikeCheck: Identifiable {
+    let id = UUID()
+    let passed: Bool
+    let text: String
+}
+
+struct SpikeReport {
+    let headline: String
+    let checks: [SpikeCheck]
+
+    var allPassed: Bool { checks.allSatisfy { $0.passed } }
+}
+
+enum CoreBridgeSpike {
+    struct TransposeCase {
+        let symbol: String
+        let steps: Int
+        let preferFlat: Bool
+        let expected: String
+        let note: String?
+
+        init(_ symbol: String, _ steps: Int, _ preferFlat: Bool, _ expected: String, note: String? = nil) {
+            self.symbol = symbol
+            self.steps = steps
+            self.preferFlat = preferFlat
+            self.expected = expected
+            self.note = note
+        }
+    }
+
+    /// Mirrors CASES in apps/studio/js/verify-bundle.mjs.
+    static let transposeCases: [TransposeCase] = [
+        TransposeCase("G", 2, false, "A"),
+        TransposeCase("G", 0, false, "G"),
+        TransposeCase("G", -2, false, "F"),
+        TransposeCase("Bb", 2, false, "C"),
+        TransposeCase("Bb", 1, false, "B"),
+        TransposeCase("A#", 1, false, "B"),
+        TransposeCase("C", 1, true, "Db"),
+        TransposeCase("C", 1, false, "C#"),
+        TransposeCase("Em", 3, false, "Gm"),
+        TransposeCase("D/F#", 2, false, "E/G#"),
+        TransposeCase("Ebmaj7", 5, false, "Abmaj7"),
+        TransposeCase("H7", 2, false, "H7", note: "unrecognized symbol passes through (core behavior)"),
+    ]
+
+    static func run() -> SpikeReport {
+        let bridge: CoreBridge
+        do {
+            bridge = try CoreBridge()
+        } catch {
+            return SpikeReport(
+                headline: "Bridge failed to load",
+                checks: [SpikeCheck(passed: false, text: message(for: error))]
+            )
+        }
+
+        var checks: [SpikeCheck] = []
+
+        let loadedPath = bridge.bundleURL.path
+        let inResources = loadedPath.contains("/Contents/Resources/")
+        checks.append(
+            SpikeCheck(
+                passed: inResources,
+                text: "bundle loaded from \(shorten(loadedPath))"
+            )
+        )
+
+        for testCase in transposeCases {
+            let signedSteps = testCase.steps >= 0 ? "+\(testCase.steps)" : "\(testCase.steps)"
+            let label = "transpose(\"\(testCase.symbol)\", \(signedSteps)"
+                + (testCase.preferFlat ? ", preferFlat" : "")
+                + ")"
+            do {
+                let actual = try bridge.transpose(
+                    testCase.symbol,
+                    steps: testCase.steps,
+                    preferFlat: testCase.preferFlat
+                )
+                let passed = actual == testCase.expected
+                var text = "\(label) = \"\(actual)\""
+                if !passed { text += " — expected \"\(testCase.expected)\"" }
+                if let note = testCase.note, passed { text += "  [\(note)]" }
+                checks.append(SpikeCheck(passed: passed, text: text))
+            } catch {
+                checks.append(SpikeCheck(passed: false, text: "\(label) threw — \(message(for: error))"))
+            }
+        }
+
+        // Invalid input must surface as a Swift error, not a crash, and the context
+        // must stay usable afterwards.
+        do {
+            let value = try bridge.transpose("", steps: 2)
+            checks.append(
+                SpikeCheck(passed: false, text: "transpose(\"\", +2) returned \"\(value)\" instead of throwing")
+            )
+        } catch let error as CoreBridgeError {
+            if case .jsException(let jsMessage) = error {
+                checks.append(SpikeCheck(passed: true, text: "transpose(\"\", +2) threw as expected — \(jsMessage)"))
+            } else {
+                checks.append(
+                    SpikeCheck(passed: false, text: "transpose(\"\", +2) threw the wrong error — \(message(for: error))")
+                )
+            }
+        } catch {
+            checks.append(
+                SpikeCheck(passed: false, text: "transpose(\"\", +2) threw an unexpected error — \(message(for: error))")
+            )
+        }
+
+        do {
+            let recovered = try bridge.transpose("G", steps: 2)
+            checks.append(
+                SpikeCheck(
+                    passed: recovered == "A",
+                    text: "context still usable after the error — transpose(\"G\", +2) = \"\(recovered)\""
+                )
+            )
+        } catch {
+            checks.append(
+                SpikeCheck(passed: false, text: "context unusable after the error — \(message(for: error))")
+            )
+        }
+
+        let failures = checks.filter { !$0.passed }.count
+        let headline = failures == 0
+            ? "All \(checks.count) checks passed"
+            : "\(failures) of \(checks.count) checks failed"
+        return SpikeReport(headline: headline, checks: checks)
+    }
+
+    private static func message(for error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? "\(error)"
+    }
+
+    /// Trim the absolute build path down to the app bundle and below.
+    private static func shorten(_ path: String) -> String {
+        guard let range = path.range(of: ".app/") else { return path }
+        let appName = path[..<range.lowerBound].split(separator: "/").last ?? ""
+        return "…/\(appName).app/\(path[range.upperBound...])"
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js
@@ -1,0 +1,72 @@
+// GENERATED FILE — do not edit.
+// Built from packages/core by apps/studio/js/build-core-bundle.mjs.
+// Exposes GraceChordsCore.transpose() on the JavaScriptCore global object.
+var GraceChordsCore = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // apps/studio/js/entry.mjs
+  var entry_exports = {};
+  __export(entry_exports, {
+    transpose: () => transpose
+  });
+
+  // packages/core/src/chordpro/index.js
+  var KEYS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+  var FLAT = { "Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#" };
+  function norm(n) {
+    return FLAT[n] || n;
+  }
+  function transposeSymPrefer(sym, steps, defaultPreferFlat = false) {
+    if (steps === 0) return sym;
+    if (sym.includes("/")) {
+      const [r, b] = sym.split("/");
+      return transposeSymPrefer(r, steps, defaultPreferFlat) + "/" + transposeSymPrefer(b, steps, defaultPreferFlat);
+    }
+    const m = sym.match(/^([A-G])([#b]?)(.*)$/);
+    if (!m) return sym;
+    const [, base, acc, rest] = m;
+    const preferFlat = acc === "b" ? true : acc === "#" ? false : defaultPreferFlat;
+    const idx = KEYS.indexOf(norm(base + (acc || "")));
+    if (idx === -1) return sym;
+    const root = KEYS[(idx + steps + 12) % 12];
+    const outRoot = preferFlat && SHARP_TO_FLAT[root] ? SHARP_TO_FLAT[root] : root;
+    return outRoot + (rest || "");
+  }
+  var SHARP_TO_FLAT = { "C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb" };
+
+  // apps/studio/js/entry.mjs
+  function transpose(sym, steps, preferFlat = false) {
+    if (typeof sym !== "string" || sym.length === 0) {
+      throw new TypeError(`transpose: sym must be a non-empty string, got ${describe(sym)}`);
+    }
+    if (typeof steps !== "number" || !Number.isInteger(steps)) {
+      throw new TypeError(`transpose: steps must be an integer, got ${describe(steps)}`);
+    }
+    if (typeof preferFlat !== "boolean") {
+      throw new TypeError(`transpose: preferFlat must be a boolean, got ${describe(preferFlat)}`);
+    }
+    return transposeSymPrefer(sym, steps, preferFlat);
+  }
+  function describe(value) {
+    if (value === null) return "null";
+    if (typeof value === "string") return `'${value}'`;
+    return `${typeof value} ${String(value)}`;
+  }
+  return __toCommonJS(entry_exports);
+})();

--- a/apps/studio/SPIKE-RESULTS.md
+++ b/apps/studio/SPIKE-RESULTS.md
@@ -1,0 +1,122 @@
+# Studio spike — `packages/core` in JavaScriptCore (gate report)
+
+Goal: prove `packages/core` can be bundled to one flat JS file, executed in a
+Swift `JSContext`, called from Swift, and return results matching `apps/mobile`.
+Transpose only. Everything else (song UI, auth, GraceTracks, other core
+functions) is out of scope.
+
+## Verdict: JS side CONFIRMED, Swift side needs one Xcode run
+
+The bundling and parity questions — the ones that could have killed the native
+approach — are answered. The remaining checks are mechanical and require macOS.
+
+## What is bundled, and what is deliberately not
+
+`entry.mjs` imports the **subpath** `@gracechords/core/chordpro/index.js`, not the
+`@gracechords/core` barrel. The barrel re-exports `supabase/client.js` →
+`@supabase/supabase-js`, which expects `fetch`, WebSocket and a storage adapter;
+none exist in a bare `JSContext`. Importing narrowly avoids the problem entirely
+rather than polyfilling it.
+
+Result: **2 modules, 3061 bytes, zero dependencies** —
+`packages/core/src/chordpro/index.js` + `apps/studio/js/entry.mjs`.
+
+Audit of the rest of core for engine assumptions (grep for Node built-ins,
+`process`, `Buffer`, `require`, DOM globals, RN polyfills) found only two soft
+spots, both already guarded and both outside the transpose path:
+`setlists/setStore.js:7` (`typeof crypto !== 'undefined'`, has a fallback) and
+`bible/translationMenu.ts:88` (`typeof Intl === 'undefined'` guard). Core's only
+external dependency anywhere is `@supabase/supabase-js`. Nothing in the transpose
+path needs a shim.
+
+## Parity with apps/mobile — CONFIRMED
+
+`verify-bundle.mjs` evaluates the built bundle as global-scope source in a bare
+`node:vm` context (the closest analogue to `JSContext.evaluateScript`: no module
+loader, `var` lands on the global) and compares every result against
+`transposeSymPrefer` imported from the same file Metro resolves for mobile.
+
+12/12 cases agree, including the accidental-preservation behavior that
+distinguishes `transposeSymPrefer` (what `ChordChart.tsx:195` and `capo.ts:30`
+actually call) from the legacy `transposeSym`:
+
+| input | steps | preferFlat | result |
+|---|---|---|---|
+| `G` | +2 | false | `A` |
+| `G` | 0 | false | `G` |
+| `G` | −2 | false | `F` |
+| `Bb` | +2 | false | `C` (stays flat) |
+| `A#` | +1 | false | `B` |
+| `C` | +1 | true | `Db` |
+| `C` | +1 | false | `C#` |
+| `Em` | +3 | false | `Gm` |
+| `D/F#` | +2 | false | `E/G#` (slash chord, both sides) |
+| `Ebmaj7` | +5 | false | `Abmaj7` |
+| `H7` | +2 | false | `H7` (see below) |
+
+All five invalid-argument cases throw `TypeError` from the bridge entry rather
+than returning garbage.
+
+## One core behavior worth knowing before building on this
+
+`transposeSymPrefer` **does not throw on a malformed chord** — it returns the
+input unchanged (`H7` → `H7`). That is core's real behavior and therefore
+mobile's, so the spike preserves it instead of "fixing" it at the bridge. The
+bridge validates *argument types* (empty/non-string symbol, non-integer steps,
+non-boolean flag) and throws there; that is the error path `CoreBridge` surfaces
+as a Swift `CoreBridgeError.jsException`.
+
+Consequence for Studio's future editor UI: chord validity must be checked
+explicitly (`packages/core`'s lint module), not inferred from transpose throwing.
+
+## Swift bridge shape
+
+`Core/CoreBridge.swift` — loads `Resources/GraceChordsCore.js`, evaluates it,
+grabs `GraceChordsCore.transpose`, and exposes exactly one typed method:
+
+```swift
+try bridge.transpose("G", steps: 2, preferFlat: false)   // "A"
+```
+
+No generic "evaluate this string" API. Every failure is a typed
+`CoreBridgeError` (`bundleMissing`, `bundleUnreadable`, `evaluationFailed`,
+`missingExport`, `jsException`, `unexpectedResult`); JS exceptions are captured
+via `JSContext.exceptionHandler` into a reference box and rethrown as Swift
+errors. `JSContext` is not thread-safe — one bridge, one thread (Studio uses the
+main thread).
+
+Two details that would have been silent bugs: arguments are built as explicit
+`JSValue`s (`JSValue(bool:in:)`), because letting Swift `Bool` bridge through
+`NSNumber` risks arriving in JS as a number; and every JavaScriptCore return
+value is widened to an Optional before unwrapping, since JSC's headers are
+inconsistently nullability-annotated across SDKs.
+
+## Checklist status
+
+| Check | Status |
+|---|---|
+| Bundle is a single flat file JSCore can run | ✅ 3061 bytes, IIFE, `GraceChordsCore` global |
+| Bundle loads in a bare context without throwing | ✅ verified in `node:vm` |
+| `transpose("G", +2)` → `"A"`, matching mobile | ✅ 12/12 cases match the module Metro resolves |
+| Invalid input handled gracefully, no crash | ✅ JS side; Swift maps it to `CoreBridgeError.jsException` |
+| Builds and runs in Xcode | ⏳ **needs macOS** — this work was done in a Linux container (no `swift`/`xcodebuild`) |
+| Bundle present in the built app's Resources | ⏳ **needs macOS** — command in `js/README.md`; the app prints the loaded path |
+
+To close the last two: open the project, Run, and read the window — it prints one
+line per case plus the path the bundle was loaded from. `js/README.md` has the
+fallback if Xcode does not copy the `.js` into Resources automatically.
+
+## If this graduates
+
+1. Gitignore `Resources/GraceChordsCore.js` and move the build to a Run Script
+   phase with an absolute `node` path (Input/Output Files declared so incremental
+   builds skip it). It is committed and manual for now — reasoning in
+   `js/README.md`.
+2. `esbuild` is currently resolved from the hoisted root `node_modules` (a
+   transitive Vite dependency, pinned at 0.27.7 in the lockfile). Declaring it
+   properly means giving `apps/studio` a `package.json`, which the root
+   `workspaces: ["apps/*"]` glob would make a workspace member — a deliberate
+   decision, out of scope here.
+3. Anything touching Supabase (auth, song library) cannot ride this bundle as-is;
+   that needs either a real HTTP/WebSocket-capable host layer in Swift or the
+   queries staying native. Worth deciding before the first data-backed feature.

--- a/apps/studio/js/README.md
+++ b/apps/studio/js/README.md
@@ -1,0 +1,93 @@
+# Studio ↔ `packages/core` JS bridge
+
+GraceChords Studio is native macOS SwiftUI, but it reuses `packages/core`'s logic
+instead of reimplementing it in Swift (where it would drift from the JS that web
+and mobile depend on). Core is bundled into one flat file and run inside a
+JavaScriptCore `JSContext`.
+
+## Files
+
+| File | Role |
+|------|------|
+| `entry.mjs` | Bridge entry. Imports the `@gracechords/core/chordpro/index.js` **subpath**, validates arguments, re-exports `transpose`. |
+| `build-core-bundle.mjs` | esbuild build → `GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js` |
+| `verify-bundle.mjs` | Parity harness: bundle vs. the module Metro resolves for `apps/mobile`. |
+
+Swift side: `GraceChords Studio/GraceChords Studio/Core/CoreBridge.swift`.
+
+## Rebuilding the bundle
+
+Run from the repo root, after any change to `entry.mjs` or to
+`packages/core/src/chordpro/`:
+
+```sh
+node "apps/studio/js/build-core-bundle.mjs"
+node "apps/studio/js/verify-bundle.mjs"     # must print ALL CHECKS PASSED
+```
+
+The output is committed, so a clean checkout builds in Xcode without running npm.
+
+### Why this is a manual step, not an Xcode Run Script phase
+
+1. Xcode build phases run with a minimal `PATH`; `node` installed via Homebrew or
+   nvm is not on it, which fails as a confusing build error rather than an
+   obvious missing-tool one.
+2. The output is committed, so regenerating it on every build would dirty the
+   working tree constantly.
+3. Fewer moving parts while the spike is being diagnosed.
+
+When this graduates past the spike, the switch is: gitignore
+`Resources/GraceChordsCore.js`, add a Run Script phase with an absolute `node`
+path (declaring `entry.mjs` + the core sources as Input Files and the bundle as
+an Output File so Xcode can skip unchanged builds).
+
+## Confirming the bundle reaches the built app
+
+The Xcode target uses a file-system-synchronized root group (`objectVersion = 77`),
+so `Resources/GraceChordsCore.js` is picked up from disk with no project-file
+edits — but Xcode decides the build phase from the file type, and a `.js` file has
+no compiler. Verify it landed:
+
+```sh
+ls -l "$(xcodebuild -project "apps/studio/GraceChords Studio/GraceChords Studio.xcodeproj" \
+  -showBuildSettings 2>/dev/null | awk -F' = ' '/ BUILT_PRODUCTS_DIR/{print $2}' \
+  )/GraceChords Studio.app/Contents/Resources/GraceChordsCore.js"
+```
+
+The app also reports this itself: the spike window prints the path the bundle was
+loaded from, and `CoreBridge` throws `bundleMissing` with remediation text rather
+than crashing if it is absent.
+
+**If it did not land:** select `GraceChordsCore.js` in Xcode → File Inspector →
+set Target Membership for "GraceChords Studio". If a synchronized group blocks
+that, add a Copy Files phase (Destination: Resources, Subpath: empty) with the
+file, or a Run Script phase after it:
+
+```sh
+cp "$SRCROOT/GraceChords Studio/Resources/GraceChordsCore.js" \
+   "$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/"
+```
+
+## Bundle format
+
+`--bundle --format=iife --global-name=GraceChordsCore --platform=neutral
+--target=safari17`, so `JSContext.evaluateScript` leaves a `GraceChordsCore`
+object on the context's global. `JSContext` has no CommonJS/ESM loader, so an
+IIFE that self-assigns is the format that needs no shim.
+
+## Do not import the `@gracechords/core` barrel here
+
+`packages/core/src/index.ts` re-exports `supabase/client.js`, which pulls in
+`@supabase/supabase-js` and its `fetch`/WebSocket/storage expectations — none of
+which exist in a bare `JSContext`. Always import the narrowest subpath
+(`@gracechords/core/<dir>/<file>`, which the package's `"./*": "./src/*"` exports
+pattern resolves). The current bundle is 2 modules / ~3 KB with no dependencies;
+`verify-bundle.mjs` prints the module list so unexpected growth is visible.
+
+## Adding another core function later
+
+1. Re-export it from `entry.mjs` with argument validation at the boundary.
+2. Add a typed Swift method to `CoreBridge` — no generic "evaluate this string"
+   API, so every call site stays checkable.
+3. Add cases to `CASES` in `verify-bundle.mjs` **and** `transposeCases` in
+   `CoreBridgeSpike.swift`.

--- a/apps/studio/js/build-core-bundle.mjs
+++ b/apps/studio/js/build-core-bundle.mjs
@@ -1,0 +1,62 @@
+// Bundles packages/core's transpose path into one flat IIFE that
+// JSContext.evaluateScript can run, and writes it where Xcode will copy it into
+// GraceChords Studio.app/Contents/Resources.
+//
+// Run manually after touching packages/core's chordpro module or entry.mjs:
+//   node "apps/studio/js/build-core-bundle.mjs"
+//
+// Deliberately not wired to an Xcode Run Script phase yet — see README.md.
+import { mkdir, writeFile, stat } from 'node:fs/promises'
+import { dirname, resolve, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../../..')
+const entry = resolve(here, 'entry.mjs')
+const outfile = resolve(here, '../GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js')
+
+// esbuild is present in the root node_modules (hoisted; Vite depends on it), so
+// this spike adds no dependency and apps/studio stays out of the workspace glob.
+let esbuild
+try {
+  esbuild = await import('esbuild')
+} catch (err) {
+  console.error(
+    'esbuild could not be resolved. Run `npm install` at the repo root (esbuild is\n' +
+      'hoisted there via Vite), or run this script with a one-off:\n' +
+      '  npx --yes esbuild@0.27.7 --version\n\n' +
+      `Original error: ${err.message}`,
+  )
+  process.exit(1)
+}
+
+const banner = [
+  '// GENERATED FILE — do not edit.',
+  '// Built from packages/core by apps/studio/js/build-core-bundle.mjs.',
+  '// Exposes GraceChordsCore.transpose() on the JavaScriptCore global object.',
+].join('\n')
+
+await mkdir(dirname(outfile), { recursive: true })
+
+const result = await esbuild.build({
+  entryPoints: [entry],
+  outfile,
+  bundle: true,
+  format: 'iife',
+  globalName: 'GraceChordsCore',
+  // JavaScriptCore is neither Node nor a browser; 'neutral' keeps esbuild from
+  // preferring platform-specific package fields during resolution.
+  platform: 'neutral',
+  target: 'safari17',
+  legalComments: 'none',
+  banner: { js: banner },
+  logLevel: 'warning',
+  metafile: true,
+})
+
+const { size } = await stat(outfile)
+const inputs = Object.keys(result.metafile.inputs).map((p) => relative(repoRoot, resolve(repoRoot, p)))
+
+console.log(`wrote ${relative(repoRoot, outfile)} (${size} bytes)`)
+console.log(`bundled ${inputs.length} module(s):`)
+for (const input of inputs) console.log(`  ${input}`)

--- a/apps/studio/js/entry.mjs
+++ b/apps/studio/js/entry.mjs
@@ -1,0 +1,39 @@
+// Bridge entry for the GraceChords Studio JavaScriptCore context.
+//
+// Imports the chordpro subpath, NOT the '@gracechords/core' barrel: the barrel
+// re-exports supabase/client.js, which would pull @supabase/supabase-js — and
+// its fetch/WebSocket/storage expectations — into an engine that has none of
+// them. chordpro/index.js has zero imports, so this bundle stays dependency-free.
+import { transposeSymPrefer } from '@gracechords/core/chordpro/index.js'
+
+/**
+ * Transpose a chord symbol, preserving its original accidental spelling.
+ *
+ * Argument validation lives here at the bridge boundary, not in core. Once the
+ * arguments are known-good the call is passed through verbatim, so Studio gets
+ * byte-identical results to apps/mobile — including core's deliberate
+ * pass-through of symbols it does not recognize ('H7' transposes to 'H7').
+ *
+ * @param {string} sym         chord symbol, e.g. 'G', 'Bbm7', 'D/F#'
+ * @param {number} steps       semitones, may be negative
+ * @param {boolean} preferFlat accidental preference for symbols with no accidental
+ * @returns {string}
+ */
+export function transpose(sym, steps, preferFlat = false) {
+  if (typeof sym !== 'string' || sym.length === 0) {
+    throw new TypeError(`transpose: sym must be a non-empty string, got ${describe(sym)}`)
+  }
+  if (typeof steps !== 'number' || !Number.isInteger(steps)) {
+    throw new TypeError(`transpose: steps must be an integer, got ${describe(steps)}`)
+  }
+  if (typeof preferFlat !== 'boolean') {
+    throw new TypeError(`transpose: preferFlat must be a boolean, got ${describe(preferFlat)}`)
+  }
+  return transposeSymPrefer(sym, steps, preferFlat)
+}
+
+function describe(value) {
+  if (value === null) return 'null'
+  if (typeof value === 'string') return `'${value}'`
+  return `${typeof value} ${String(value)}`
+}

--- a/apps/studio/js/verify-bundle.mjs
+++ b/apps/studio/js/verify-bundle.mjs
@@ -1,0 +1,105 @@
+// Parity harness for the JavaScriptCore spike.
+//
+//   node "apps/studio/js/verify-bundle.mjs"
+//
+// Runs the built bundle the way Swift does — evaluated as global-scope source in
+// a bare context, then called through the global object — and compares every
+// result against the exact module apps/mobile resolves through Metro
+// (@gracechords/core/chordpro/index.js). Any drift between the bundle and the
+// source mobile uses fails the run.
+//
+// CASES is the same table CoreBridge's self-check asserts on the Swift side.
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import vm from 'node:vm'
+
+import { transposeSymPrefer } from '@gracechords/core/chordpro/index.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const bundlePath = resolve(here, '../GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js')
+
+/** [symbol, steps, preferFlat, expected] */
+export const CASES = [
+  ['G', 2, false, 'A'],
+  ['G', 0, false, 'G'],
+  ['G', -2, false, 'F'],
+  ['Bb', 2, false, 'C'],
+  ['Bb', 1, false, 'B'],
+  ['A#', 1, false, 'B'],
+  ['C', 1, true, 'Db'],
+  ['C', 1, false, 'C#'],
+  ['Em', 3, false, 'Gm'],
+  ['D/F#', 2, false, 'E/G#'],
+  ['Ebmaj7', 5, false, 'Abmaj7'],
+  ['H7', 2, false, 'H7'], // core passes unrecognized symbols through unchanged
+]
+
+const source = await readFile(bundlePath, 'utf8')
+
+// Closest analogue to JSContext.evaluateScript: no module loader, no Node
+// globals, top-level `var` lands on the context's global object.
+const sandbox = {}
+vm.createContext(sandbox)
+vm.runInContext(source, sandbox, { filename: bundlePath })
+
+const namespace = sandbox.GraceChordsCore
+let failures = 0
+const fail = (message) => {
+  failures += 1
+  console.log(`FAIL  ${message}`)
+}
+
+if (!namespace) {
+  console.log('FAIL  bundle did not define a GraceChordsCore global')
+  process.exit(1)
+}
+if (typeof namespace.transpose !== 'function') {
+  console.log('FAIL  GraceChordsCore.transpose is not a function')
+  process.exit(1)
+}
+console.log('PASS  bundle evaluated in a bare context; GraceChordsCore.transpose is callable\n')
+
+console.log('sym         steps  flat   bundle   mobile   expected')
+console.log('----------------------------------------------------')
+for (const [sym, steps, preferFlat, expected] of CASES) {
+  let bundled
+  try {
+    bundled = namespace.transpose(sym, steps, preferFlat)
+  } catch (err) {
+    fail(`transpose(${sym}, ${steps}) threw: ${err.message}`)
+    continue
+  }
+  const mobile = transposeSymPrefer(sym, steps, preferFlat)
+  const ok = bundled === mobile && bundled === expected
+  const row = [
+    sym.padEnd(11),
+    String(steps).padStart(5),
+    String(preferFlat).padEnd(6),
+    String(bundled).padEnd(8),
+    String(mobile).padEnd(8),
+    String(expected),
+  ].join(' ')
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${row}`)
+  if (!ok) failures += 1
+}
+
+console.log('\nerror paths (must throw, not crash or return garbage):')
+const badArgs = [
+  ['empty symbol', ['', 2, false]],
+  ['null symbol', [null, 2, false]],
+  ['non-integer steps', ['G', 1.5, false]],
+  ['missing steps', ['G', undefined, false]],
+  ['non-boolean preferFlat', ['G', 2, 'yes']],
+]
+for (const [label, args] of badArgs) {
+  try {
+    const value = namespace.transpose(...args)
+    fail(`${label}: returned ${JSON.stringify(value)} instead of throwing`)
+  } catch (err) {
+    console.log(`PASS  ${label} → ${err.constructor.name}: ${err.message}`)
+  }
+}
+
+console.log(failures === 0 ? '\nALL CHECKS PASSED' : `\n${failures} CHECK(S) FAILED`)
+process.exit(failures === 0 ? 0 : 1)


### PR DESCRIPTION
## Summary

This spike proves that `packages/core`'s transpose logic can be bundled into a single flat JavaScript file, executed in a Swift `JSContext`, and called from native code with results matching `apps/mobile` exactly. The implementation includes a complete bridge layer, verification harness, and self-check UI.

## Key Changes

- **`CoreBridge.swift`**: Thin wrapper around a `JSContext` that loads `GraceChordsCore.js`, exposes a single typed `transpose(_:steps:preferFlat:)` method, and maps JavaScript exceptions to typed Swift errors. Not thread-safe; designed for single-threaded use on the main thread.

- **`CoreBridgeSpike.swift`**: Self-check harness that runs 12 transpose test cases (mirrored from the JS verification suite) plus error-path validation. Reports pass/fail for each case and confirms the bundle was loaded from the app's Resources directory.

- **JavaScript bundling** (`entry.mjs`, `build-core-bundle.mjs`):
  - `entry.mjs` imports only `@gracechords/core/chordpro/index.js` (not the barrel), validates arguments at the bridge boundary, and re-exports `transpose`.
  - `build-core-bundle.mjs` bundles to a single 3061-byte IIFE (`GraceChordsCore` global) with zero dependencies, targeting Safari 17 for `JSContext` compatibility.

- **Verification** (`verify-bundle.mjs`): Parity harness that evaluates the built bundle in a bare `node:vm` context and compares all results against the exact module Metro resolves for `apps/mobile`. All 12 cases match, including core's pass-through behavior for unrecognized symbols.

- **`ContentView.swift`**: Temporary spike UI that displays the self-check results in a scrollable list, showing the loaded bundle path and pass/fail status for each test case.

- **Documentation** (`SPIKE-RESULTS.md`, `js/README.md`): Comprehensive spike report with verdict, checklist status, and instructions for rebuilding the bundle and confirming it reaches the built app.

## Notable Implementation Details

- **Argument marshalling**: Arguments are explicitly converted to `JSValue` (e.g., `JSValue(bool:in:)`) rather than relying on Swift-to-NSNumber bridging, which could hand `preferFlat` to JS as a number instead of a boolean.

- **Exception handling**: JavaScript exceptions are captured via `JSContext.exceptionHandler` into a reference box and rethrown as typed `CoreBridgeError` cases, with line numbers extracted when available.

- **Nullability workaround**: Every `JSContext` return value is widened to an Optional before unwrapping, since JSC's headers are inconsistently annotated across SDKs.

- **Subpath import**: The bundle imports `@gracechords/core/chordpro/index.js` rather than the barrel to avoid pulling in `@supabase/supabase-js` and its unmet `fetch`/WebSocket/storage expectations.

- **Manual build step**: The bundle is committed and rebuilt manually (not via Xcode Run Script) to avoid PATH issues with Homebrew/nvm Node and to prevent constant working-tree dirtying. Documented in `js/README.md` with a future migration path.

## Checklist Status

✅ Bundle is a single flat file JSCore can run (3061 bytes, IIFE, `GraceChordsCore` global)  
✅ Bundle loads in a bare context without throwing  
✅ `transpose("G", +2)` → `"A"`, matching mobile (12/12 cases verified)  
✅ Invalid input handled gracefully, no crash  
⏳ Builds and runs in Xcode (needs macOS; verified in Linux container)  
⏳ Bundle present in the built app's Resources (needs Xcode Run to confirm)

To close the last two: open the project, Run, and read the window — it prints one line per case plus the path the bundle was loaded from.

https://claude.ai/code/session_01HTefjFTarGZbiQs6RuVBLV