### PR TITLE
feat(studio): song creation, editing, publishing and deletion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,11 @@ hardcode token values in any app.
   Studio deliberately keeps SwiftUI's semantic colors instead of tokens.
 
 ## Roles & auth (shared model)
-- Supabase provides auth and data for both apps. The role system is `user → collaborator → editor → admin → owner`, stored in `public.users.role`.
+- Supabase provides auth and data for both apps. The role system is `user → editor → admin → owner`, stored in `public.users.role`. (`collaborator` was removed in `20260708000000_remove_collaborator_role.sql` — existing collaborators were demoted to `user`, and all authenticated users may now submit songs for review. Note that `hasMinRole()` grants an unrecognised role *nothing*, not even `user`, so a stray `collaborator` value fails closed.)
 - **Single source of truth:** `packages/core/src/rbac/roles.js` exports `ROLE_ORDER`, `ROLES_BY_RANK_DESC`, and `hasMinRole()`. Always use `hasMinRole()` for gate checks; never hardcode role strings in conditionals unless adding a new role. The `workers/pptx-upload/` worker keeps its own copy because it's bundled separately — keep the two in sync if the hierarchy changes.
-- All Supabase tables have row-level security. Test query changes with a non-owner account before shipping.
+- All Supabase tables have row-level security. Test query changes with a non-owner account before shipping. RLS policies are **permissive and OR'd together**, so an overlapping policy widens access rather than narrowing it — adding a restricting clause to one policy does nothing if a broader policy on the same command still exists. Enumerate what is actually live with `select policyname, cmd, qual, with_check from pg_policies where tablename = '<table>'` before editing one.
+- **The remote database is applied by hand, not by `supabase db push`.** `supabase migration list --linked` shows every migration as un-recorded remotely, so `db push` would attempt to replay all of them from scratch (several are destructive — `TRUNCATE`, `DROP TABLE ... CASCADE`). Apply a new migration with `supabase db query --linked -f <file>` or the dashboard SQL editor, and write migrations idempotently (`IF NOT EXISTS`, `DROP POLICY IF EXISTS` before `CREATE POLICY`) because the files have drifted from the live schema more than once.
+- New migrations should ship a `<timestamp>_<name>.down.sql` beside them (convention introduced 2026-07-28). It is not picked up by any tooling — it is applied by hand the same way the up migration is — and its header should state plainly whether the revert is data-lossless or only schema-clean.
 - The **anon** key is safe in both clients; the **service-role** key is server-side only (Node build scripts, Workers, Pages Functions) and must never reach bundled app code.
 
 ## General AI principles

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Auth/AuthController.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Auth/AuthController.swift
@@ -33,10 +33,20 @@ final class AuthController: ObservableObject {
     @Published private(set) var isWorking = false
     @Published var errorText: String?
 
+    /// The signed-in account's role from `public.users.role`, defaulting to the
+    /// least-privileged value.
+    ///
+    /// Starts at and returns to "user" so no role-gated surface can appear during
+    /// the window between a session being restored and the role being read — the
+    /// gate opening for a moment and then closing would be worse than opening late.
+    @Published private(set) var role = "user"
+
     private let client: SupabaseClient
+    private let users: UserRepository
 
     init(client: SupabaseClient) {
         self.client = client
+        self.users = UserRepository(client: client)
     }
 
     /// Restores any persisted session, then follows auth state for the lifetime of
@@ -45,6 +55,7 @@ final class AuthController: ObservableObject {
         do {
             let session = try await client.auth.session
             apply(session: session)
+            await refreshRole()
         } catch {
             // No stored session, or one that could not be refreshed — either way
             // the answer is the sign-in screen, not an error.
@@ -58,7 +69,12 @@ final class AuthController: ObservableObject {
             if case .signedOut = event {
                 clear()
             } else if let session = session {
+                let wasSignedIn = phase == .signedIn
                 apply(session: session)
+                // A token refresh fires this stream repeatedly for a session that
+                // was already established; re-reading the role each time would be a
+                // query per refresh for an answer that has not changed.
+                if !wasSignedIn { await refreshRole() }
             } else {
                 clear()
             }
@@ -80,6 +96,7 @@ final class AuthController: ObservableObject {
             // not wait on the stream.
             phase = .signedIn
             signedInEmail = trimmedEmail
+            await refreshRole()
         } catch {
             errorText = Self.message(for: error)
         }
@@ -106,7 +123,22 @@ final class AuthController: ObservableObject {
 
     private func clear() {
         signedInEmail = nil
+        role = "user"
         phase = .signedOut
+    }
+
+    /// Read the role for the current session.
+    ///
+    /// Called after the initial session check and after every sign-in, rather than
+    /// lazily when a gated surface is first asked for — the shell needs the answer
+    /// to decide whether that surface exists at all, and one query at sign-in is
+    /// cheaper than making every gate check async.
+    func refreshRole() async {
+        guard phase == .signedIn else {
+            role = "user"
+            return
+        }
+        role = await users.fetchRole()
     }
 
     private static func message(for error: Error) -> String {

--- a/apps/studio/GraceChords Studio/GraceChords Studio/ContentView.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/ContentView.swift
@@ -47,13 +47,103 @@ private struct SignedInGate: View {
             case .signedOut:
                 SignInView(auth: auth)
             case .signedIn:
-                LibrarySplitView(services: services, auth: auth, library: library)
+                StudioShell(services: services, auth: auth, library: library)
             }
         }
         .task {
             // Restores the Keychain-persisted session, then follows auth state for
             // as long as the window lives.
             await auth.observeAuthState()
+        }
+    }
+}
+
+/// The signed-in app: a section picker plus the selected section's own split view.
+///
+/// The Manage section is revealed by role rather than always present-but-disabled.
+/// A disabled tab advertises a capability the account does not have and invites the
+/// user to go looking for why, where an absent one simply is not part of their app —
+/// which is how apps/web's portal behaves for the same roles.
+///
+/// The gate is a courtesy, not the security boundary. Every write is independently
+/// enforced by the `songs_insert` / `songs_update` / `songs_delete` policies, so a
+/// user who forced this open would gain a UI, not permissions.
+private struct StudioShell: View {
+    let services: AppServices
+    @ObservedObject var auth: AuthController
+    @ObservedObject var library: LibraryViewModel
+
+    private enum Section: String, Hashable, CaseIterable {
+        case library = "Library"
+        case manage = "Manage"
+
+        var symbol: String {
+            switch self {
+            case .library: return "music.note.list"
+            case .manage: return "square.and.pencil"
+            }
+        }
+    }
+
+    @State private var section: Section = .library
+
+    /// editor+ per packages/core's `canDirectWrite`, answered through the bridged
+    /// `hasMinRole` rather than a Swift copy of the hierarchy.
+    ///
+    /// A bridge that failed to load yields false, so the Manage section stays hidden
+    /// — fail closed. That is also the honest answer: without the bridge there is no
+    /// parser, so the editor would have no preview and no slug generation anyway.
+    private var canManage: Bool {
+        guard let bridge = services.bridge else { return false }
+        return (try? bridge.hasMinRole(auth.role, atLeast: "editor")) ?? false
+    }
+
+    var body: some View {
+        Group {
+            switch section {
+            case .library:
+                LibrarySplitView(services: services, auth: auth, library: library)
+            case .manage:
+                ManageSongsView(
+                    services: services,
+                    library: library,
+                    onSessionExpired: { auth.sessionExpired() }
+                )
+            }
+        }
+        .toolbar {
+            if canManage {
+                ToolbarItem(placement: .navigation) {
+                    Picker("Section", selection: $section) {
+                        ForEach(Section.allCases, id: \.self) { section in
+                            Label(section.rawValue, systemImage: section.symbol).tag(section)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .help("Switch between reading the library and editing songs")
+                }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    if let email = auth.signedInEmail {
+                        Text(email)
+                    }
+                    if auth.role != "user" {
+                        Text("Role: \(auth.role)")
+                    }
+                    Button("Reload Library") { Task { await library.load() } }
+                    Divider()
+                    Button("Sign Out") { Task { await auth.signOut() } }
+                } label: {
+                    Label("Account", systemImage: "person.crop.circle")
+                }
+            }
+        }
+        // A role that drops below editor mid-session (or a bridge that never loaded)
+        // must not leave the user sitting in a section that no longer exists.
+        .onChange(of: canManage) { _, allowed in
+            if !allowed, section == .manage { section = .library }
         }
     }
 }
@@ -87,22 +177,9 @@ private struct LibrarySplitView: View {
                 detail
             }
             .navigationSplitViewStyle(.balanced)
-            // Attached to the split view, not to the GeometryReader around it, so
-            // the items reach the window toolbar.
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Menu {
-                        if let email = auth.signedInEmail {
-                            Text(email)
-                        }
-                        Button("Reload Library") { Task { await library.load() } }
-                        Divider()
-                        Button("Sign Out") { Task { await auth.signOut() } }
-                    } label: {
-                        Label("Account", systemImage: "person.crop.circle")
-                    }
-                }
-            }
+            // The Account menu and the section picker live on StudioShell, which
+            // wraps both sections — otherwise each section would install its own and
+            // they would appear and disappear as the user switched.
             .onAppear { applyLayout(for: geometry.size.width) }
             .onChange(of: geometry.size.width) { _, width in applyLayout(for: width) }
         }

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Core/CoreBridge.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Core/CoreBridge.swift
@@ -29,7 +29,7 @@ enum CoreBridgeError: Error, LocalizedError {
     /// The call returned something other than the expected type.
     case unexpectedResult(String)
     /// The JSON the bundle returned did not match the expected Swift model.
-    case decodingFailed(String)
+    case decodingFailed(type: String, reason: String)
 
     var errorDescription: String? {
         switch self {
@@ -49,8 +49,8 @@ enum CoreBridgeError: Error, LocalizedError {
             return "JavaScript error: \(message)"
         case .unexpectedResult(let message):
             return "Unexpected result from the core bundle: \(message)"
-        case .decodingFailed(let message):
-            return "Could not decode the parsed song: \(message)"
+        case .decodingFailed(let type, let reason):
+            return "Could not decode \(type) from the core bundle: \(reason)"
         }
     }
 }
@@ -76,6 +76,9 @@ final class CoreBridge {
     private let renderFunction: JSValue
     private let stepsBetweenFunction: JSValue
     private let formatKeyFunction: JSValue
+    private let lintFunction: JSValue
+    private let hasMinRoleFunction: JSValue
+    private let slugifyFunction: JSValue
     private let sink: ExceptionSink
 
     /// Path of the bundle that was actually loaded — used by the spike's
@@ -125,6 +128,9 @@ final class CoreBridge {
         self.renderFunction = try Self.requireFunction(named: "renderToJSON", on: namespace)
         self.stepsBetweenFunction = try Self.requireFunction(named: "stepsBetween", on: namespace)
         self.formatKeyFunction = try Self.requireFunction(named: "formatKey", on: namespace)
+        self.lintFunction = try Self.requireFunction(named: "lintToJSON", on: namespace)
+        self.hasMinRoleFunction = try Self.requireFunction(named: "hasMinRole", on: namespace)
+        self.slugifyFunction = try Self.requireFunction(named: "slugify", on: namespace)
         self.sink = sink
     }
 
@@ -204,6 +210,48 @@ final class CoreBridge {
         return try callReturningString(formatKeyFunction, named: "formatKey", arguments: arguments)
     }
 
+    /// Lint a ChordPro body through `packages/core`'s `lintChordPro`.
+    ///
+    /// Advisory only. Core emits nothing but `warn:*` codes and has no severity
+    /// field, so there is no "error" to distinguish here — a body so malformed that
+    /// it cannot be parsed at all surfaces through `parse`/`render` throwing
+    /// instead, which the editor presents separately. Consequently lint never
+    /// fails a save; it annotates one.
+    ///
+    /// The raw string is passed through rather than a parsed document because core
+    /// only runs its unbalanced-`{start_of_*}` scan on raw text, so linting the
+    /// editor's buffer catches strictly more than linting its parse would.
+    func lint(_ chordpro: String) throws -> [LintWarning] {
+        let arguments = try jsValues([.string(chordpro)])
+        let json = try callReturningString(lintFunction, named: "lintToJSON", arguments: arguments)
+        return try decodeJSON([LintWarning].self, from: json, describedAs: "lint warnings")
+    }
+
+    /// Role-hierarchy check through `packages/core`'s `hasMinRole`.
+    ///
+    /// Bridged rather than reimplemented because AGENTS.md makes rbac/roles.js the
+    /// one source of truth for gate checks: a Swift copy of ROLE_ORDER is exactly
+    /// what outlives a hierarchy change unnoticed, and `collaborator` was already
+    /// removed from that list once.
+    ///
+    /// Core's tolerance is preserved — an unrecognised role grants nothing, and an
+    /// empty role is read as `user` — so the caller may ask before the role has
+    /// loaded and get the closed answer.
+    func hasMinRole(_ role: String, atLeast minimum: String) throws -> Bool {
+        let arguments = try jsValues([.string(role), .string(minimum)])
+        return try callReturningBool(hasMinRoleFunction, named: "hasMinRole", arguments: arguments)
+    }
+
+    /// Title → URL-safe slug through `packages/core`'s `slugify`.
+    ///
+    /// Returns "" when the title contains no alphanumerics — core's signal that no
+    /// slug can be derived. `songs.slug` is UNIQUE NOT NULL, so a caller that gets
+    /// "" must refuse the write rather than pass it along.
+    func slugify(_ title: String) throws -> String {
+        let arguments = try jsValues([.string(title)])
+        return try callReturningString(slugifyFunction, named: "slugify", arguments: arguments)
+    }
+
     /// Interpolation values for the capo chip, or nil when the chip is hidden.
     ///
     /// Port of `capoChipValues` in apps/mobile/src/lib/capo.ts: the fret is pure
@@ -246,14 +294,44 @@ final class CoreBridge {
     }
 
     private func decodeDoc(from json: String) throws -> SongDoc {
+        try decodeJSON(SongDoc.self, from: json, describedAs: "the parsed song")
+    }
+
+    private func decodeJSON<T: Decodable>(
+        _ type: T.Type,
+        from json: String,
+        describedAs description: String
+    ) throws -> T {
         guard let data = json.data(using: .utf8) else {
-            throw CoreBridgeError.unexpectedResult("parsed JSON was not valid UTF-8")
+            throw CoreBridgeError.unexpectedResult("\(description): JSON was not valid UTF-8")
         }
         do {
-            return try JSONDecoder().decode(SongDoc.self, from: data)
+            return try JSONDecoder().decode(type, from: data)
         } catch {
-            throw CoreBridgeError.decodingFailed("\(error)")
+            throw CoreBridgeError.decodingFailed(type: description, reason: "\(error)")
         }
+    }
+
+    private func callReturningBool(
+        _ function: JSValue,
+        named name: String,
+        arguments: [JSValue]
+    ) throws -> Bool {
+        _ = sink.take()
+        let returned: JSValue? = function.call(withArguments: arguments)
+        if let message = sink.take() {
+            throw CoreBridgeError.jsException(message)
+        }
+        guard let result = returned else {
+            throw CoreBridgeError.unexpectedResult("\(name) returned no value")
+        }
+        // `isBoolean`, not `toBool()`: JSValue happily coerces a string or a number
+        // to a boolean, which would turn a bridge-contract break into a silently
+        // wrong permission answer.
+        guard result.isBoolean else {
+            throw CoreBridgeError.unexpectedResult("\(name) expected a boolean, got \(result)")
+        }
+        return result.toBool()
     }
 
     private func callReturningInt(

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Core/LintWarning.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Core/LintWarning.swift
@@ -1,0 +1,54 @@
+//
+//  LintWarning.swift
+//  GraceChords Studio
+//
+//  One advisory finding from packages/core/src/chordpro/lint.ts.
+//
+//  No CodingKeys: core emits `{code, message, sectionIndex, lineIndex}` in
+//  camelCase already, unlike the snake_case PostgREST rows in Data/SongModels.swift.
+//
+//  There is deliberately no severity here, because core has none — every code it
+//  emits is prefixed `warn:` and the module never reports a hard error. A body the
+//  parser cannot handle is a different failure entirely (CoreBridge.parse throws),
+//  and the editor shows that as its own state rather than folding it in as a
+//  pseudo-warning that lint never actually produced.
+//
+
+import Foundation
+
+struct LintWarning: Codable, Hashable, Identifiable {
+    /// Core's code, e.g. `warn:missing_key`. Kept as a raw String rather than an
+    /// enum so a code added to core later renders as an unfamiliar-but-visible
+    /// warning instead of failing the whole array's decode.
+    let code: String
+    let message: String
+    /// Index into the parsed document's sections, when the warning is about one.
+    let sectionIndex: Int?
+    /// For most codes this indexes the *lyric lines within a section*, but for
+    /// `warn:section_mismatch` it is an index into the raw body's lines — core
+    /// derives that one from a separate text scan. That inconsistency is why
+    /// nothing here tries to turn it into a caret position in the editor.
+    let lineIndex: Int?
+
+    /// Stable across a re-lint of unchanged text, which keeps SwiftUI from
+    /// re-creating rows as the user types.
+    var id: String { "\(code)|\(sectionIndex?.description ?? "-")|\(lineIndex?.description ?? "-")|\(message)" }
+
+    /// The code with its `warn:` prefix dropped and underscores opened up, for the
+    /// small label next to the message: `warn:missing_key` → "missing key".
+    var shortLabel: String {
+        let stripped = code.hasPrefix("warn:") ? String(code.dropFirst("warn:".count)) : code
+        return stripped.replacingOccurrences(of: "_", with: " ")
+    }
+
+    /// A human-readable location, or nil when the warning is about the whole song
+    /// (a missing title or key).
+    var locationText: String? {
+        if let lineIndex = lineIndex, let sectionIndex = sectionIndex {
+            return "section \(sectionIndex + 1), line \(lineIndex + 1)"
+        }
+        if let lineIndex = lineIndex { return "line \(lineIndex + 1)" }
+        if let sectionIndex = sectionIndex { return "section \(sectionIndex + 1)" }
+        return nil
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Data/SongModels.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Data/SongModels.swift
@@ -13,6 +13,25 @@
 
 import Foundation
 
+/// Publication state of a row in `public.songs`.
+///
+/// Two cases, matching the `songs_status_check` constraint. `public.personal_songs`
+/// has four ('draft','submitted','published','archived') because it feeds the
+/// submission/review queue; this column deliberately does not.
+enum SongStatus: String, Codable, Hashable, CaseIterable {
+    case draft
+    case published
+
+    /// An unrecognised value decodes as `.published` rather than throwing. The
+    /// column is NOT NULL DEFAULT 'published' and every pre-existing row is live
+    /// content, so if a future migration adds a third state the failure mode is a
+    /// song shown as published — not a library that refuses to decode.
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = SongStatus(rawValue: raw) ?? .published
+    }
+}
+
 /// A library row — everything except the ChordPro body.
 struct SongListItem: Codable, Identifiable, Hashable {
     let id: String
@@ -24,9 +43,15 @@ struct SongListItem: Codable, Identifiable, Hashable {
     let tags: [String]?
     let tempo: Int?
     let createdAt: String?
+    /// Only editor+ ever receives `.draft` rows — the `songs_select` policy filters
+    /// them out for everyone else, so a non-editor's list is published-only without
+    /// the client asking for that.
+    let status: SongStatus
+
+    var isDraft: Bool { status == .draft }
 
     enum CodingKeys: String, CodingKey {
-        case id, slug, title, artist, tags, tempo
+        case id, slug, title, artist, tags, tempo, status
         case defaultKey = "default_key"
         case timeSignature = "time_signature"
         case createdAt = "created_at"
@@ -43,11 +68,46 @@ struct SongDetail: Codable, Identifiable, Hashable {
     let timeSignature: String?
     let tempo: Int?
     let chordproContent: String?
+    let status: SongStatus
+
+    var isDraft: Bool { status == .draft }
 
     enum CodingKeys: String, CodingKey {
-        case id, slug, title, artist, tempo
+        case id, slug, title, artist, tempo, status
         case defaultKey = "default_key"
         case timeSignature = "time_signature"
+        case chordproContent = "chordpro_content"
+    }
+}
+
+/// Every authoring-relevant column of a song, for the editor.
+///
+/// Wider than `SongDetail` because the editor owns fields the viewer never reads
+/// (tags, country, language, YouTube id, pptx url). Mirrors the column set
+/// `packages/core/src/songs/songAuthoring.ts` maps to and from, so a song written
+/// here and one written by the web editor carry the same fields.
+struct SongEditable: Codable, Identifiable, Hashable {
+    let id: String
+    let slug: String
+    let title: String
+    let artist: String?
+    let defaultKey: String?
+    let tempo: Int?
+    let timeSignature: String?
+    let country: String?
+    let youtubeID: String?
+    let language: String?
+    let pptxURL: String?
+    let tags: [String]?
+    let chordproContent: String?
+    let status: SongStatus
+
+    enum CodingKeys: String, CodingKey {
+        case id, slug, title, artist, tempo, country, language, tags, status
+        case defaultKey = "default_key"
+        case timeSignature = "time_signature"
+        case youtubeID = "youtube_id"
+        case pptxURL = "pptx_url"
         case chordproContent = "chordpro_content"
     }
 }

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Data/SongWritePayload.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Data/SongWritePayload.swift
@@ -1,0 +1,140 @@
+//
+//  SongWritePayload.swift
+//  GraceChords Studio
+//
+//  What Studio sends to `public.songs` on an insert or an update, and the
+//  `editor_audit_log` row that accompanies it.
+//
+//  Swift equivalent of `formToSongRow` in packages/core/src/songs/songAuthoring.ts:
+//  the same columns, and the same empty-string-to-NULL coalescing, so a song saved
+//  from Studio is indistinguishable from one saved by the web editor.
+//
+//  Properties are named exactly as the columns are, so no CodingKeys are needed —
+//  and unlike the Decodable row models, an accidental rename here would be a write
+//  to a column that does not exist rather than a field that silently stays nil.
+//
+
+import Foundation
+
+struct SongWritePayload: Encodable {
+    let title: String
+    let artist: String?
+    let default_key: String?
+    let tempo: Int?
+    let time_signature: String?
+    let country: String?
+    let youtube_id: String?
+    let language: String?
+    let pptx_url: String?
+    let tags: [String]
+    let chordpro_content: String
+    let slug: String
+    let is_deleted: Bool
+    let updated_at: String
+    /// Only set on an insert. `nil` is skipped by the encoder below, so an update
+    /// never rewrites the creation time.
+    let created_at: String?
+    /// Only set on an insert — a new song is always a draft. Deliberately absent on
+    /// an update, which is what makes "saving an edit cannot un-publish a song" a
+    /// property of the payload rather than a rule the UI has to remember.
+    let status: String?
+
+    /// `encodeIfPresent` throughout: PostgREST treats a key present with a JSON
+    /// null as "set this column to NULL", so encoding `created_at: nil` on an
+    /// update would wipe the creation timestamp rather than leave it alone. The
+    /// nullable *content* columns are encoded unconditionally, because there
+    /// clearing a field back to NULL is exactly what the user asked for.
+    enum CodingKeys: String, CodingKey {
+        case title, artist, default_key, tempo, time_signature, country
+        case youtube_id, language, pptx_url, tags, chordpro_content, slug
+        case is_deleted, updated_at, created_at, status
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(title, forKey: .title)
+        try container.encode(artist, forKey: .artist)
+        try container.encode(default_key, forKey: .default_key)
+        try container.encode(tempo, forKey: .tempo)
+        try container.encode(time_signature, forKey: .time_signature)
+        try container.encode(country, forKey: .country)
+        try container.encode(youtube_id, forKey: .youtube_id)
+        try container.encode(language, forKey: .language)
+        try container.encode(pptx_url, forKey: .pptx_url)
+        try container.encode(tags, forKey: .tags)
+        try container.encode(chordpro_content, forKey: .chordpro_content)
+        try container.encode(slug, forKey: .slug)
+        try container.encode(is_deleted, forKey: .is_deleted)
+        try container.encode(updated_at, forKey: .updated_at)
+        try container.encodeIfPresent(created_at, forKey: .created_at)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+}
+
+extension SongWritePayload {
+    /// Build the payload from editor state.
+    ///
+    /// `isInsert` decides the two write-once fields: a new row gets `created_at`
+    /// and `status = 'draft'`; an existing row gets neither, so its publication
+    /// state and creation time survive the save untouched.
+    init(form: SongForm, slug: String, isInsert: Bool, now: String = SongsRepository.timestamp()) {
+        self.title = form.title.trimmed
+        self.artist = form.artist.nilIfBlank
+        self.default_key = form.defaultKey.nilIfBlank
+        self.tempo = form.tempoValue
+        self.time_signature = form.timeSignature.nilIfBlank
+        self.country = form.country.nilIfBlank
+        self.youtube_id = form.youtubeID.nilIfBlank
+        self.language = form.language.nilIfBlank
+        self.pptx_url = form.pptxURL.nilIfBlank
+        self.tags = form.tags
+        // Coalesced to "" rather than NULL, matching core's note that the live
+        // column is NOT NULL — saving an empty body must not violate it.
+        self.chordpro_content = form.chordproContent
+        self.slug = slug
+        self.is_deleted = false
+        self.updated_at = now
+        self.created_at = isInsert ? now : nil
+        self.status = isInsert ? SongStatus.draft.rawValue : nil
+    }
+}
+
+/// A row for `public.editor_audit_log`, matching core's `writeAuditLog`.
+///
+/// `action` is a plain String because the table's CHECK constraint owns the
+/// vocabulary ('direct_save', 'suggestion_submitted', 'approved', 'rejected',
+/// 'deleted', 'touched_up'); `EditorAuditEntry.Action` below covers the two Studio
+/// actually writes.
+struct EditorAuditEntry: Encodable {
+    enum Action: String {
+        case directSave = "direct_save"
+        case deleted
+    }
+
+    let actor_id: String?
+    let action: String
+    /// Null for a delete, so the log row survives the `ON DELETE SET NULL` FK.
+    let song_id: String?
+    let song_slug: String?
+    let song_title: String?
+    let note: String?
+
+    init(action: Action, actorID: String?, songID: String?, slug: String?, title: String?, note: String? = nil) {
+        self.actor_id = actorID
+        self.action = action.rawValue
+        self.song_id = songID
+        self.song_slug = slug
+        self.song_title = title
+        self.note = note
+    }
+}
+
+extension String {
+    var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    /// Trimmed, or nil when nothing is left — core's `form.field || null`.
+    var nilIfBlank: String? {
+        let value = trimmed
+        return value.isEmpty ? nil : value
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Data/SongsRepository.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Data/SongsRepository.swift
@@ -6,11 +6,24 @@
 //  columns, same filters, same ordering, so Studio sees exactly the rows
 //  apps/mobile does.
 //
-//  Reads do not require a session: public.songs carries the policy
-//  "Songs are publicly readable" — `for select using (is_deleted = false)` with no
-//  role restriction (supabase/migrations/20260305_songs_migration.sql). The app
-//  still gates its UI behind sign-in, matching mobile, but a list that loads while
-//  auth is broken is a config/network problem, not an auth one.
+//  Reads do not require a session: public.songs carries the policy `songs_select`,
+//  which is `USING (is_deleted = false AND (status = 'published' OR
+//  has_min_role('editor')))` with no role restriction on the published branch
+//  (supabase/migrations/20260728000100_songs_status.sql). The app still gates its
+//  UI behind sign-in, matching mobile, but a list that loads while auth is broken
+//  is a config/network problem, not an auth one.
+//
+//  Draft filtering is NOT done here, on purpose. There is no `.eq("status", ...)`
+//  anywhere in this file: the policy decides what a caller can see, so an editor's
+//  list contains drafts and everyone else's does not, without the client asking.
+//  Duplicating the rule client-side is how you end up with a filter that disagrees
+//  with the policy — which is exactly the bug the 2026-07-28 consolidation
+//  migration was written to fix (`songs_select USING (true)` had been silently
+//  overriding the `is_deleted = false` that every query relied on).
+//
+//  Writes are editor+ per `songs_insert` / `songs_update` / `songs_delete`. A
+//  non-editor's write is rejected by the database, not by this type — the UI gate
+//  in ContentView is a courtesy, not the enforcement.
 //
 
 import Foundation
@@ -19,12 +32,28 @@ import Supabase
 enum SongsRepositoryError: LocalizedError {
     /// The access token was rejected — the caller should return to sign-in.
     case sessionExpired
+    /// A write was refused by row-level security. The UI gate should have prevented
+    /// this, so it means the account's role is below editor or was changed mid-session.
+    case notPermitted
+    /// The slug collided despite `uniqueSlug(for:)` — two editors saving new songs
+    /// with the same title at the same time is the realistic way this happens.
+    case slugTaken
     case requestFailed(String)
 
     var errorDescription: String? {
         switch self {
         case .sessionExpired:
             return "Your session expired. Please sign in again."
+        case .notPermitted:
+            return """
+            Your account does not have permission to change the song catalog. \
+            Editing songs requires the editor role or higher.
+            """
+        case .slugTaken:
+            return """
+            Another song already uses this title's web address. \
+            Change the title slightly and save again.
+            """
         case .requestFailed(let message):
             return message
         }
@@ -32,12 +61,20 @@ enum SongsRepositoryError: LocalizedError {
 }
 
 struct SongsRepository {
-    /// Mirrors apps/mobile/src/lib/useSongList.ts COLUMNS.
+    /// Mirrors apps/mobile/src/lib/useSongList.ts COLUMNS, plus `status` so the
+    /// library can badge a draft.
     private static let listColumns =
-        "id, slug, title, artist, default_key, time_signature, tags, tempo, created_at"
-    /// Mirrors core's fetchSongBySlug default columns.
+        "id, slug, title, artist, default_key, time_signature, tags, tempo, created_at, status"
+    /// Mirrors core's fetchSongBySlug default columns, plus `status`.
     private static let detailColumns =
-        "id, slug, title, artist, default_key, time_signature, tempo, chordpro_content"
+        "id, slug, title, artist, default_key, time_signature, tempo, chordpro_content, status"
+    /// Every authoring-relevant column, for the editor. Mirrors the column set
+    /// packages/core/src/songs/songAuthoring.ts maps to and from.
+    private static let editableColumns =
+        """
+        id, slug, title, artist, default_key, tempo, time_signature, country, \
+        youtube_id, language, pptx_url, tags, chordpro_content, status
+        """
 
     let client: SupabaseClient
 
@@ -77,12 +114,210 @@ struct SongsRepository {
         }
     }
 
+    // MARK: - Editing
+
+    /// One song by id with every authoring column, or nil when there is no match.
+    ///
+    /// By id rather than slug because the editor can change the title, and a slug
+    /// derived from the old title stops matching the moment it does.
+    func fetchEditable(id: String) async throws -> SongEditable? {
+        do {
+            let rows: [SongEditable] = try await client
+                .from("songs")
+                .select(Self.editableColumns)
+                .eq("id", value: id)
+                .eq("is_deleted", value: false)
+                .limit(1)
+                .execute()
+                .value
+            return rows.first
+        } catch {
+            throw Self.mapped(error)
+        }
+    }
+
+    /// Insert a new song and return the saved row.
+    ///
+    /// `slug` is resolved by the caller through `uniqueSlug(for:)`. `created_at` and
+    /// `updated_at` are stamped here rather than left to the column defaults so an
+    /// insert and an update take the same path through `SongWritePayload` — and
+    /// because `songs` has no `update_updated_at` trigger (only `personal_songs`
+    /// does), so nothing else would set `updated_at` on a later save.
+    func insert(_ payload: SongWritePayload) async throws -> SongEditable {
+        do {
+            let rows: [SongEditable] = try await client
+                .from("songs")
+                .insert(payload)
+                .select(Self.editableColumns)
+                .execute()
+                .value
+            guard let saved = rows.first else {
+                throw SongsRepositoryError.requestFailed("The song was not returned after saving.")
+            }
+            return saved
+        } catch let error as SongsRepositoryError {
+            throw error
+        } catch {
+            throw Self.mapped(error)
+        }
+    }
+
+    /// Update an existing song by id and return the saved row.
+    ///
+    /// The payload deliberately carries no `status`, so saving an edit to a
+    /// published song cannot un-publish it. Publication is moved only by
+    /// `setStatus(id:to:)`, from an explicit Publish/Unpublish action.
+    func update(id: String, with payload: SongWritePayload) async throws -> SongEditable {
+        do {
+            let rows: [SongEditable] = try await client
+                .from("songs")
+                .update(payload)
+                .eq("id", value: id)
+                .select(Self.editableColumns)
+                .execute()
+                .value
+            guard let saved = rows.first else {
+                // An editor+ caller whose UPDATE matches nothing means the row was
+                // deleted underneath them — RLS returning zero rows and a missing
+                // row are indistinguishable here, and both mean the same thing.
+                throw SongsRepositoryError.requestFailed(
+                    "This song no longer exists. It may have been deleted in another session."
+                )
+            }
+            return saved
+        } catch let error as SongsRepositoryError {
+            throw error
+        } catch {
+            throw Self.mapped(error)
+        }
+    }
+
+    /// Publish or unpublish, the only path that moves `status`.
+    func setStatus(id: String, to status: SongStatus) async throws -> SongEditable {
+        struct StatusPayload: Encodable {
+            let status: String
+            let updated_at: String
+        }
+        do {
+            let rows: [SongEditable] = try await client
+                .from("songs")
+                .update(StatusPayload(status: status.rawValue, updated_at: Self.timestamp()))
+                .eq("id", value: id)
+                .select(Self.editableColumns)
+                .execute()
+                .value
+            guard let saved = rows.first else {
+                throw SongsRepositoryError.requestFailed(
+                    "This song no longer exists. It may have been deleted in another session."
+                )
+            }
+            return saved
+        } catch let error as SongsRepositoryError {
+            throw error
+        } catch {
+            throw Self.mapped(error)
+        }
+    }
+
+    /// Permanently delete a song. There is no recovery step.
+    ///
+    /// A genuine `DELETE`, not the `is_deleted = true` soft delete apps/web and
+    /// apps/mobile perform — so it also cascades: `setlist_songs.song_id` and
+    /// `user_starred_songs.song_id` are both `ON DELETE CASCADE`, meaning the song
+    /// leaves every personal and team setlist and every favourites list along with
+    /// it. `editor_audit_log.song_id` is `ON DELETE SET NULL`, so an audit row
+    /// written before the delete survives with its `song_slug` / `song_title` text
+    /// intact — which is why `SongEditorModel` writes it first.
+    func delete(id: String) async throws {
+        do {
+            try await client
+                .from("songs")
+                .delete()
+                .eq("id", value: id)
+                .execute()
+        } catch {
+            throw Self.mapped(error)
+        }
+    }
+
+    /// A slug that no other row holds, mirroring core's `deriveUniqueSlug`:
+    /// `_2`, `_3`… appended until free, with `currentID`'s own row not counting as
+    /// a collision so re-saving keeps its slug.
+    ///
+    /// Returns nil when the title yields no slug at all (no alphanumerics), which
+    /// core signals with '' — `songs.slug` is UNIQUE NOT NULL, so the caller must
+    /// refuse the write rather than insert an empty slug.
+    func uniqueSlug(for title: String, bridge: CoreBridge, currentID: String? = nil) async throws -> String? {
+        let base = try bridge.slugify(title)
+        guard !base.isEmpty else { return nil }
+
+        var candidate = base
+        var suffix = 2
+        // Same bounded guard as core: a title colliding a thousand times bails out
+        // rather than looping forever.
+        for _ in 0..<1000 {
+            let rows: [SlugProbe]
+            do {
+                rows = try await client
+                    .from("songs")
+                    .select("id")
+                    .eq("slug", value: candidate)
+                    .limit(1)
+                    .execute()
+                    .value
+            } catch {
+                throw Self.mapped(error)
+            }
+            guard let existing = rows.first else { return candidate }
+            if existing.id == currentID { return candidate }
+            candidate = "\(base)_\(suffix)"
+            suffix += 1
+        }
+        return candidate
+    }
+
+    /// Best-effort `editor_audit_log` row, matching core's `writeAuditLog`.
+    ///
+    /// Failures are the caller's to swallow: the log is a record of an action, and
+    /// losing the record must never be the reason the action itself fails.
+    func writeAuditLog(_ entry: EditorAuditEntry) async throws {
+        do {
+            try await client.from("editor_audit_log").insert(entry).execute()
+        } catch {
+            throw Self.mapped(error)
+        }
+    }
+
+    private struct SlugProbe: Decodable { let id: String }
+
+    /// ISO-8601 with fractional seconds, matching JavaScript's `toISOString()` so
+    /// rows written by Studio sort identically to rows written by web and mobile.
+    static func timestamp(_ date: Date = Date()) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+
     /// Recognise a rejected token without depending on a specific error type from
     /// supabase-swift: PostgREST reports an expired/invalid JWT as PGRST301, and
     /// GoTrue phrases it in the message. Matching on text keeps this working
     /// across client versions; the cost of a false positive is one extra sign-in.
+    ///
+    /// The write-side codes are recognised the same way and for the same reason:
+    /// 42501 is Postgres's "new row violates row-level security policy" (an INSERT
+    /// the `songs_insert` policy refused), and 23505 is a unique-constraint
+    /// violation, which on this table means the slug.
     private static func mapped(_ error: Error) -> SongsRepositoryError {
         let description = "\(error)".lowercased()
+        if description.contains("42501") || description.contains("row-level security") {
+            return .notPermitted
+        }
+        if description.contains("23505")
+            || description.contains("songs_slug_idx")
+            || description.contains("duplicate key value") {
+            return .slugTaken
+        }
         let looksLikeAuthFailure =
             description.contains("pgrst301")
             || description.contains("jwt expired")

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Data/UserRepository.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Data/UserRepository.swift
@@ -1,0 +1,59 @@
+//
+//  UserRepository.swift
+//  GraceChords Studio
+//
+//  The signed-in account's role.
+//
+//  Native equivalent of `fetchUserRole` in packages/core/src/rbac/userRole.js —
+//  same table, same column, same 'user' fallback — so the column name `role` lives
+//  in one place per platform rather than being inlined at each call site. (The
+//  live column was renamed from `global_role` to `role` at some point, and the
+//  policies that inlined the old name had to be rewritten; see
+//  supabase/migrations/20260522000000_advisor_hardening.sql.)
+//
+//  The role gates which sections of the UI appear. It is NOT the security boundary:
+//  every write is independently gated by the `songs_insert` / `songs_update` /
+//  `songs_delete` policies, so a tampered-with role in this process buys nothing.
+//
+
+import Foundation
+import Supabase
+
+struct UserRepository {
+    let client: SupabaseClient
+
+    private struct RoleRow: Decodable { let role: String? }
+
+    /// The signed-in user's id, or nil when there is no session.
+    ///
+    /// Lives here rather than in the caller so that view models need no `import
+    /// Supabase` — the target builds with SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY,
+    /// under which reaching through `client.auth.session.user` requires importing
+    /// both Supabase and Auth at the use site.
+    func currentUserID() async -> String? {
+        try? await client.auth.session.user.id.uuidString
+    }
+
+    /// The current user's role, or "user" when unauthenticated, absent, or
+    /// unreadable.
+    ///
+    /// Never throws. A failure here would otherwise have to be handled at the shell
+    /// level as a third state alongside signed-in and signed-out, and the only sane
+    /// answer to "we could not read your role" is the least-privileged one — so it
+    /// fails closed and returns "user".
+    func fetchRole() async -> String {
+        guard let userID = try? await client.auth.session.user.id else { return "user" }
+        do {
+            let rows: [RoleRow] = try await client
+                .from("users")
+                .select("role")
+                .eq("id", value: userID)
+                .limit(1)
+                .execute()
+                .value
+            return rows.first?.role ?? "user"
+        } catch {
+            return "user"
+        }
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Editor/LintWarningsView.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Editor/LintWarningsView.swift
@@ -1,0 +1,101 @@
+//
+//  LintWarningsView.swift
+//  GraceChords Studio
+//
+//  The advisory strip under the preview.
+//
+//  Presented as warnings, never as errors, because that is all core produces: every
+//  code from packages/core/src/chordpro/lint.ts is prefixed `warn:` and the module
+//  has no severity field. Nothing here blocks a save — a song with a suspicious
+//  chord symbol is still a song, and a linter that stopped the user from writing
+//  down what the band actually plays would be worse than no linter.
+//
+//  A body the PARSER rejects is a different failure and is shown in the preview
+//  pane itself, not here.
+//
+
+import SwiftUI
+
+struct LintWarningsView: View {
+    let warnings: [LintWarning]
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            header
+            if isExpanded, !warnings.isEmpty {
+                Divider()
+                list
+            }
+        }
+        .background(GCColor.surface)
+    }
+
+    private var header: some View {
+        Button {
+            isExpanded.toggle()
+        } label: {
+            HStack(spacing: GCSpacing.sm) {
+                Image(systemName: warnings.isEmpty ? "checkmark.circle" : "exclamationmark.triangle")
+                    .foregroundStyle(warnings.isEmpty ? GCColor.success : GCColor.star)
+                Text(summary)
+                    .gcTextStyle(.rowMeta)
+                    .foregroundStyle(GCColor.sec)
+                Spacer()
+                if !warnings.isEmpty {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.up")
+                        .foregroundStyle(GCColor.muted)
+                        .font(.system(size: 9, weight: .semibold))
+                }
+            }
+            .padding(.horizontal, GCSpacing.md)
+            .padding(.vertical, GCSpacing.sm)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(warnings.isEmpty)
+        .help(warnings.isEmpty ? "No ChordPro warnings" : "Show or hide ChordPro warnings")
+    }
+
+    private var summary: String {
+        if warnings.isEmpty { return "No ChordPro warnings" }
+        let noun = warnings.count == 1 ? "warning" : "warnings"
+        return "\(warnings.count) ChordPro \(noun) — these do not prevent saving"
+    }
+
+    private var list: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(warnings) { warning in
+                    HStack(alignment: .firstTextBaseline, spacing: GCSpacing.sm) {
+                        Text(warning.shortLabel)
+                            .gcTextStyle(.overline)
+                            .foregroundStyle(GCColor.textAccent)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(GCColor.accentSoft, in: RoundedRectangle(cornerRadius: 4))
+                            .frame(width: 150, alignment: .leading)
+                        Text(warning.message)
+                            .gcTextStyle(.rowMeta)
+                            .foregroundStyle(GCColor.ink)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if let location = warning.locationText {
+                            Text(location)
+                                .gcTextStyle(.overline)
+                                .foregroundStyle(GCColor.muted)
+                        }
+                    }
+                    .padding(.horizontal, GCSpacing.md)
+                    .padding(.vertical, GCSpacing.xs)
+                    Divider().opacity(0.4)
+                }
+            }
+            .padding(.vertical, GCSpacing.xs)
+        }
+        // Tall enough for a handful of rows, capped so the warnings never crowd out
+        // the preview they annotate.
+        .frame(maxHeight: 150)
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Editor/SongEditorModel.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Editor/SongEditorModel.swift
@@ -1,0 +1,423 @@
+//
+//  SongEditorModel.swift
+//  GraceChords Studio
+//
+//  State for one song being written: the form, the debounced live preview, the
+//  lint warnings, and the save / publish / delete actions.
+//
+//  The preview reuses the Viewer's renderer rather than a second rendering path:
+//  `CoreBridge.render` produces the same SongDoc the Viewer draws, and
+//  Editor/SongEditorView hands it to the same `ChordChartView`. So the preview
+//  cannot drift from what a worshipper sees — there is only one renderer.
+//
+//  Re-parsing is debounced rather than run per keystroke. Each refresh is a
+//  JavaScriptCore parse + transpose map + JSON encode, then a JSONDecoder pass,
+//  then a full SwiftUI re-layout of the chart — and CoreBridge is explicitly not
+//  thread-safe, so all of that runs on the main thread and competes with typing for
+//  the run loop.
+//
+
+// Combine is imported explicitly because the target builds with
+// SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY.
+import Combine
+import Foundation
+
+@MainActor
+final class SongEditorModel: ObservableObject {
+    /// Trailing debounce before the preview and lint refresh.
+    ///
+    /// 300ms sits in the gap between two thresholds: a fast typist's inter-key
+    /// interval is roughly 120–150ms, so a continuous burst of typing collapses to
+    /// ONE refresh at the end of the burst rather than one per character; and a
+    /// preview that lags more than ~400ms starts reading as disconnected from the
+    /// keyboard. Raising this is the correct response if a long song ever feels
+    /// heavy — moving the work off the main thread is not, because that would mean
+    /// a second JSContext and therefore a second copy of the parser.
+    static let previewDebounce = Duration.milliseconds(300)
+
+    // MARK: - Form
+
+    @Published var form: SongForm {
+        didSet {
+            guard form != oldValue else { return }
+            // Only a body change needs the bridge; editing the tempo field must not
+            // re-parse the chart.
+            if form.chordproContent != oldValue.chordproContent {
+                scheduleRefresh()
+            }
+        }
+    }
+
+    /// The form as it was last saved, for the dirty check.
+    private var savedForm: SongForm
+
+    var isDirty: Bool { form != savedForm }
+
+    // MARK: - Identity and publication state
+
+    /// nil until the first successful save — a new song has no row yet.
+    @Published private(set) var songID: String?
+    @Published private(set) var slug: String?
+    @Published private(set) var status: SongStatus
+
+    var isNew: Bool { songID == nil }
+
+    // MARK: - Preview
+
+    /// The chart as it should be drawn right now.
+    ///
+    /// Held across a refresh rather than cleared first, so the pane never blanks
+    /// mid-edit: an in-flight parse leaves the previous good document on screen.
+    @Published private(set) var previewDoc: SongDoc?
+    /// Set when the body could not be parsed at all. Distinct from `warnings` —
+    /// this is the parser throwing, not an advisory finding.
+    @Published private(set) var previewErrorText: String?
+    /// Everything core reported, before the not-applicable codes are dropped.
+    @Published private(set) var rawWarnings: [LintWarning] = []
+
+    /// The warnings actually worth showing. Derived rather than stored so that
+    /// clearing the title restores `warn:missing_title` immediately — the filter
+    /// depends on form fields that do not trigger a re-lint, and re-running the
+    /// bridge just to re-apply a predicate would be wasteful.
+    var warnings: [LintWarning] { Self.applicable(rawWarnings, given: form) }
+    @Published var showsPreview = true
+    @Published var showsWarnings = true
+
+    // MARK: - Work state
+
+    @Published private(set) var isLoading = false
+    @Published private(set) var isSaving = false
+    @Published var errorText: String?
+    @Published var statusMessage: String?
+
+    private let services: AppServices
+    private var refreshTask: Task<Void, Never>?
+    /// The body the current `previewDoc` was built from, so an edit that lands back
+    /// on the previously parsed text (typing a character and deleting it) skips the
+    /// bridge entirely.
+    private var lastRenderedBody: String?
+
+    /// Called after a successful create, save, publish or delete so the library list
+    /// can update without a refetch.
+    var onSaved: ((SongEditable) -> Void)?
+    var onDeleted: ((String) -> Void)?
+    var onSessionExpired: (() -> Void)?
+
+    // MARK: - Init
+
+    /// A blank draft. No row is written until the first save: `songs.slug` is UNIQUE
+    /// NOT NULL and core's slugify yields "" for an empty title, so a row genuinely
+    /// cannot exist before there is a title — and creating one on "New Song" would
+    /// leave an empty row behind every time the user changed their mind.
+    init(services: AppServices) {
+        self.services = services
+        self.form = SongForm()
+        self.savedForm = SongForm()
+        self.songID = nil
+        self.slug = nil
+        self.status = .draft
+    }
+
+    /// An existing song, loaded by id.
+    init(services: AppServices, songID: String) {
+        self.services = services
+        self.form = SongForm()
+        self.savedForm = SongForm()
+        self.songID = songID
+        self.slug = nil
+        self.status = .published
+    }
+
+    // MARK: - Loading
+
+    func load() async {
+        guard let songID = songID else {
+            // A blank draft still lints, so the "missing title / missing key"
+            // warnings are visible from the start rather than after the first
+            // keystroke.
+            refreshNow()
+            return
+        }
+        isLoading = true
+        errorText = nil
+        do {
+            guard let row = try await services.songs.fetchEditable(id: songID) else {
+                errorText = "This song could not be found. It may have been deleted."
+                isLoading = false
+                return
+            }
+            apply(row)
+        } catch SongsRepositoryError.sessionExpired {
+            onSessionExpired?()
+        } catch {
+            errorText = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+        }
+        isLoading = false
+    }
+
+    private func apply(_ row: SongEditable) {
+        let loaded = SongForm(row: row)
+        form = loaded
+        savedForm = loaded
+        songID = row.id
+        slug = row.slug
+        status = row.status
+        refreshNow()
+    }
+
+    // MARK: - Preview refresh
+
+    private func scheduleRefresh() {
+        refreshTask?.cancel()
+        refreshTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.previewDebounce)
+            guard !Task.isCancelled else { return }
+            self?.refreshNow()
+        }
+    }
+
+    /// Re-parse, re-render and re-lint the current body immediately.
+    func refreshNow() {
+        let body = form.chordproContent
+        guard let bridge = services.bridge else {
+            previewErrorText = services.bridgeErrorText ?? "The ChordPro parser is unavailable."
+            return
+        }
+        guard body != lastRenderedBody else { return }
+        lastRenderedBody = body
+
+        // Lint first and independently of the render. A body the parser rejects is
+        // exactly the body whose warnings are most worth reading, so the warning
+        // list must not be collateral damage of a parse failure.
+        do {
+            rawWarnings = try bridge.lint(body)
+        } catch {
+            rawWarnings = []
+        }
+
+        guard !body.isEmpty else {
+            previewDoc = nil
+            previewErrorText = nil
+            return
+        }
+        do {
+            // steps 0 / letters: the editor previews the song in its own key. There
+            // is no transpose control here — transposing is a reading concern, and
+            // the Viewer owns it.
+            previewDoc = try bridge.render(body, steps: 0, preferFlat: false, style: .letters)
+            previewErrorText = nil
+        } catch {
+            // The previous document is deliberately NOT cleared: mid-edit a body is
+            // transiently unparseable (a half-typed `{start_of_`), and blanking the
+            // pane on every such keystroke would make the preview unusable. The
+            // error is shown alongside the last good chart instead.
+            previewErrorText = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+        }
+    }
+
+    /// Drop the warnings that cannot apply to a GraceChords row.
+    ///
+    /// `lintChordPro` was written for standalone `.chordpro` files, where `{title}`
+    /// and `{key}` directives in the body are the only place that metadata lives. In
+    /// this database they live in the `title` and `default_key` COLUMNS instead, and
+    /// core's own `canonicalizeForm` is explicit that it will not inject them into the
+    /// body. The result is that `warn:missing_title` and `warn:missing_key` fire on
+    /// every single one of the 206 songs in the catalog — a panel that is wrong twice
+    /// about every song is a panel nobody reads, and it would bury the warnings that
+    /// do matter (`warn:section_mismatch`, `warn:unknown_chord`).
+    ///
+    /// Filtered here rather than in core: the module's behaviour is correct for the
+    /// input it documents, `apps/web` has a test asserting exactly this output, and a
+    /// row whose column IS empty still gets the warning — which is the case where it
+    /// is telling the truth.
+    static func applicable(_ warnings: [LintWarning], given form: SongForm) -> [LintWarning] {
+        warnings.filter { warning in
+            switch warning.code {
+            case "warn:missing_title": return form.title.trimmed.isEmpty
+            case "warn:missing_key": return form.defaultKey.trimmed.isEmpty
+            default: return true
+            }
+        }
+    }
+
+    /// Raw lyrics for a body the parser cannot handle — the Viewer's fallback,
+    /// reused so an unparseable draft still previews something readable.
+    var rawFallbackLines: [String] {
+        SongViewerModel.rawFallbackLines(from: form.chordproContent)
+    }
+
+    // MARK: - Saving
+
+    /// Insert or update. Never changes `status` — see `SongWritePayload.init`.
+    ///
+    /// Editing a published song and saving leaves it published: silently
+    /// un-publishing on save would pull a live song out of every worshipper's
+    /// library because someone fixed a typo, and this design has no review step to
+    /// put it back. Publication moves only through `publish()` / `unpublish()`.
+    func save() async {
+        guard form.isSavable else {
+            errorText = "Give this song a title before saving."
+            return
+        }
+        guard let bridge = services.bridge else {
+            errorText = services.bridgeErrorText ?? "The ChordPro parser is unavailable, so the web address cannot be derived."
+            return
+        }
+
+        isSaving = true
+        errorText = nil
+        statusMessage = nil
+        defer { isSaving = false }
+
+        do {
+            let saved: SongEditable
+            if let songID = songID {
+                // The slug is NOT re-derived from a changed title. It is the song's
+                // public URL on gracechords.com, and re-slugging on a title edit
+                // would silently break every existing link and QR code pointing at
+                // it. Core's upsertSong makes the same choice (`existing.slug ||
+                // deriveUniqueSlug(...)`).
+                guard let existingSlug = slug else {
+                    errorText = "This song's web address is missing, so it cannot be saved safely."
+                    return
+                }
+                let payload = SongWritePayload(form: form, slug: existingSlug, isInsert: false)
+                saved = try await services.songs.update(id: songID, with: payload)
+            } else {
+                guard let newSlug = try await services.songs.uniqueSlug(for: form.title, bridge: bridge) else {
+                    errorText = """
+                    This title cannot be turned into a web address. \
+                    Add at least one letter or number to it.
+                    """
+                    return
+                }
+                let payload = SongWritePayload(form: form, slug: newSlug, isInsert: true)
+                saved = try await services.songs.insert(payload)
+            }
+
+            apply(saved)
+            savedForm = form
+            statusMessage = status == .published ? "Saved." : "Draft saved."
+            await logAudit(.directSave, for: saved)
+            onSaved?(saved)
+        } catch SongsRepositoryError.sessionExpired {
+            onSessionExpired?()
+        } catch {
+            errorText = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+        }
+    }
+
+    /// Publishing is where completeness is enforced — core's full
+    /// `validateSongForm` rule, so Studio and the web editor admit the same songs to
+    /// the public catalog. Saving a draft deliberately does not require this.
+    func publish() async {
+        guard form.isPublishable else {
+            errorText = """
+            Before publishing, fill in the key and at least one tag. \
+            You can keep saving this as a draft in the meantime.
+            """
+            return
+        }
+        await moveStatus(to: .published, message: "Published. This song is now live.")
+    }
+
+    func unpublish() async {
+        await moveStatus(to: .draft, message: "Unpublished. This song is now a draft.")
+    }
+
+    private func moveStatus(to next: SongStatus, message: String) async {
+        guard let songID = songID else {
+            errorText = "Save this song before publishing it."
+            return
+        }
+        isSaving = true
+        errorText = nil
+        statusMessage = nil
+        defer { isSaving = false }
+        do {
+            let saved = try await services.songs.setStatus(id: songID, to: next)
+            status = saved.status
+            slug = saved.slug
+            statusMessage = message
+            await logAudit(.directSave, for: saved)
+            onSaved?(saved)
+        } catch SongsRepositoryError.sessionExpired {
+            onSessionExpired?()
+        } catch {
+            errorText = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+        }
+    }
+
+    /// Permanently delete. Hard delete, no recovery — the caller is responsible for
+    /// having confirmed first.
+    func delete() async {
+        guard let songID = songID else { return }
+        isSaving = true
+        errorText = nil
+        defer { isSaving = false }
+
+        // Written BEFORE the delete, deliberately. `editor_audit_log.song_id` is
+        // ON DELETE SET NULL, so this row survives the cascade with its song_slug
+        // and song_title text intact — which is the only trace of the song that
+        // remains afterwards.
+        await logAudit(.deleted, songID: songID, slug: slug, title: form.title)
+
+        do {
+            try await services.songs.delete(id: songID)
+            onDeleted?(songID)
+        } catch SongsRepositoryError.sessionExpired {
+            onSessionExpired?()
+        } catch {
+            errorText = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+        }
+    }
+
+    // MARK: - Audit log
+
+    private func logAudit(_ action: EditorAuditEntry.Action, for row: SongEditable) async {
+        await logAudit(action, songID: row.id, slug: row.slug, title: row.title)
+    }
+
+    /// Best-effort, matching core's callers: a failed audit write must never be the
+    /// reason a save or delete reports failure, so the error is swallowed rather
+    /// than surfaced.
+    private func logAudit(
+        _ action: EditorAuditEntry.Action,
+        songID: String?,
+        slug: String?,
+        title: String
+    ) async {
+        let actorID = await services.users.currentUserID()
+        let entry = EditorAuditEntry(
+            action: action,
+            actorID: actorID,
+            // Null for a delete so the row is not itself removed by the FK cascade.
+            songID: action == .deleted ? nil : songID,
+            slug: slug,
+            title: title
+        )
+        try? await services.songs.writeAuditLog(entry)
+    }
+
+    // MARK: - Display
+
+    /// Sentence naming everything a delete destroys, used verbatim in the
+    /// confirmation dialog. The setlist and favourites consequences are named
+    /// because they are not obvious from "delete this song", and they are not
+    /// recoverable: both FKs are ON DELETE CASCADE.
+    var deleteConfirmationMessage: String {
+        """
+        This permanently deletes the song and its ChordPro content. It will also be \
+        removed from every setlist that contains it, including other people's and \
+        your team's, and all favourites for it will be lost.
+
+        This cannot be undone. There is no recovery step.
+        """
+    }
+
+    var windowTitle: String {
+        let name = form.title.trimmed
+        if name.isEmpty { return isNew ? "New Song" : "Untitled Song" }
+        return name
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Editor/SongEditorView.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Editor/SongEditorView.swift
@@ -1,0 +1,622 @@
+//
+//  SongEditorView.swift
+//  GraceChords Studio
+//
+//  One song being written: metadata form, plain-text ChordPro editor, live preview.
+//
+//  Layout is a horizontal split — editor left, preview right — with the preview
+//  toggleable rather than permanent. On a 13" display the metadata form plus two
+//  panes is genuinely cramped, and while writing a verse the preview is often not
+//  what you want the width for.
+//
+//  The preview is `ChordChartView`, the SAME view the Song Viewer draws, fed the
+//  same `SongDoc` from the same bridged parser. There is deliberately no
+//  editor-specific renderer: a preview that could disagree with the Viewer would be
+//  worse than no preview.
+//
+//  The editor itself is a plain monospaced `TextEditor`. Syntax highlighting for
+//  [chords] and {directives} is NOT here — SwiftUI's TextEditor cannot style
+//  ranges, so it would mean dropping to NSTextView via NSViewRepresentable with a
+//  custom NSTextStorage, which brings its own problems (attribute runs fighting the
+//  undo manager, IME marked-text ranges, re-highlight cost on a long song) and is
+//  orthogonal to whether saving and publishing work. See apps/studio/README.md.
+//
+
+import SwiftUI
+
+struct SongEditorView: View {
+    @ObservedObject var model: SongEditorModel
+    /// Tags already in the catalog, so a typed tag snaps to their spelling instead of
+    /// minting a case-variant duplicate. See `SongForm.addTag`.
+    var knownTags: [String] = []
+    var onClose: () -> Void
+
+    @State private var pendingTag = ""
+    @State private var showsDeleteConfirmation = false
+    @State private var showsDiscardConfirmation = false
+    @State private var showsDetails = true
+    /// In a pane too narrow to split, the preview replaces the editor rather than
+    /// sitting beside it. Separate from `model.showsPreview` because the sensible
+    /// default differs: side by side the preview should be up, but a narrow pane must
+    /// open on the editor — you open an editor to type in it.
+    @State private var narrowShowsPreview = false
+
+    /// Minimum width for a side-by-side split, and the two panes' minimums that add
+    /// up to it. Kept as one set of numbers so the threshold cannot drift above what
+    /// the panes actually need and strand the preview.
+    ///
+    /// Measured on the DETAIL COLUMN, not the window: with the sidebar taking
+    /// 240–300 this pane is that much narrower than the window around it, which is
+    /// why the first cut's 900 meant the preview never appeared at an ordinary window
+    /// size. A 1000pt window with the sidebar at its 240 minimum leaves ~740 here.
+    private static let writingMinimumWidth: CGFloat = 360
+    private static let previewMinimumWidth: CGFloat = 320
+    private static let splitMinimumWidth: CGFloat = writingMinimumWidth + previewMinimumWidth
+
+    @State private var availableWidth: CGFloat = 0
+
+    private enum PaneLayout { case editorOnly, previewOnly, split }
+
+    private var isWide: Bool { availableWidth >= Self.splitMinimumWidth }
+
+    private var paneLayout: PaneLayout {
+        if isWide { return model.showsPreview ? .split : .editorOnly }
+        return narrowShowsPreview ? .previewOnly : .editorOnly
+    }
+
+    /// Whether the preview is on screen at all, in either layout.
+    private var isPreviewVisible: Bool { paneLayout != .editorOnly }
+
+    var body: some View {
+        content
+            .navigationTitle(model.windowTitle)
+            .navigationSubtitle(model.isDirty ? "Edited" : "")
+            .toolbar { toolbarItems }
+            .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { width in
+                guard abs(width - availableWidth) > 0.5 else { return }
+                availableWidth = width
+            }
+            .task { await model.load() }
+            .alert("Delete “\(model.windowTitle)”?", isPresented: $showsDeleteConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Delete Song", role: .destructive) {
+                    Task { await model.delete() }
+                }
+            } message: {
+                Text(model.deleteConfirmationMessage)
+            }
+            .alert("Discard unsaved changes?", isPresented: $showsDiscardConfirmation) {
+                Button("Keep Editing", role: .cancel) {}
+                Button("Discard", role: .destructive) { onClose() }
+            } message: {
+                Text("Your edits to “\(model.windowTitle)” have not been saved. Closing the editor loses them.")
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.isLoading {
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let errorText = model.errorText, model.songID == nil, model.form.title.isEmpty {
+            // A load that failed outright — distinct from a save error, which is
+            // shown as a banner over a working editor.
+            VStack(alignment: .leading, spacing: GCSpacing.sm) {
+                Text(errorText).gcTextStyle(.body).foregroundStyle(GCColor.sec)
+                Button("Back to Songs") { onClose() }
+            }
+            .padding(GCSpacing.xl)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else {
+            editor
+        }
+    }
+
+    @ViewBuilder
+    private var editor: some View {
+        VStack(spacing: 0) {
+            statusBanner
+            switch paneLayout {
+            case .split:
+                // Two hierarchies rather than one with a conditional inside, so
+                // toggling the preview does not rebuild the HSplitView and reset the
+                // divider position the user dragged.
+                HSplitView {
+                    writingPane
+                    previewPane
+                }
+            case .editorOnly:
+                writingPane
+            case .previewOnly:
+                previewPane
+            }
+        }
+    }
+
+    // MARK: - Banners
+
+    @ViewBuilder
+    private var statusBanner: some View {
+        if let errorText = model.errorText {
+            banner(errorText, icon: "exclamationmark.triangle.fill", tint: GCColor.danger) {
+                model.errorText = nil
+            }
+        } else if let statusMessage = model.statusMessage {
+            banner(statusMessage, icon: "checkmark.circle.fill", tint: GCColor.success) {
+                model.statusMessage = nil
+            }
+        }
+    }
+
+    private func banner(
+        _ text: String,
+        icon: String,
+        tint: Color,
+        dismiss: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: GCSpacing.sm) {
+            Image(systemName: icon).foregroundStyle(tint)
+            Text(text)
+                .gcTextStyle(.rowMeta)
+                .foregroundStyle(GCColor.ink)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark").font(.system(size: 9, weight: .bold))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(GCColor.muted)
+        }
+        .padding(.horizontal, GCSpacing.md)
+        .padding(.vertical, GCSpacing.sm)
+        .background(GCColor.surfaceAlt)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    // MARK: - Writing pane
+
+    private var writingPane: some View {
+        VStack(spacing: 0) {
+            detailsHeader
+            if showsDetails {
+                Divider()
+                // Sized to its content, not to a fixed height. The first cut pinned
+                // this to 320pt, which left a band of dead space under the last row
+                // on every song and took it away from the editor.
+                metadataForm
+                    .padding(.horizontal, GCSpacing.lg)
+                    .padding(.bottom, GCSpacing.lg)
+            }
+            Divider()
+            chordproEditor
+        }
+        .frame(minWidth: Self.writingMinimumWidth)
+    }
+
+    /// Collapsible header for the metadata form. Collapsed, it summarises what is
+    /// hidden — a bare chevron over nothing would make the user open it to remember
+    /// whether the key was set.
+    private var detailsHeader: some View {
+        Button {
+            showsDetails.toggle()
+        } label: {
+            HStack(spacing: GCSpacing.sm) {
+                Image(systemName: showsDetails ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(GCColor.muted)
+                Text("Details").gcTextStyle(.overline).foregroundStyle(GCColor.sec)
+                if !showsDetails {
+                    Text(collapsedSummary)
+                        .gcTextStyle(.overline)
+                        .foregroundStyle(GCColor.muted)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if !model.form.isPublishable {
+                    // Amber, not red, and worded as a publish precondition — because
+                    // saving is not blocked by it. 8 songs already in the catalog have
+                    // no tags; the editor must not present those as broken.
+                    Label(
+                        model.status == .published ? "Missing details" : "Not ready to publish",
+                        systemImage: "exclamationmark.circle"
+                    )
+                    .gcTextStyle(.overline)
+                    .foregroundStyle(GCColor.star)
+                }
+            }
+            .padding(.horizontal, GCSpacing.md)
+            .padding(.vertical, GCSpacing.sm)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(showsDetails ? "Hide the song details" : "Show the song details")
+    }
+
+    private var collapsedSummary: String {
+        var parts: [String] = []
+        if !model.form.defaultKey.isEmpty { parts.append("Key of \(model.form.defaultKey)") }
+        if let tempo = model.form.tempoValue { parts.append("\(tempo) bpm") }
+        if !model.form.tags.isEmpty { parts.append(model.form.tags.joined(separator: ", ")) }
+        return parts.isEmpty ? "" : "— " + parts.joined(separator: " · ")
+    }
+
+    private var metadataForm: some View {
+        VStack(alignment: .leading, spacing: GCSpacing.md) {
+            HStack(alignment: .top, spacing: GCSpacing.md) {
+                field("Title", requirement: .toSave, error: model.form.errors.title) {
+                    TextField("Song title", text: $model.form.title)
+                }
+                field("Artist", error: nil) {
+                    TextField("Optional", text: $model.form.artist)
+                }
+            }
+            HStack(alignment: .top, spacing: GCSpacing.md) {
+                field("Key", requirement: .toPublish, error: model.form.errors.defaultKey) {
+                    Picker("", selection: $model.form.defaultKey) {
+                        Text("Choose…").tag("")
+                        ForEach(SongForm.keys, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                }
+                field("Time", error: nil) {
+                    Picker("", selection: $model.form.timeSignature) {
+                        Text("None").tag("")
+                        ForEach(SongForm.timeSignatures, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                }
+                field("Tempo", error: nil) {
+                    TextField("BPM", text: $model.form.tempo)
+                }
+                field("Language", error: nil) {
+                    Picker("", selection: $model.form.language) {
+                        Text("None").tag("")
+                        ForEach(SongForm.languages, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                }
+            }
+            tagsField
+            HStack(alignment: .top, spacing: GCSpacing.md) {
+                field("YouTube", error: nil, warning: youtubeWarning) {
+                    TextField("URL or video ID", text: $model.form.youtubeID)
+                        .onSubmit(normalizeYouTube)
+                }
+                field("Country", error: nil) {
+                    TextField("Optional", text: $model.form.country)
+                }
+            }
+        }
+        .textFieldStyle(.roundedBorder)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var youtubeWarning: String? {
+        let raw = model.form.youtubeID.trimmed
+        guard !raw.isEmpty else { return nil }
+        return SongForm.normalizeYouTube(raw).valid ? nil : "Not a recognised YouTube URL or ID"
+    }
+
+    private func normalizeYouTube() {
+        let result = SongForm.normalizeYouTube(model.form.youtubeID)
+        if result.valid { model.form.youtubeID = result.id }
+    }
+
+    private var tagsField: some View {
+        field("Tags", requirement: .toPublish, error: model.form.errors.tags) {
+            VStack(alignment: .leading, spacing: GCSpacing.sm) {
+                HStack(spacing: GCSpacing.sm) {
+                    TextField("Add a tag and press Return", text: $pendingTag)
+                        .onSubmit(commitTag)
+                    Button("Add", action: commitTag)
+                        .disabled(pendingTag.trimmed.isEmpty)
+                    if !suggestedTags.isEmpty {
+                        Menu {
+                            ForEach(suggestedTags, id: \.self) { tag in
+                                Button(tag) { model.form.addTag(tag, knownTags: knownTags) }
+                            }
+                        } label: {
+                            Image(systemName: "list.bullet")
+                        }
+                        .menuStyle(.borderlessButton)
+                        .frame(width: 28)
+                        .help("Add an existing tag from the catalog")
+                    }
+                }
+                if !model.form.tags.isEmpty {
+                    FlowLayout(horizontalSpacing: GCSpacing.xs, verticalSpacing: GCSpacing.xs) {
+                        ForEach(model.form.tags, id: \.self) { tag in
+                            HStack(spacing: 4) {
+                                Text(tag).gcTextStyle(.rowMeta)
+                                Button {
+                                    model.form.removeTag(tag)
+                                } label: {
+                                    Image(systemName: "xmark").font(.system(size: 8, weight: .bold))
+                                }
+                                .buttonStyle(.plain)
+                            }
+                            .padding(.horizontal, GCSpacing.sm)
+                            .padding(.vertical, 3)
+                            .background(GCColor.accentSoft, in: Capsule())
+                            .foregroundStyle(GCColor.textAccent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func commitTag() {
+        model.form.addTag(pendingTag, knownTags: knownTags)
+        pendingTag = ""
+    }
+
+    /// Catalog tags not already on this song, most common first as supplied.
+    /// Picking from here is how a tag stays spelled the way the rest of the catalog
+    /// spells it.
+    private var suggestedTags: [String] {
+        knownTags.filter { candidate in
+            !model.form.tags.contains { $0.caseInsensitiveCompare(candidate) == .orderedSame }
+        }
+    }
+
+    /// How badly a field is needed. Distinguished because Save and Publish have
+    /// different bars: only the title blocks a save, while the key and tags block
+    /// only publication — so showing all three as equally red errors would say the
+    /// editor is stuck when it is not.
+    private enum FieldRequirement {
+        case optional
+        /// Blocks saving. Red.
+        case toSave
+        /// Blocks publishing only. Amber.
+        case toPublish
+
+        var marker: Color? {
+            switch self {
+            case .optional: return nil
+            case .toSave: return GCColor.danger
+            case .toPublish: return GCColor.star
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func field<Content: View>(
+        _ label: String,
+        requirement: FieldRequirement = .optional,
+        error: String?,
+        warning: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 2) {
+                Text(label).gcTextStyle(.overline).foregroundStyle(GCColor.sec)
+                if let marker = requirement.marker {
+                    Text("*").gcTextStyle(.overline).foregroundStyle(marker)
+                }
+            }
+            content()
+            if let error = error {
+                Text(requirement == .toPublish ? "\(error) to publish" : error)
+                    .gcTextStyle(.overline)
+                    .foregroundStyle(requirement.marker ?? GCColor.danger)
+            } else if let warning = warning {
+                Text(warning).gcTextStyle(.overline).foregroundStyle(GCColor.star)
+            }
+        }
+    }
+
+    // MARK: - ChordPro editor
+
+    private var chordproEditor: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: GCSpacing.sm) {
+                Text("ChordPro").gcTextStyle(.overline).foregroundStyle(GCColor.sec)
+                Spacer()
+                Text("\(model.form.chordproContent.count) characters")
+                    .gcTextStyle(.overline)
+                    .foregroundStyle(GCColor.muted)
+            }
+            .padding(.horizontal, GCSpacing.md)
+            .padding(.vertical, GCSpacing.sm)
+
+            TextEditor(text: $model.form.chordproContent)
+                .font(.system(size: 12.5, weight: .regular, design: .monospaced))
+                .lineSpacing(2)
+                // Spelling and autocorrect fight ChordPro constantly: {sov} and
+                // [Bbmaj7] are not words, and macOS's automatic substitutions would
+                // turn a straight quote in a lyric into a curly one that the parser
+                // then carries into the chart.
+                .disableAutocorrection(true)
+                .scrollContentBackground(.hidden)
+                .background(GCColor.bg)
+                .frame(minHeight: 200)
+        }
+    }
+
+    // MARK: - Preview pane
+
+    private var previewPane: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: GCSpacing.sm) {
+                Text("Preview").gcTextStyle(.overline).foregroundStyle(GCColor.sec)
+                if !model.form.defaultKey.isEmpty {
+                    Text("Key of \(model.form.defaultKey)")
+                        .gcTextStyle(.overline)
+                        .foregroundStyle(GCColor.textAccent)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, GCSpacing.md)
+            .padding(.vertical, GCSpacing.sm)
+            Divider()
+
+            ScrollView {
+                previewBody
+                    .padding(GCSpacing.lg)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .background(GCColor.bg)
+
+            LintWarningsView(warnings: model.warnings, isExpanded: $model.showsWarnings)
+        }
+        .frame(minWidth: Self.previewMinimumWidth)
+    }
+
+    @ViewBuilder
+    private var previewBody: some View {
+        VStack(alignment: .leading, spacing: GCSpacing.md) {
+            // A parse failure is shown ABOVE the last good chart rather than
+            // replacing it: mid-edit a body is transiently unparseable, and blanking
+            // the pane on those keystrokes would make the preview unusable.
+            if let parseError = model.previewErrorText {
+                HStack(alignment: .firstTextBaseline, spacing: GCSpacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(GCColor.star)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Cannot draw the chart for this text yet")
+                            .gcTextStyle(.rowMeta)
+                            .foregroundStyle(GCColor.ink)
+                        Text(parseError)
+                            .gcTextStyle(.overline)
+                            .foregroundStyle(GCColor.muted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(GCSpacing.sm)
+                .background(GCColor.surfaceAlt, in: RoundedRectangle(cornerRadius: GCRadius.sm))
+            }
+
+            if let doc = model.previewDoc {
+                ChordChartView(
+                    doc: doc,
+                    options: ChartRenderOptions(
+                        showChords: true,
+                        showSections: true,
+                        fontScale: 1.0,
+                        splitInstrumentals: false
+                    )
+                )
+            } else if model.form.chordproContent.trimmed.isEmpty {
+                VStack(alignment: .leading, spacing: GCSpacing.xs) {
+                    Text("Nothing to preview yet").gcTextStyle(.body).foregroundStyle(GCColor.ink)
+                    Text("Start typing ChordPro on the left and the chart appears here.")
+                        .gcTextStyle(.rowMeta).foregroundStyle(GCColor.muted)
+                }
+            } else {
+                // Never parsed successfully even once — show the recovered lyrics,
+                // the same fallback the Viewer uses.
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(model.rawFallbackLines.enumerated()), id: \.offset) { _, line in
+                        Text(line.isEmpty ? " " : line)
+                            .font(.system(size: GCChartMetrics.lyricSize))
+                            .foregroundStyle(GCColor.ink)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarItems: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            Button {
+                if model.isDirty { showsDiscardConfirmation = true } else { onClose() }
+            } label: {
+                Label("Songs", systemImage: "chevron.left")
+            }
+            .help("Back to Songs")
+        }
+
+        // The toggle is always present, in both layouts. It was previously gated on
+        // there being room for a split, which meant the preview — the whole point of
+        // the editor — was simply unreachable in any window that was not very wide.
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                if isWide { model.showsPreview.toggle() } else { narrowShowsPreview.toggle() }
+            } label: {
+                Label(
+                    "Preview",
+                    systemImage: isWide
+                        ? (isPreviewVisible ? "sidebar.right" : "sidebar.squares.right")
+                        : (isPreviewVisible ? "pencil" : "eye")
+                )
+            }
+            .help(previewToggleHelp)
+            .foregroundStyle(isPreviewVisible ? GCColor.accent : GCColor.sec)
+        }
+
+        ToolbarItem(placement: .primaryAction) {
+            statusPill
+        }
+
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                Task { await model.save() }
+            } label: {
+                Text(model.status == .published ? "Save" : "Save Draft")
+            }
+            .keyboardShortcut("s", modifiers: .command)
+            .disabled(!model.form.isSavable || model.isSaving)
+            .help(model.form.isSavable ? "Save this song" : "Give this song a title first")
+        }
+
+        ToolbarItem(placement: .primaryAction) {
+            Menu {
+                if model.status == .draft {
+                    Button("Publish…") { Task { await model.publish() } }
+                        // Not disabled on incompleteness — the action reports what is
+                        // missing. A silently disabled Publish with no explanation is
+                        // how you get someone hunting for the reason.
+                        .disabled(model.isNew || model.isDirty)
+                } else {
+                    Button("Unpublish") { Task { await model.unpublish() } }
+                }
+                Divider()
+                Button("Delete Song…", role: .destructive) {
+                    showsDeleteConfirmation = true
+                }
+                .disabled(model.isNew)
+            } label: {
+                Label("More", systemImage: "ellipsis.circle")
+            }
+            .disabled(model.isSaving)
+        }
+    }
+
+    private var previewToggleHelp: String {
+        if isWide {
+            return isPreviewVisible ? "Hide the preview" : "Show the preview beside the editor"
+        }
+        // Named explicitly, because in a narrow pane the two swap rather than one
+        // appearing next to the other, and a button that says "Show preview" while
+        // hiding what you were typing needs to say so.
+        return isPreviewVisible
+            ? "Back to the editor — the pane is too narrow to show both"
+            : "Show the preview instead of the editor — the pane is too narrow for both"
+    }
+
+    private var statusPill: some View {
+        HStack(spacing: GCSpacing.xs) {
+            Circle()
+                .fill(model.status == .published ? GCColor.success : GCColor.star)
+                .frame(width: 6, height: 6)
+            Text(model.isNew ? "New draft" : (model.status == .published ? "Published" : "Draft"))
+                .gcTextStyle(.overline)
+                .foregroundStyle(GCColor.sec)
+        }
+        .padding(.horizontal, GCSpacing.sm)
+        .padding(.vertical, 3)
+        .background(GCColor.surfaceAlt, in: Capsule())
+        .help(
+            model.status == .published
+                ? "This song is live in the public library. Saving an edit keeps it live."
+                : "This song is a draft. Only editors can see it until you publish it."
+        )
+    }
+}
+

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Editor/SongForm.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Editor/SongForm.swift
@@ -1,0 +1,159 @@
+//
+//  SongForm.swift
+//  GraceChords Studio
+//
+//  The editor's working state for one song.
+//
+//  Swift mirror of `SongForm` / `validateSongForm` / `BLANK_SONG_FORM` in
+//  packages/core/src/songs/songAuthoring.ts, deliberately hand-written rather than
+//  bridged: the bridge passes primitives across a JSON boundary, so validating
+//  through it would mean serialising the whole form on every keystroke to get three
+//  booleans back. What IS bridged is everything whose *output* has to match another
+//  client byte for byte — the parser, the transposer, the linter, `slugify`, and
+//  the role hierarchy (see Core/CoreBridge.swift).
+//
+//  The validation rules are core's exactly: title, key, and at least one tag. If
+//  core's rules change, this must follow — a song Studio accepts and the web
+//  editor rejects is the failure mode to avoid.
+//
+//  TIME_SIGNATURES and LANGUAGE_OPTIONS are core's lists verbatim, for the same
+//  reason: they populate pickers whose values land in shared columns.
+//
+
+import Foundation
+
+struct SongForm: Equatable {
+    var title = ""
+    var artist = ""
+    var defaultKey = ""
+    /// Held as text, not Int, so the field can be empty and a half-typed number
+    /// does not snap back while the user is typing.
+    var tempo = ""
+    var timeSignature = ""
+    var country = ""
+    var youtubeID = ""
+    var language = ""
+    var pptxURL = ""
+    var tags: [String] = []
+    var chordproContent = ""
+
+    /// Core's `TIME_SIGNATURES`.
+    static let timeSignatures = ["4/4", "3/4", "2/4", "6/8"]
+    /// Core's `LANGUAGE_OPTIONS`, minus its leading '' — an empty selection is
+    /// modelled by the picker's own "None" tag instead.
+    static let languages = ["English", "Turkish", "Spanish", "Arabic", "Korean", "Other"]
+    /// The keys the picker offers, matching the chart's letter spellings.
+    static let keys = [
+        "C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb",
+        "G", "G#", "Ab", "A", "A#", "Bb", "B",
+    ]
+
+    var tempoValue: Int? {
+        let trimmed = tempo.trimmed
+        guard !trimmed.isEmpty, let value = Int(trimmed), value > 0 else { return nil }
+        return value
+    }
+
+    // MARK: - Validation (port of core's validateSongForm)
+
+    struct Errors: Equatable {
+        var title: String?
+        var defaultKey: String?
+        var tags: String?
+
+        var isEmpty: Bool { title == nil && defaultKey == nil && tags == nil }
+    }
+
+    var errors: Errors {
+        var errors = Errors()
+        if title.trimmed.isEmpty { errors.title = "Title is required" }
+        if defaultKey.isEmpty { errors.defaultKey = "Key is required" }
+        if tags.isEmpty { errors.tags = "At least one tag is required" }
+        return errors
+    }
+
+    /// Complete enough to publish — core's `validateSongForm` exactly, so Studio and
+    /// the web editor accept the same songs into the public catalog.
+    var isPublishable: Bool { errors.isEmpty }
+
+    /// Complete enough to SAVE, which is a lower bar than publishing on purpose.
+    ///
+    /// Gating Save on the full rule made 13 songs already in the catalog uneditable:
+    /// 8 published rows have no tags and 5 have no key, so an editor opening one to
+    /// fix a typo would have had to invent a tag before the Save button would even
+    /// enable. A draft is also allowed to be incomplete — that is most of what makes
+    /// it a draft.
+    ///
+    /// Title is the one field that cannot be deferred: `songs.title` is NOT NULL, and
+    /// the slug for a new row is derived from it.
+    var isSavable: Bool { !title.trimmed.isEmpty }
+
+    // MARK: - Mapping
+
+    /// Port of core's `songRowToForm`.
+    init(row: SongEditable) {
+        self.title = row.title
+        self.artist = row.artist ?? ""
+        self.defaultKey = row.defaultKey ?? ""
+        self.tempo = row.tempo.map(String.init) ?? ""
+        self.timeSignature = row.timeSignature ?? ""
+        self.country = row.country ?? ""
+        self.youtubeID = row.youtubeID ?? ""
+        self.language = row.language ?? ""
+        self.pptxURL = row.pptxURL ?? ""
+        self.tags = row.tags ?? []
+        self.chordproContent = row.chordproContent ?? ""
+    }
+
+    /// A blank draft — core's `BLANK_SONG_FORM`.
+    init() {}
+
+    // MARK: - Tags
+
+    /// Add a tag, snapping to the catalog's existing spelling when one matches
+    /// case-insensitively.
+    ///
+    /// `songs.tags` is matched case-SENSITIVELY by the library's tag filter and by
+    /// the web app's tag pages, and the live catalog is Title Case ("Slow",
+    /// "Praise", "Worship"). So neither passing the input through nor forcing a case
+    /// is right on its own: typing "worship" must not mint a second tag alongside
+    /// "Worship" and split the filter, but a genuinely new tag has to keep the
+    /// casing the user chose. Hence snap-if-known, keep-as-typed otherwise.
+    ///
+    /// Pass `knownTags` from `LibraryViewModel.availableTags`. With none supplied the
+    /// input is kept verbatim, which is the safe direction — a tag that duplicates an
+    /// existing one by case is fixable, a silently rewritten one is not.
+    mutating func addTag(_ raw: String, knownTags: [String] = []) {
+        let typed = raw.trimmed
+        guard !typed.isEmpty else { return }
+        let tag = knownTags.first { $0.caseInsensitiveCompare(typed) == .orderedSame } ?? typed
+        guard !tags.contains(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) else { return }
+        tags.append(tag)
+    }
+
+    mutating func removeTag(_ tag: String) {
+        tags.removeAll { $0 == tag }
+    }
+
+    // MARK: - YouTube
+
+    /// Port of core's `normalizeYoutubeInput`: a full URL or a bare id in, an
+    /// 11-character video id out. `valid` is false when the text looks like neither,
+    /// which the field shows as a warning without blocking the save — core does the
+    /// same, because a wrong id is recoverable and a blocked save is not.
+    static func normalizeYouTube(_ raw: String) -> (id: String, valid: Bool) {
+        let trimmed = raw.trimmed
+        guard !trimmed.isEmpty else { return ("", true) }
+        if trimmed.range(of: "^[a-zA-Z0-9_-]{11}$", options: .regularExpression) != nil {
+            return (trimmed, true)
+        }
+        for pattern in [#"[?&]v=([a-zA-Z0-9_-]{11})"#, #"youtu\.be/([a-zA-Z0-9_-]{11})"#, #"shorts/([a-zA-Z0-9_-]{11})"#] {
+            if let range = trimmed.range(of: pattern, options: .regularExpression) {
+                let match = String(trimmed[range])
+                let id = String(match.suffix(11))
+                return (id, true)
+            }
+        }
+        return (trimmed, false)
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Library/LibraryViewModel.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Library/LibraryViewModel.swift
@@ -143,6 +143,51 @@ final class LibraryViewModel: ObservableObject {
         isLoading = false
     }
 
+    // MARK: - Local mutations
+
+    /// Fold a saved song into the loaded list in place.
+    ///
+    /// Applied locally rather than by refetching so the sidebar updates the instant
+    /// a save returns, with no second round trip and no scroll-position reset. The
+    /// row that comes back is the row the database actually wrote, so this cannot
+    /// drift from the server the way an optimistic guess could.
+    func upsert(_ saved: SongEditable) {
+        let item = SongListItem(
+            id: saved.id,
+            slug: saved.slug,
+            title: saved.title,
+            artist: saved.artist,
+            defaultKey: saved.defaultKey,
+            timeSignature: saved.timeSignature,
+            tags: saved.tags,
+            tempo: saved.tempo,
+            // The list query selects created_at but the editor's does not. Preserve
+            // whatever the existing row had so a save cannot reorder the
+            // "recently added" sort; a newly inserted row legitimately has none
+            // loaded yet and sorts as unknown until the next full load.
+            createdAt: songs.first(where: { $0.id == saved.id })?.createdAt,
+            status: saved.status
+        )
+        if let index = songs.firstIndex(where: { $0.id == saved.id }) {
+            songs[index] = item
+        } else {
+            songs.append(item)
+        }
+        // Sections and search recompute from `songs`, so re-sorting here is not
+        // needed for display — but keeping the array title-ordered matches what a
+        // reload would produce, so the two paths cannot diverge.
+        songs.sort { $0.title.localizedCompare($1.title) == .orderedAscending }
+    }
+
+    /// Drop a hard-deleted song from the loaded list.
+    func remove(id: String) {
+        guard let index = songs.firstIndex(where: { $0.id == id }) else { return }
+        let removed = songs.remove(at: index)
+        // The Viewer is keyed on slug; leaving it selected would point it at a row
+        // that no longer exists.
+        if selectedSlug == removed.slug { selectedSlug = nil }
+    }
+
     private static func matchRank(_ song: SongListItem, query: String) -> Int? {
         if song.title.lowercased().contains(query) { return 0 }
         for tag in song.tags ?? [] where tag.lowercased().contains(query) { return 1 }

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Library/SongLibraryView.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Library/SongLibraryView.swift
@@ -236,9 +236,28 @@ private struct SongRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: GCSpacing.sm) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(song.title)
-                    .gcTextStyle(.rowTitle)
-                    .lineLimit(1)
+                HStack(spacing: GCSpacing.xs) {
+                    Text(song.title)
+                        .gcTextStyle(.rowTitle)
+                        .lineLimit(1)
+                    // Drafts reach this list only for editor+ — the `songs_select`
+                    // policy filters them out for everyone else — so the badge is not
+                    // gated on a role here. It exists because an unbadged draft mixed
+                    // into the catalog looks published, and an editor could reasonably
+                    // think their unfinished song was already live.
+                    if song.isDraft {
+                        Text("DRAFT")
+                            .font(.system(size: 8.5, weight: .bold))
+                            .tracking(0.4)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .strokeBorder(.secondary, lineWidth: 1)
+                            )
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 if let artist = song.artist, !artist.isEmpty {
                     Text(artist)
                         .gcTextStyle(.rowSubtitle)

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Manage/ManageSongsView.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Manage/ManageSongsView.swift
@@ -1,0 +1,249 @@
+//
+//  ManageSongsView.swift
+//  GraceChords Studio
+//
+//  The editor+ section: a list of every song this account can see — drafts included
+//  — and the editor for the selected one.
+//
+//  A separate section rather than a mode bolted onto the Library/Viewer split, for
+//  two concrete reasons. The Viewer installs `.focusedSceneObject(export)` and owns
+//  the File ▸ Export menu plus its own toolbar, and an editor mode inside it would
+//  contend for both. And the two surfaces own different state: the Library owns
+//  "which song is selected for reading", while the editor owns "does this song have
+//  unsaved changes" — collapsing them means one view holding both, where a stale
+//  dirty flag can outlive the song it belonged to.
+//
+//  Drafts are listed here because RLS returns them: `songs_select` admits
+//  `status = 'draft'` rows for editor+. Nothing in this file filters on status.
+//
+
+import SwiftUI
+
+struct ManageSongsView: View {
+    let services: AppServices
+    @ObservedObject var library: LibraryViewModel
+    var onSessionExpired: () -> Void
+
+    /// nil = nothing open. `.new` = an unsaved blank draft.
+    @State private var openSong: OpenSong?
+    /// The live editor, owned here.
+    ///
+    /// Held in @State rather than built where it is used: a model constructed inside
+    /// `body` would be a NEW model on every re-render, so every keystroke would
+    /// discard the edit that caused the re-render. It is replaced only when
+    /// `openSong` actually changes.
+    @State private var editor: SongEditorModel?
+    @State private var query = ""
+
+    private enum OpenSong: Hashable, Identifiable {
+        case new
+        case existing(id: String)
+
+        var id: String {
+            switch self {
+            case .new: return "new"
+            case .existing(let id): return id
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationSplitViewColumnWidth(min: 240, ideal: 300, max: 380)
+        } detail: {
+            detail
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
+
+    // MARK: - Sidebar
+
+    private var sidebar: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: GCSpacing.sm) {
+                HStack(spacing: GCSpacing.sm) {
+                    Image(systemName: "magnifyingglass").foregroundStyle(GCColor.muted)
+                    TextField("Search songs…", text: $query)
+                        .textFieldStyle(.plain)
+                        .gcTextStyle(.body)
+                    if !query.isEmpty {
+                        Button {
+                            query = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill").foregroundStyle(GCColor.muted)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, GCSpacing.sm)
+                .padding(.vertical, 5)
+                .background(GCColor.surfaceAlt, in: RoundedRectangle(cornerRadius: GCRadius.sm))
+            }
+            .padding(GCSpacing.sm)
+
+            Divider()
+            list
+        }
+        .navigationTitle("Manage Songs")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    open(.new)
+                } label: {
+                    Label("New Song", systemImage: "plus")
+                }
+                .keyboardShortcut("n", modifiers: .command)
+                .help("Create a new song as a draft")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var list: some View {
+        if library.isLoading, library.songs.isEmpty {
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let errorText = library.errorText, library.songs.isEmpty {
+            VStack(alignment: .leading, spacing: GCSpacing.sm) {
+                Text(errorText).gcTextStyle(.rowMeta).foregroundStyle(GCColor.sec)
+                Button("Try Again") { Task { await library.load() } }
+            }
+            .padding(GCSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else {
+            List(selection: selectionBinding) {
+                if !drafts.isEmpty {
+                    Section("Drafts (\(drafts.count))") {
+                        ForEach(drafts) { song in
+                            ManageRow(song: song).tag(song.id)
+                        }
+                    }
+                }
+                Section("Published (\(published.count))") {
+                    ForEach(published) { song in
+                        ManageRow(song: song).tag(song.id)
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+        }
+    }
+
+    /// The list drives selection by song id, but `openSong` also has a `.new` case
+    /// that no row corresponds to — so a `.new` editor shows no row as selected, and
+    /// picking a row replaces it.
+    private var selectionBinding: Binding<String?> {
+        Binding(
+            get: {
+                if case .existing(let id) = openSong { return id }
+                return nil
+            },
+            set: { id in
+                if let id = id { open(.existing(id: id)) } else { closeEditor() }
+            }
+        )
+    }
+
+    private var filtered: [SongListItem] {
+        let trimmed = query.trimmed.lowercased()
+        guard !trimmed.isEmpty else { return library.songs }
+        return library.songs.filter { song in
+            song.title.lowercased().contains(trimmed)
+                || (song.artist ?? "").lowercased().contains(trimmed)
+                || (song.tags ?? []).contains { $0.lowercased().contains(trimmed) }
+        }
+    }
+
+    /// Drafts first and in their own section: they are the work in progress, and a
+    /// draft buried alphabetically among hundreds of published songs is a draft
+    /// nobody finishes.
+    private var drafts: [SongListItem] {
+        filtered.filter(\.isDraft).sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
+    }
+
+    private var published: [SongListItem] {
+        filtered.filter { !$0.isDraft }.sorted { $0.title.localizedCompare($1.title) == .orderedAscending }
+    }
+
+    // MARK: - Detail
+
+    @ViewBuilder
+    private var detail: some View {
+        if let editor = editor, let openSong = openSong {
+            SongEditorView(model: editor, knownTags: library.availableTags, onClose: closeEditor)
+                // Keyed on the open song so switching songs rebuilds the view's own
+                // @State (pending-tag text, dialog flags) rather than carrying the
+                // previous song's over.
+                .id(openSong.id)
+        } else {
+            VStack(spacing: GCSpacing.sm) {
+                Text("Select a song to edit")
+                    .gcTextStyle(.body)
+                    .foregroundStyle(GCColor.sec)
+                Button("New Song") { open(.new) }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    /// Open a song, replacing any editor already open.
+    ///
+    /// Building the model here rather than in `body` is what keeps an in-progress
+    /// edit alive across re-renders. Re-opening the song that is already open is a
+    /// no-op, so clicking the selected row does not silently discard edits.
+    private func open(_ song: OpenSong) {
+        guard song != openSong else { return }
+        openSong = song
+
+        let model: SongEditorModel
+        switch song {
+        case .new:
+            model = SongEditorModel(services: services)
+        case .existing(let id):
+            model = SongEditorModel(services: services, songID: id)
+        }
+        model.onSessionExpired = onSessionExpired
+        model.onSaved = { saved in
+            library.upsert(saved)
+            // A new draft had no row until this save, so the sidebar had nothing
+            // selected. Point at the real row now — without rebuilding the model,
+            // which would throw away the editor the user is still typing in.
+            openSong = .existing(id: saved.id)
+        }
+        model.onDeleted = { id in
+            library.remove(id: id)
+            closeEditor()
+        }
+        editor = model
+    }
+
+    private func closeEditor() {
+        openSong = nil
+        editor = nil
+    }
+}
+
+/// A Manage sidebar row. Unlike the Library's SongRow this one shows publication
+/// state, because in this section it is the most important thing about a song.
+private struct ManageRow: View {
+    let song: SongListItem
+
+    var body: some View {
+        HStack(spacing: GCSpacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(song.title).gcTextStyle(.rowTitle).lineLimit(1)
+                if let artist = song.artist, !artist.isEmpty {
+                    Text(artist)
+                        .gcTextStyle(.rowSubtitle)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: GCSpacing.xs)
+            if let key = song.defaultKey, !key.isEmpty {
+                Text(key).gcTextStyle(.rowKey).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js
@@ -24,8 +24,12 @@ var GraceChordsCore = (() => {
   var entry_exports = {};
   __export(entry_exports, {
     formatKey: () => formatKey,
+    hasMinRole: () => hasMinRole2,
+    lintToJSON: () => lintToJSON,
     parseToJSON: () => parseToJSON,
     renderToJSON: () => renderToJSON,
+    roleOrderJSON: () => roleOrderJSON,
+    slugify: () => slugify2,
     stepsBetween: () => stepsBetween2,
     transpose: () => transpose
   });
@@ -349,6 +353,68 @@ var GraceChordsCore = (() => {
     return doc;
   }
 
+  // packages/core/src/chordpro/lint.ts
+  var RX_CHORD_VALID = /^[A-G](?:#|b)?(?:(?:maj|min|m|dim|sus|add)?\d*)?(?:\/[A-G](?:#|b)?)?$/;
+  function lintChordPro(rawOrDoc) {
+    const doc = typeof rawOrDoc === "string" ? parseChordProOrLegacy(rawOrDoc) : rawOrDoc;
+    const warnings = [];
+    if (!doc.meta?.title || !doc.meta.title.trim()) {
+      warnings.push({ code: "warn:missing_title", message: "Missing {title}." });
+    }
+    if (!doc.meta?.key || !doc.meta.key.trim()) {
+      warnings.push({ code: "warn:missing_key", message: "Missing {key}." });
+    }
+    doc.sections.forEach((sec, si) => {
+      const lyricLines = sec.lines.filter((ln) => !("comment" in ln));
+      if (lyricLines.length === 0) {
+        warnings.push({ code: "warn:empty_section", message: `Section "${sec.label || sec.kind}" has no lyric lines.`, sectionIndex: si });
+      }
+      lyricLines.forEach((ln, li) => {
+        if ((ln.lyrics || "").length > 90) {
+          warnings.push({ code: "warn:long_line", message: "Very long lyric line may force downsizing.", sectionIndex: si, lineIndex: li });
+        }
+        ;
+        (ln.chords || []).forEach((ch) => {
+          if (!RX_CHORD_VALID.test(ch.sym)) {
+            warnings.push({ code: "warn:unknown_chord", message: `Suspicious chord "${ch.sym}".`, sectionIndex: si, lineIndex: li });
+          }
+        });
+      });
+    });
+    for (let i = 1; i < doc.sections.length; i++) {
+      const a = doc.sections[i - 1];
+      const b = doc.sections[i];
+      if ((a.label || a.kind) === (b.label || b.kind)) {
+        const aLen = a.lines.filter((ln) => !("comment" in ln)).length;
+        const bLen = b.lines.filter((ln) => !("comment" in ln)).length;
+        if (aLen <= 2 && bLen <= 2) {
+          warnings.push({ code: "warn:duplicate_section_header", message: `Adjacent duplicate "${a.label || a.kind}" with very few lines.`, sectionIndex: i });
+        }
+      }
+    }
+    if (typeof rawOrDoc === "string") {
+      const lines = rawOrDoc.split(/\r?\n/);
+      const stack = [];
+      lines.forEach((raw, idx) => {
+        const m = raw.trim().match(/^\{(start_of|end_of)_([^}:]+).*\}$/i);
+        if (m) {
+          const type = m[1].toLowerCase();
+          const kind = m[2].toLowerCase();
+          if (type === "start_of") {
+            stack.push({ kind, lineIndex: idx });
+          } else {
+            const last = stack.pop();
+            if (!last || last.kind !== kind) {
+              warnings.push({ code: "warn:section_mismatch", message: `Stray {end_of_${kind}}`, lineIndex: idx });
+            }
+          }
+        }
+      });
+      stack.forEach((st) => warnings.push({ code: "warn:section_mismatch", message: `Unclosed {start_of_${st.kind}}`, lineIndex: st.lineIndex }));
+    }
+    return warnings;
+  }
+
   // packages/core/src/songs/instrumental.js
   function normalizeSpec(spec) {
     const chords = Array.isArray(spec?.chords) ? spec.chords.map((ch) => String(ch || "").trim()).filter(Boolean) : [];
@@ -361,6 +427,21 @@ var GraceChordsCore = (() => {
     const transposed = steps ? chords.map((sym) => transposeSymPrefer(sym, steps, preferFlat)) : chords.slice();
     const mapped = style === "solfege" ? transposed.map((sym) => formatChord(sym, { style })) : transposed;
     return { chords: mapped, repeat };
+  }
+
+  // packages/core/src/rbac/roles.js
+  var ROLE_ORDER = ["user", "editor", "admin", "owner"];
+  var ROLES_BY_RANK_DESC = [...ROLE_ORDER].reverse();
+  function hasMinRole(userRole, minRole) {
+    const userIdx = ROLE_ORDER.indexOf(userRole || "user");
+    const minIdx = ROLE_ORDER.indexOf(minRole || "user");
+    if (minIdx < 0) return false;
+    return userIdx >= minIdx;
+  }
+
+  // packages/core/src/songs/slug.ts
+  function slugify(title) {
+    return (title || "").toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/_+/g, "_").replace(/^_+|_+$/g, "");
   }
 
   // apps/studio/js/entry.mjs
@@ -422,6 +503,28 @@ var GraceChordsCore = (() => {
       }
     }
     return JSON.stringify(doc);
+  }
+  function lintToJSON(chordpro) {
+    if (typeof chordpro !== "string") {
+      throw new TypeError(`lintToJSON: chordpro must be a string, got ${describe(chordpro)}`);
+    }
+    return JSON.stringify(lintChordPro(chordpro));
+  }
+  function hasMinRole2(userRole, minRole) {
+    if (typeof userRole !== "string") {
+      throw new TypeError(`hasMinRole: userRole must be a string, got ${describe(userRole)}`);
+    }
+    requireString("hasMinRole", "minRole", minRole);
+    return hasMinRole(userRole, minRole);
+  }
+  function roleOrderJSON() {
+    return JSON.stringify(ROLE_ORDER);
+  }
+  function slugify2(title) {
+    if (typeof title !== "string") {
+      throw new TypeError(`slugify: title must be a string, got ${describe(title)}`);
+    }
+    return slugify(title);
   }
   function requireString(fn, name, value) {
     if (typeof value !== "string" || value.length === 0) {

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Services/AppServices.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Services/AppServices.swift
@@ -15,6 +15,7 @@ import Supabase
 final class AppServices {
     let client: SupabaseClient
     let songs: SongsRepository
+    let users: UserRepository
     let export: ExportService
     let bridge: CoreBridge?
     let bridgeErrorText: String?
@@ -26,6 +27,7 @@ final class AppServices {
         )
         self.client = client
         self.songs = SongsRepository(client: client)
+        self.users = UserRepository(client: client)
         self.export = ExportService(client: client, apiBaseURL: config.apiBaseURL)
 
         do {

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -17,14 +17,20 @@ monorepo's install graph. See [`js/README.md`](js/README.md) for the JS bridge a
 | 0 | `packages/core` transpose bundled into JavaScriptCore, called from Swift |
 | 1 | Auth (email/password), Song Library with search, Song Viewer rendering parsed ChordPro |
 | 2 | Design tokens generated into Swift; Viewer and Library brought to iOS/iPadOS parity |
+| 3 | Song creation, editing, publishing and deletion in a role-gated Manage section |
 
 Phase 2 covers the live view controls (transpose bar, key picker, capo hint, view
 options, two-column chart), favorites, server-rendered PDF/JPG export and Telegram
 push, and the library's filter & sort, result counts and lettered sections.
 
-Not built yet: setlists, admin/content management, song editing, GraceTracks,
-offline caching. Personal drafts (`personal_songs`, which mobile merges into its
-library) are not included — Studio shows the public catalog only.
+Phase 3 adds the editor: a plain-text ChordPro editor with a live preview that
+reuses the Viewer's own renderer, draft/published state on `public.songs`, hard
+delete, and the bridged ChordPro linter. See [Editing songs](#editing-songs).
+
+Not built yet: setlists, admin/content management beyond songs, GraceTracks,
+offline caching, ChordPro syntax highlighting. Personal drafts (`personal_songs`,
+which mobile merges into its library) are not included — Studio reads and writes
+the public catalog only.
 
 ## First-run setup
 
@@ -95,11 +101,13 @@ Config/StudioDefaults.swift    app-wide prefs (chord style, keep-awake, auto-hid
 Design/Theme.swift             SwiftUI layer over the generated tokens
 Design/DesignTokens.generated.swift  generated from packages/tokens — do not edit
 Services/AppServices.swift     one SupabaseClient, one SongsRepository, one CoreBridge
-Auth/AuthController.swift      session phase, Keychain-persisted via supabase-swift
+Auth/AuthController.swift      session phase + role, Keychain-persisted via supabase-swift
 Auth/SignInView.swift          email + password only
-Data/SongsRepository.swift     public.songs queries mirroring core's songsRepo.js
+Data/SongsRepository.swift     public.songs reads and writes, mirroring core's songsRepo.js
+Data/SongWritePayload.swift    insert/update column set + editor_audit_log row
+Data/UserRepository.swift      public.users.role, mirroring core's fetchUserRole
 Data/StarsRepository.swift     user_starred_songs (favorites)
-Data/SongModels.swift          row models (snake_case CodingKeys)
+Data/SongModels.swift          row models (snake_case CodingKeys), SongStatus
 Services/ExportService.swift   /api/export/song + /api/telegram/push
 Library/LibraryViewModel.swift fetch-once, search, tag filter, sort, selection
 Library/LibrarySort.swift      grouping/sorting, port of mobile's buildSections
@@ -117,7 +125,14 @@ Viewer/StarButton.swift        favorite toggle (optimistic)
 Viewer/ViewerPrefs.swift       per-song column mode
 Viewer/KeepScreenAwake.swift   display-sleep assertion, scoped to the view
 Viewer/FlowLayout.swift        wrapping row layout for chord-over-word cells
-Core/CoreBridge.swift          JSContext wrapper: transpose, parse, render, key helpers
+Manage/ManageSongsView.swift   editor+ section: drafts + published list, owns the editor
+Editor/SongForm.swift          form state + validation, mirrors core's songAuthoring.ts
+Editor/SongEditorModel.swift   debounced preview, lint, save / publish / delete
+Editor/SongEditorView.swift    metadata form, monospaced ChordPro editor, split preview
+Editor/LintWarningsView.swift  the advisory strip under the preview
+Core/CoreBridge.swift          JSContext wrapper: transpose, parse, render, key helpers,
+                               lint, hasMinRole, slugify
+Core/LintWarning.swift         one finding from core's lint.ts (warnings only)
 Core/ChordStyle.swift          ChordStyle, Accidental, Capo.fret
 Core/SongDoc.swift             Swift mirrors of chordpro/types.ts
 ContentView.swift              config gate → auth gate → split view
@@ -172,10 +187,143 @@ Two deliberate exceptions:
 ### Data access and RLS
 
 Reading the catalog does **not** require a session: `public.songs` carries
-`"Songs are publicly readable"` — `for select using (is_deleted = false)` with no
-role restriction (`supabase/migrations/20260305_songs_migration.sql`). The UI is
-still gated behind sign-in, matching mobile, but that means a library that loads
-while auth is broken indicates a config/network problem, not an auth one.
+`songs_select`, whose published branch has no role restriction
+(`supabase/migrations/20260728000100_songs_status.sql`). The UI is still gated
+behind sign-in, matching mobile, but that means a library that loads while auth is
+broken indicates a config/network problem, not an auth one.
+
+The policy is:
+
+```sql
+USING (is_deleted = false AND (status = 'published' OR public.has_min_role('editor')))
+```
+
+so anon and regular users get published songs, and editor+ additionally gets
+drafts. **Studio never filters on `status` client-side.** An editor's library
+legitimately contains drafts (badged `DRAFT`); everyone else's does not, because
+the policy decided that, not the query. Duplicating the rule in the client is how
+you end up with a filter that disagrees with the policy.
+
+Writes are editor+ via `songs_insert` / `songs_update` / `songs_delete`. The UI
+gate on the Manage section is a courtesy; the database is the enforcement, so a
+non-editor who reached the editor would get a rejected write rather than a
+successful one.
+
+> **Two migrations underpin this, and the first is a security fix.** Before
+> 2026-07-28 the live table had accumulated ten policies across three naming
+> generations, including `songs_select USING (true)`. Permissive policies are OR'd,
+> so that one overrode the others and made every row readable by anyone —
+> soft-deleted rows included. `is_deleted = false` was being enforced only by each
+> query's client-side `.eq()`. `20260728000000_songs_policy_consolidation.sql`
+> replaces all ten with one per command; `20260728000100_songs_status.sql` then adds
+> the column and the draft clause. Both have `.down.sql` counterparts.
+
+### Editing songs
+
+The **Manage** section appears only for editor+ (`packages/core`'s
+`canDirectWrite`), checked through the bridged `hasMinRole` rather than a Swift copy
+of the hierarchy. A role that cannot be read at all resolves to `user`, and a
+bridge that failed to load resolves the gate to `false` — both fail closed.
+
+It is a separate section rather than a mode on the Library/Viewer split for two
+concrete reasons: `SongViewerView` installs `.focusedSceneObject(export)` and owns
+the File ▸ Export menu plus its own toolbar, which an editor mode would contend
+with; and the two surfaces own different state — the Library owns "which song is
+selected for reading", the editor owns "does this song have unsaved changes".
+
+**The preview is always reachable.** Above 680pt of *detail-column* width (the writing
+pane's 360 plus the preview's 320) it sits beside the editor; below that the toolbar
+toggle swaps the two panes instead, opening on the editor — you open an editor to type
+in it. The first cut gated the split on 900pt measured on that same column which, with
+the sidebar taking 240–300 of the window, meant the preview never appeared at an
+ordinary window size. The threshold is now defined as the sum of the two panes'
+minimum widths so it cannot drift above what they actually need.
+
+**The preview is the Viewer's renderer.** `SongEditorModel` calls the same
+`CoreBridge.render` and hands the resulting `SongDoc` to the same `ChordChartView`.
+There is deliberately no editor-specific rendering path, so the preview cannot
+disagree with what a worshipper sees.
+
+**Re-parse is debounced 300 ms** (`SongEditorModel.previewDebounce`), trailing and
+restarted per keystroke, and skipped entirely when the debounced text matches what
+was last parsed. A fast typist's inter-key gap is ~120–150 ms, so a burst of typing
+collapses to one refresh at the end of it. The measured cost of a refresh —
+`renderToJSON` + `lintToJSON` + `JSONDecoder` into `SongDoc` — is **~1.4 ms** on the
+longest song in the live catalog (95 lines) and ~8 ms on one ten times that size, so
+the bridge is not the constraint; SwiftUI's chart layout is the rest. If it ever
+feels sluggish, lower that one constant rather than moving the work off the main
+thread, which would mean a second `JSContext` and a second copy of the parser.
+
+**Validation gates publishing, not saving.** Save needs only a title (`songs.title`
+is NOT NULL and the slug derives from it); Publish enforces core's full
+`validateSongForm` rule — title, key, ≥1 tag — so Studio and the web editor admit the
+same songs to the public catalog. The split exists because the live catalog does not
+satisfy its own create-time rule: **8 published songs have no tags and 5 have no key**,
+and gating Save on the full rule made all of them uneditable — an editor opening one
+to fix a typo would have had to invent a tag before Save would enable. A draft is
+allowed to be incomplete too; that is most of what makes it a draft. The Details
+header shows an amber "Missing details" rather than a red error, and Publish reports
+what is missing instead of being silently disabled.
+
+**Two lint codes are suppressed when the columns supply the value.**
+`warn:missing_title` and `warn:missing_key` are dropped while `title` /
+`default_key` are set (`SongEditorModel.applicable`). `lintChordPro` assumes a
+standalone `.chordpro` file where `{title}` and `{key}` in the body are the only place
+that metadata lives; here it lives in columns, and core's `canonicalizeForm` is
+explicit that it will not inject it into the body. Every one of the 206 songs in the
+catalog therefore tripped both — a panel that is wrong twice about every song is a
+panel nobody reads, and it buried the codes that matter
+(`warn:section_mismatch`, `warn:unknown_chord`). Filtered at the Studio boundary, not
+in core: the module is correct for the input it documents, `apps/web` has a test
+asserting exactly that output, and a row whose column *is* empty still gets the
+warning.
+
+**Typed tags snap to the catalog's spelling.** `songs.tags` is matched
+case-sensitively by the library filter and the web app's tag pages, and the live data
+is Title Case (`Slow`, `Praise`, `Worship`), so typing "worship" must not mint a
+second tag beside "Worship". `SongForm.addTag` reuses an existing tag when one matches
+case-insensitively and otherwise keeps what was typed; the ⋯ button beside the field
+lists the catalog's tags to pick from.
+
+**Saving never changes publication state.** `SongWritePayload` omits `status` on an
+update, so editing a published song and saving keeps it live — silently
+un-publishing on save would pull a song out of every worshipper's library because
+someone fixed a typo, and this design has no review step to put it back. Publication
+moves only via the explicit Publish / Unpublish actions.
+
+**A new song writes no row until the first save.** `songs.slug` is `UNIQUE NOT NULL`
+and core's `slugify` returns `''` for a title with no alphanumerics, so a row cannot
+exist before there is a title — and creating one on "New Song" would leave an empty
+row behind every abandoned attempt. The slug is derived once, on insert, and is
+**never** re-derived when the title changes: it is the song's public URL, and
+re-slugging would break every existing link to it (core's `upsertSong` makes the
+same choice).
+
+**Delete is a hard delete** — a real `DELETE`, not the `is_deleted = true` soft
+delete `apps/web` and `apps/mobile` perform. It therefore cascades:
+`setlist_songs.song_id` and `user_starred_songs.song_id` are both
+`ON DELETE CASCADE`, so the song leaves every personal and team setlist and every
+favourites list with it. The confirmation dialog names those consequences. An
+`editor_audit_log` row is written **before** the delete, because
+`editor_audit_log.song_id` is `ON DELETE SET NULL` — the row survives the cascade
+carrying `song_slug` and `song_title` text, and is the only remaining trace.
+
+**Lint is advisory and never blocks a save.** Every code
+`packages/core/src/chordpro/lint.ts` emits is prefixed `warn:` and the module has no
+severity field, so there is nothing to present as an error. A body the *parser*
+rejects is a separate failure and appears in the preview pane, above the last
+successfully rendered chart rather than replacing it — mid-edit a body is
+transiently unparseable (a half-typed `{start_of_`), and blanking the pane on those
+keystrokes would make the preview unusable.
+
+**Syntax highlighting is not implemented.** SwiftUI's `TextEditor` cannot style
+ranges, so it needs `NSViewRepresentable` over `NSTextView` with a custom
+`NSTextStorage` — which brings attribute runs fighting the undo manager, IME
+marked-text ranges, and re-highlight cost on a long song. That is a self-contained
+piece of work orthogonal to whether saving and publishing are correct, so the editor
+ships monospaced and unhighlighted. Clicking a lint warning to jump to its line
+waits on the same change, and `LintWarning.lineIndex` is inconsistent besides
+(section-relative for most codes, body-relative for `warn:section_mismatch`).
 
 ### Search
 

--- a/apps/studio/js/README.md
+++ b/apps/studio/js/README.md
@@ -9,7 +9,7 @@ JavaScriptCore `JSContext`.
 
 | File | Role |
 |------|------|
-| `entry.mjs` | Bridge entry. Imports core **subpaths** (never the barrel), validates arguments, exports `transpose` and `parseToJSON`. |
+| `entry.mjs` | Bridge entry. Imports core **subpaths** (never the barrel), validates arguments, exports the functions in the table below. |
 | `build-core-bundle.mjs` | esbuild build → `GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js` |
 | `verify-bundle.mjs` | Parity harness: bundle vs. the core modules `apps/mobile` resolves. |
 
@@ -19,6 +19,28 @@ Exposed to Swift:
 |----|-------|---------------|
 | `GraceChordsCore.transpose(sym, steps, preferFlat)` | `CoreBridge.transpose(_:steps:preferFlat:)` | `chordpro/index.js` → `transposeSymPrefer` |
 | `GraceChordsCore.parseToJSON(text)` | `CoreBridge.parse(_:) -> SongDoc` | `chordpro/parser.ts` → `parseChordProOrLegacy` |
+| `GraceChordsCore.renderToJSON(text, steps, preferFlat, style)` | `CoreBridge.render(_:steps:preferFlat:style:)` | composition of the above + `songs/instrumental.js` |
+| `GraceChordsCore.stepsBetween(from, to)` | `CoreBridge.stepsBetween(from:to:)` | `chordpro/index.js` → `stepsBetween` |
+| `GraceChordsCore.formatKey(key, style)` | `CoreBridge.formatKey(_:style:)` | `chordpro/solfege.js` → `formatKeyDisplay` |
+| `GraceChordsCore.lintToJSON(text)` | `CoreBridge.lint(_:) -> [LintWarning]` | `chordpro/lint.ts` → `lintChordPro` |
+| `GraceChordsCore.hasMinRole(role, min)` | `CoreBridge.hasMinRole(_:atLeast:)` | `rbac/roles.js` → `hasMinRole` |
+| `GraceChordsCore.roleOrderJSON()` | *(parity harness only)* | `rbac/roles.js` → `ROLE_ORDER` |
+| `GraceChordsCore.slugify(title)` | `CoreBridge.slugify(_:)` | `songs/slug.ts` → `slugify` |
+
+Adding `lint.ts` and `slug.ts` cost the bundle nothing transitively: `lint.ts`'s only
+runtime import is `./parser`, which was already bundled, and `slug.ts` imports
+nothing. `rbac/roles.js` likewise. The build script prints its module list — eight
+files as of Phase 3 — so a dependency creeping in is visible on every rebuild.
+
+`hasMinRole` and `slugify` are bridged rather than ported for the same reason as the
+parser: both have outputs that must match another client exactly. A Swift copy of
+`ROLE_ORDER` is precisely the thing that outlives a hierarchy change unnoticed
+(`collaborator` was removed from it in 2026-07), and a Swift slug regex that differed
+from core's by one character class would mint URLs no other client produces.
+
+`lintChordPro` returns **warnings only** — every code is prefixed `warn:` and there is
+no severity field. Studio was its first consumer; before Phase 3 the function was
+referenced by one web test and no UI.
 
 `parseToJSON` returns the whole `SongDoc` as a JSON string so Swift decodes it in
 one `JSONDecoder` step instead of walking a `JSValue` tree; the Swift mirrors of
@@ -109,6 +131,22 @@ themselves:
   source through `esbuild.transform` — the same erasure Metro and Vite perform.
   Comparison is the full `SongDoc` as JSON, over 12 hand-written cases plus the six
   real fixtures in `apps/web/src/__tests__/fixtures/chordpro/` (read-only).
+- **lint:** against `chordpro/lint.ts`. Same problem as the parser plus a real
+  extensionless runtime import, so the reference goes through `esbuild.build`
+  (bundling, not just transforming). Comparison is the full `LintWarning[]` as JSON
+  over the parser corpus plus 12 cases written to trip each warning code, and every
+  returned warning is checked for the exact key set `Core/LintWarning.swift` decodes
+  — an added key would otherwise be silently dropped on the Swift side.
+- **lint independence:** lint must return an array for every body the corpus
+  contains, including ones the parser rejects. The editor shows warnings for exactly
+  the bodies most worth reading them on, so lint must not fail alongside the parse.
+- **hasMinRole:** the full role × minimum matrix against `rbac/roles.js`, including
+  roles no longer in the hierarchy (`collaborator`) and the empty string, plus a
+  hardcoded assertion that only editor/admin/owner clear the editor+ gate — so a
+  hierarchy change that promoted `user` fails here rather than in the app.
+- **slugify:** against `songs/slug.ts` over 16 titles including non-ASCII and
+  punctuation-only, plus the contract Swift depends on — an unslugifiable title must
+  return `''` so the caller refuses the insert rather than writing an empty `slug`.
 
 ## Adding another core function later
 

--- a/apps/studio/js/entry.mjs
+++ b/apps/studio/js/entry.mjs
@@ -7,7 +7,10 @@
 import { stepsBetween as coreStepsBetween, transposeSymPrefer } from '@gracechords/core/chordpro/index.js'
 import { formatChord, formatKeyDisplay } from '@gracechords/core/chordpro/solfege.js'
 import { parseChordProOrLegacy } from '@gracechords/core/chordpro/parser.ts'
+import { lintChordPro } from '@gracechords/core/chordpro/lint.ts'
 import { transposeInstrumental } from '@gracechords/core/songs/instrumental.js'
+import { hasMinRole as coreHasMinRole, ROLE_ORDER } from '@gracechords/core/rbac/roles.js'
+import { slugify as coreSlugify } from '@gracechords/core/songs/slug.ts'
 
 const STYLES = ['letters', 'solfege']
 
@@ -145,6 +148,85 @@ export function renderToJSON(chordpro, steps, preferFlat, style) {
     }
   }
   return JSON.stringify(doc)
+}
+
+/**
+ * Lint a ChordPro body through `packages/core`'s `lintChordPro`, returned as a
+ * JSON array string.
+ *
+ * Warnings only — every code core emits is `warn:*` and there is no severity
+ * field, because the module is advisory: it flags a missing {key}, an empty
+ * section, an over-long lyric line, a suspicious chord symbol, and unbalanced
+ * {start_of_*}/{end_of_*} pairs. A body the parser cannot handle at all is a
+ * different mechanism entirely — `parseToJSON` throws, and the caller falls back
+ * to raw text — so the editor surfaces the two separately rather than pretending
+ * lint returns errors.
+ *
+ * The string overload is passed through deliberately: core only runs its
+ * unbalanced-directive scan when given raw text, so linting the editor's buffer
+ * catches strictly more than linting an already-parsed document would.
+ *
+ * @param {string} chordpro
+ * @returns {string} JSON-encoded LintWarning[] (see packages/core/src/chordpro/lint.ts)
+ */
+export function lintToJSON(chordpro) {
+  if (typeof chordpro !== 'string') {
+    throw new TypeError(`lintToJSON: chordpro must be a string, got ${describe(chordpro)}`)
+  }
+  return JSON.stringify(lintChordPro(chordpro))
+}
+
+/**
+ * Role-hierarchy check through `packages/core`'s `hasMinRole`.
+ *
+ * Bridged rather than ported to Swift because AGENTS.md makes rbac/roles.js the
+ * single source of truth for gate checks, and a hand-written Swift copy of
+ * ROLE_ORDER is exactly the kind of thing that silently outlives a hierarchy
+ * change — `collaborator` was removed from this list in 2026-07 and the root
+ * AGENTS.md table still has not caught up.
+ *
+ * Core's own tolerance is preserved: an unknown or empty `userRole` is treated as
+ * 'user' rather than rejected, so the caller can ask before the role has loaded.
+ * An unknown `minRole` returns false.
+ *
+ * @param {string} userRole
+ * @param {string} minRole  one of ROLE_ORDER
+ * @returns {boolean}
+ */
+export function hasMinRole(userRole, minRole) {
+  if (typeof userRole !== 'string') {
+    throw new TypeError(`hasMinRole: userRole must be a string, got ${describe(userRole)}`)
+  }
+  requireString('hasMinRole', 'minRole', minRole)
+  return coreHasMinRole(userRole, minRole)
+}
+
+/** The role hierarchy, lowest privilege first, as a JSON array string. */
+export function roleOrderJSON() {
+  return JSON.stringify(ROLE_ORDER)
+}
+
+/**
+ * Title → URL-safe slug through `packages/core`'s `slugify`.
+ *
+ * Bridged rather than reimplemented because the slug is the song's public URL on
+ * gracechords.com: a Swift regex that differed from core's by one character class
+ * would mint Studio-shaped slugs that no other client produces, and the drift
+ * would only show up as a wrong link. Returns '' for a title with no
+ * alphanumerics, which is core's signal that no slug can be derived — the caller
+ * must not write a row in that case (`songs.slug` is UNIQUE NOT NULL).
+ *
+ * Collision resolution stays on the Swift side: core's `deriveUniqueSlug` needs a
+ * Supabase client to probe the table, and this context has no network.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+export function slugify(title) {
+  if (typeof title !== 'string') {
+    throw new TypeError(`slugify: title must be a string, got ${describe(title)}`)
+  }
+  return coreSlugify(title)
 }
 
 function requireString(fn, name, value) {

--- a/apps/studio/js/verify-bundle.mjs
+++ b/apps/studio/js/verify-bundle.mjs
@@ -14,6 +14,8 @@ import vm from 'node:vm'
 
 import { stepsBetween as refStepsBetween, transposeSymPrefer } from '@gracechords/core/chordpro/index.js'
 import { formatChord as refFormatChord, formatKeyDisplay as refFormatKeyDisplay } from '@gracechords/core/chordpro/solfege.js'
+// rbac/roles.js is plain .js with no imports, so Node's loader resolves it directly.
+import { hasMinRole as refHasMinRole, ROLE_ORDER as REF_ROLE_ORDER } from '@gracechords/core/rbac/roles.js'
 
 // parser.ts cannot be imported by Node's ESM loader: it carries a type-only
 // import written as a value import (`import { SongDoc } from './types'`), which
@@ -63,6 +65,43 @@ async function loadReferenceInstrumental() {
 }
 const { transposeInstrumental: refTransposeInstrumental } = await loadReferenceInstrumental()
 
+// chordpro/lint.ts has both problems at once: it is TypeScript, and it carries a
+// real runtime import of './parser' written extensionless. Node's loader resolves
+// neither, so the reference copy goes through esbuild's bundler — the same
+// treatment loadReferenceInstrumental gives, and the same resolution Metro and
+// Vite apply to this file in the apps.
+async function loadReferenceLint() {
+  const esbuild = await import('esbuild')
+  const entry = fileURLToPath(import.meta.resolve('@gracechords/core/chordpro/lint.ts'))
+  const built = await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    format: 'esm',
+    platform: 'neutral',
+    loader: { '.ts': 'ts' },
+    resolveExtensions: ['.ts', '.js', '.mjs', '.json'],
+  })
+  const dataURL = `data:text/javascript;base64,${Buffer.from(built.outputFiles[0].text).toString('base64')}`
+  return { module: await import(dataURL), sourcePath: entry }
+}
+const { module: refLintModule, sourcePath: lintSourcePath } = await loadReferenceLint()
+const refLintChordPro = refLintModule.lintChordPro
+
+// songs/slug.ts is TypeScript but imports nothing, so a bare transform is enough
+// — no bundling needed, unlike lint.ts and instrumental.js.
+async function loadReferenceSlug() {
+  const esbuild = await import('esbuild')
+  const sourcePath = fileURLToPath(import.meta.resolve('@gracechords/core/songs/slug.ts'))
+  const { code } = await esbuild.transform(await readFile(sourcePath, 'utf8'), {
+    loader: 'ts',
+    format: 'esm',
+  })
+  const dataURL = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
+  return import(dataURL)
+}
+const { slugify: refSlugify } = await loadReferenceSlug()
+
 const here = dirname(fileURLToPath(import.meta.url))
 const bundlePath = resolve(here, '../GraceChords Studio/GraceChords Studio/Resources/GraceChordsCore.js')
 // Real songs the web app's parser tests already cover — read-only.
@@ -104,13 +143,26 @@ if (!namespace) {
   console.log('FAIL  bundle did not define a GraceChordsCore global')
   process.exit(1)
 }
-for (const exported of ['transpose', 'parseToJSON', 'stepsBetween', 'formatKey', 'renderToJSON']) {
+const REQUIRED_EXPORTS = [
+  'transpose',
+  'parseToJSON',
+  'stepsBetween',
+  'formatKey',
+  'renderToJSON',
+  'lintToJSON',
+  'hasMinRole',
+  'roleOrderJSON',
+  'slugify',
+]
+for (const exported of REQUIRED_EXPORTS) {
   if (typeof namespace[exported] !== 'function') {
     console.log(`FAIL  GraceChordsCore.${exported} is not a function`)
     process.exit(1)
   }
 }
-console.log('PASS  bundle evaluated in a bare context; all five exports are callable\n')
+console.log(
+  `PASS  bundle evaluated in a bare context; all ${REQUIRED_EXPORTS.length} exports are callable\n`,
+)
 
 console.log('sym         steps  flat   bundle   mobile   expected')
 console.log('----------------------------------------------------')
@@ -322,6 +374,216 @@ for (const [label, input] of PARSE_CASES) {
   }
 }
 console.log(`PASS  identity case: renderToJSON(0, false, 'letters') matches parseToJSON`)
+
+// ── lint parity ──────────────────────────────────────────────────────────────
+// Whole-array structural equality over the same corpus the parser cases use, plus
+// bodies written specifically to trip each warning code. Both sides run the same
+// code path, so JSON key order matches and string comparison is a deep compare.
+const LINT_CASES = [
+  ...PARSE_CASES,
+  ['lint: missing title and key', 'Verse 1\n[G]Amazing [C]grace'],
+  ['lint: empty section', '{title: T}\n{key: G}\n{soc}\n{eoc}'],
+  ['lint: stray end_of', '{title: T}\n{key: G}\nVerse\n[G]Line\n{end_of_chorus}'],
+  ['lint: unclosed start_of', '{title: T}\n{key: G}\n{start_of_verse}\n[G]Line'],
+  ['lint: mismatched pair', '{start_of_verse}\n[G]Line\n{end_of_chorus}'],
+  ['lint: suspicious chords', '{title: T}\n{key: G}\nVerse\n[H7]Line [Xyz]more [G]ok'],
+  ['lint: long lyric line', `{title: T}\n{key: G}\nVerse\n[G]${'la '.repeat(40)}`],
+  ['lint: adjacent duplicate headers', '{title: T}\n{key: G}\nChorus\n[G]One\nChorus\n[C]Two'],
+  ['lint: nested unbalanced', '{start_of_verse}\n{start_of_chorus}\n[G]Line\n{end_of_verse}'],
+  ['lint: unterminated chord bracket', '{title: T}\n{key: G}\nVerse\n[G]Fine [Cunclosed lyric'],
+  ['lint: only directives', '{title: T}\n{key: G}'],
+  ['lint: whitespace-only body', '   \n\t\n   '],
+]
+
+console.log(`\nlint parity (full LintWarning[], bundle vs. ${relative(process.cwd(), lintSourcePath)}):`)
+for (const [label, input] of LINT_CASES) {
+  let bundled
+  try {
+    bundled = namespace.lintToJSON(input)
+  } catch (err) {
+    fail(`${label}: lintToJSON threw — ${err.message}`)
+    continue
+  }
+  const expected = JSON.stringify(refLintChordPro(input))
+  if (bundled === expected) {
+    const codes = JSON.parse(bundled).map((w) => w.code)
+    const summary = codes.length ? `${codes.length}: ${[...new Set(codes)].join(', ')}` : 'clean'
+    console.log(`PASS  ${label.padEnd(42)} ${summary}`)
+  } else {
+    fail(`${label}: warnings differ\n      bundle:   ${bundled}\n      expected: ${expected}`)
+  }
+}
+
+// Every warning must carry the fields Swift's LintWarning decodes, or the editor
+// would silently drop rows it could not decode.
+console.log('\nlint warning shape (code + message present, indices numeric when present):')
+{
+  let shapeFailures = 0
+  let inspected = 0
+  for (const [label, input] of LINT_CASES) {
+    for (const warning of JSON.parse(namespace.lintToJSON(input))) {
+      inspected += 1
+      const keys = Object.keys(warning)
+      const unexpected = keys.filter((k) => !['code', 'message', 'sectionIndex', 'lineIndex'].includes(k))
+      if (typeof warning.code !== 'string' || !warning.code) {
+        fail(`${label}: warning has no code — ${JSON.stringify(warning)}`); shapeFailures += 1
+      } else if (typeof warning.message !== 'string' || !warning.message) {
+        fail(`${label}: warning has no message — ${JSON.stringify(warning)}`); shapeFailures += 1
+      } else if (unexpected.length) {
+        fail(`${label}: warning has unexpected key(s) ${unexpected.join(', ')} — Swift's LintWarning would ignore them`)
+        shapeFailures += 1
+      } else if (
+        ('sectionIndex' in warning && !Number.isInteger(warning.sectionIndex)) ||
+        ('lineIndex' in warning && !Number.isInteger(warning.lineIndex))
+      ) {
+        fail(`${label}: non-integer index — ${JSON.stringify(warning)}`); shapeFailures += 1
+      }
+    }
+  }
+  if (shapeFailures === 0) console.log(`PASS  ${inspected} warning(s) across ${LINT_CASES.length} case(s) all well-formed`)
+}
+
+// A body that makes the PARSER throw is a separate failure mode from a lint
+// warning, and the editor presents them differently. Nothing in the corpus should
+// throw — if a future parser change makes one throw, the editor's preview must
+// still hold, so it is worth knowing which case it was.
+console.log('\nparse-vs-lint independence (lint must not throw on anything the parser accepts):')
+{
+  let independenceFailures = 0
+  for (const [label, input] of LINT_CASES) {
+    let parseThrew = false
+    try { namespace.parseToJSON(input) } catch { parseThrew = true }
+    try {
+      namespace.lintToJSON(input)
+    } catch (err) {
+      fail(`${label}: parser ${parseThrew ? 'also threw' : 'accepted this body'} but lint threw — ${err.message}`)
+      independenceFailures += 1
+    }
+  }
+  if (independenceFailures === 0) console.log(`PASS  lint returned an array for all ${LINT_CASES.length} case(s)`)
+}
+
+console.log('\nlintToJSON error paths:')
+for (const [label, value] of [
+  ['null input', null],
+  ['missing input', undefined],
+  ['number input', 42],
+  ['array input', []],
+]) {
+  try {
+    namespace.lintToJSON(value)
+    fail(`${label}: returned instead of throwing`)
+  } catch (err) {
+    console.log(`PASS  ${label} → ${err.constructor.name}: ${err.message}`)
+  }
+}
+
+// ── rbac parity ──────────────────────────────────────────────────────────────
+// The full matrix, not a spot check: this is the gate that decides whether the
+// Manage section appears at all, so every cell is compared against core.
+console.log('\nhasMinRole parity (bundle vs. rbac/roles.js), full matrix:')
+{
+  const bundledOrder = JSON.parse(namespace.roleOrderJSON())
+  if (JSON.stringify(bundledOrder) !== JSON.stringify(REF_ROLE_ORDER)) {
+    fail(`roleOrderJSON differs: bundle ${JSON.stringify(bundledOrder)} vs core ${JSON.stringify(REF_ROLE_ORDER)}`)
+  } else {
+    console.log(`PASS  ROLE_ORDER matches core: ${bundledOrder.join(' → ')}`)
+  }
+  // Roles the hierarchy no longer contains must not quietly grant anything.
+  const probeRoles = [...REF_ROLE_ORDER, 'collaborator', 'nonsense', '']
+  let matrixFailures = 0
+  for (const userRole of probeRoles) {
+    const row = []
+    for (const minRole of REF_ROLE_ORDER) {
+      const bundled = namespace.hasMinRole(userRole, minRole)
+      const expected = refHasMinRole(userRole, minRole)
+      if (bundled !== expected) {
+        fail(`hasMinRole('${userRole}', '${minRole}') → ${bundled}, core says ${expected}`)
+        matrixFailures += 1
+      }
+      row.push(`${minRole}:${bundled ? 'Y' : 'n'}`)
+    }
+    console.log(`      ${(userRole || "''").padEnd(14)} ${row.join('  ')}`)
+  }
+  if (matrixFailures === 0) {
+    console.log(`PASS  ${probeRoles.length * REF_ROLE_ORDER.length} hasMinRole comparisons match core`)
+  }
+  // The gate Studio actually uses. Hardcoded expectations so a hierarchy change
+  // that silently promotes 'user' to editor fails here rather than in the app.
+  for (const [role, expected] of [['user', false], ['editor', true], ['admin', true], ['owner', true], ['collaborator', false], ['', false]]) {
+    const got = namespace.hasMinRole(role, 'editor')
+    if (got !== expected) fail(`canDirectWrite gate: hasMinRole('${role}', 'editor') → ${got}, expected ${expected}`)
+  }
+  console.log(`PASS  editor+ gate: only editor/admin/owner pass`)
+}
+
+console.log('\nhasMinRole error paths:')
+for (const [label, args] of [
+  ['null userRole', [null, 'editor']],
+  ['number userRole', [3, 'editor']],
+  ['empty minRole', ['owner', '']],
+  ['null minRole', ['owner', null]],
+  ['missing minRole', ['owner', undefined]],
+]) {
+  try {
+    const value = namespace.hasMinRole(...args)
+    fail(`${label}: returned ${JSON.stringify(value)} instead of throwing`)
+  } catch (err) {
+    console.log(`PASS  ${label} → ${err.constructor.name}: ${err.message}`)
+  }
+}
+
+// ── slugify parity ───────────────────────────────────────────────────────────
+// The slug becomes the song's public URL, so a divergence here is a broken link
+// on gracechords.com rather than a cosmetic difference.
+console.log('\nslugify parity (bundle vs. songs/slug.ts):')
+{
+  const titles = [
+    'Amazing Grace',
+    '10,000 Reasons (Bless the Lord)',
+    "It Is Well With My Soul",
+    'Holy, Holy, Holy!',
+    '  leading and trailing  ',
+    'Multiple   Spaces',
+    'Hyphen-ated Title',
+    'Ya Rabbi Yasu',
+    'Türkçe Şarkı',           // non-ASCII: every letter is stripped
+    '日本語',                   // fully non-ASCII → '' (no slug derivable)
+    '!!!',                     // punctuation only → ''
+    '',
+    'Song 2',
+    'A',
+    'under_scores_already',
+    'Trailing punctuation...',
+  ]
+  for (const title of titles) {
+    const bundled = namespace.slugify(title)
+    const expected = refSlugify(title)
+    const ok = bundled === expected
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${JSON.stringify(title).padEnd(36)} → ${JSON.stringify(bundled)}`)
+    if (!ok) {
+      fail(`slugify(${JSON.stringify(title)}) → ${JSON.stringify(bundled)}, core says ${JSON.stringify(expected)}`)
+    }
+  }
+  // The contract Swift depends on before writing a row: no alphanumerics means no
+  // slug, and songs.slug is UNIQUE NOT NULL, so the caller must refuse to insert.
+  for (const title of ['', '!!!', '日本語', '   ']) {
+    if (namespace.slugify(title) !== '') {
+      fail(`slugify(${JSON.stringify(title)}) should be '' so callers can refuse the write`)
+    }
+  }
+  console.log(`PASS  unslugifiable titles all yield '' (the "refuse to insert" signal)`)
+}
+
+console.log('\nslugify error paths:')
+for (const [label, value] of [['null title', null], ['number title', 7], ['missing title', undefined]]) {
+  try {
+    const value_ = namespace.slugify(value)
+    fail(`${label}: returned ${JSON.stringify(value_)} instead of throwing`)
+  } catch (err) {
+    console.log(`PASS  ${label} → ${err.constructor.name}: ${err.message}`)
+  }
+}
 
 console.log('\nviewer-helper error paths:')
 const viewerBadArgs = [

--- a/supabase/migrations/20260728000000_songs_policy_consolidation.down.sql
+++ b/supabase/migrations/20260728000000_songs_policy_consolidation.down.sql
@@ -1,0 +1,84 @@
+-- =============================================================================
+-- DOWN migration for 20260728000000_songs_policy_consolidation.sql
+--
+-- Restores all ten pre-consolidation policies verbatim, as captured from
+-- pg_policies on 2026-07-28.
+--
+-- WARNING — this reopens a real hole. `songs_select USING (true)` is permissive
+-- and OR's with everything else, so restoring it makes every row in public.songs
+-- readable by anyone, including rows with is_deleted = true. Only run this if you
+-- are reverting the whole change set; do not leave the database in this state.
+--
+-- Apply 20260728000100_songs_status.down.sql FIRST if that migration is also
+-- applied — it rewrites songs_select, and this file recreates it.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop the consolidated policies
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "songs_select" ON public.songs;
+DROP POLICY IF EXISTS "songs_insert" ON public.songs;
+DROP POLICY IF EXISTS "songs_update" ON public.songs;
+DROP POLICY IF EXISTS "songs_delete" ON public.songs;
+
+-- ---------------------------------------------------------------------------
+-- 2. Restore the original ten
+-- ---------------------------------------------------------------------------
+
+-- SELECT (three overlapping policies; the first makes the other two moot)
+CREATE POLICY "songs_select"
+  ON public.songs FOR SELECT
+  USING (true);
+
+CREATE POLICY "Songs are publicly readable"
+  ON public.songs FOR SELECT
+  USING (is_deleted = false);
+
+CREATE POLICY "Authenticated users can read songs"
+  ON public.songs FOR SELECT
+  USING (auth.uid() IS NOT NULL AND is_deleted = false);
+
+-- INSERT (duplicate pair)
+CREATE POLICY "songs_insert"
+  ON public.songs FOR INSERT
+  WITH CHECK (public.has_min_role('editor'));
+
+CREATE POLICY "Admins and editors can insert songs"
+  ON public.songs FOR INSERT
+  WITH CHECK (public.has_min_role('editor'));
+
+-- UPDATE (duplicate pair; neither carried a WITH CHECK, so Postgres reuses USING)
+CREATE POLICY "songs_update"
+  ON public.songs FOR UPDATE
+  USING (public.has_min_role('editor'));
+
+CREATE POLICY "Admins and editors can update songs"
+  ON public.songs FOR UPDATE
+  USING (public.has_min_role('editor'));
+
+-- DELETE (admin+ and editor+ OR'd together, i.e. effectively editor+)
+CREATE POLICY "songs_delete"
+  ON public.songs FOR DELETE
+  USING (public.has_min_role('admin'));
+
+CREATE POLICY "Admins and editors can delete songs"
+  ON public.songs FOR DELETE
+  USING (public.has_min_role('editor'));
+
+-- cmd=ALL, with the inline users lookup rather than has_min_role()
+CREATE POLICY "songs_write_editor"
+  ON public.songs FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users u
+      WHERE u.id = auth.uid()
+        AND u.role = ANY (ARRAY['editor'::text, 'admin'::text, 'owner'::text])
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.users u
+      WHERE u.id = auth.uid()
+        AND u.role = ANY (ARRAY['editor'::text, 'admin'::text, 'owner'::text])
+    )
+  );

--- a/supabase/migrations/20260728000000_songs_policy_consolidation.sql
+++ b/supabase/migrations/20260728000000_songs_policy_consolidation.sql
@@ -1,0 +1,90 @@
+-- =============================================================================
+-- GraceChords: consolidate public.songs RLS policies (2026-07-28)
+--
+-- The live songs table had accumulated TEN policies across three naming
+-- generations. Because permissive policies are OR'd together, the duplicates
+-- were not merely untidy: `songs_select USING (true)` overrode both other SELECT
+-- policies, so every row was readable by anyone — anon included — INCLUDING rows
+-- with is_deleted = true. The `is_deleted = false` guarantee the apps depend on
+-- was being enforced only by the client-side .eq() in each query, never by RLS.
+--
+-- This migration replaces all ten with exactly one policy per command. Semantics
+-- are otherwise preserved: public SELECT of non-deleted rows, editor+
+-- INSERT/UPDATE/DELETE. The draft/published visibility rule is deliberately NOT
+-- here — it lands in 20260728000100_songs_status.sql — so this file can be
+-- reviewed as the security fix it is.
+--
+-- Effective DELETE was ALREADY editor+, not admin+: songs_delete's admin+ check
+-- was OR'd with two editor+ grants ("Admins and editors can delete songs" and
+-- the cmd=ALL songs_write_editor). This migration makes that explicit rather
+-- than changing who can delete.
+--
+-- Superseded policies, verbatim from pg_policies (the down migration restores
+-- them exactly):
+--   songs_select                          SELECT  USING (true)
+--   "Songs are publicly readable"         SELECT  USING (is_deleted = false)
+--   "Authenticated users can read songs"  SELECT  USING (auth.uid() IS NOT NULL AND is_deleted = false)
+--   songs_insert                          INSERT  WITH CHECK (has_min_role('editor'))
+--   "Admins and editors can insert songs" INSERT  WITH CHECK (has_min_role('editor'))
+--   songs_update                          UPDATE  USING (has_min_role('editor'))
+--   "Admins and editors can update songs" UPDATE  USING (has_min_role('editor'))
+--   songs_delete                          DELETE  USING (has_min_role('admin'))
+--   "Admins and editors can delete songs" DELETE  USING (has_min_role('editor'))
+--   songs_write_editor                    ALL     USING + WITH CHECK
+--       (EXISTS (SELECT 1 FROM users u
+--                WHERE u.id = auth.uid()
+--                  AND u.role = ANY (ARRAY['editor','admin','owner'])))
+--
+-- The inline `EXISTS (SELECT ... FROM users)` form in songs_write_editor is
+-- replaced by public.has_min_role(), for the reason 20260522000000 gives: an
+-- inlined role list has to be found and edited every time the hierarchy changes,
+-- and one of these already drifted (users.global_role → users.role).
+-- =============================================================================
+
+ALTER TABLE public.songs ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop every existing policy on public.songs
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "songs_select"                         ON public.songs;
+DROP POLICY IF EXISTS "Songs are publicly readable"          ON public.songs;
+DROP POLICY IF EXISTS "Authenticated users can read songs"   ON public.songs;
+DROP POLICY IF EXISTS "songs_insert"                         ON public.songs;
+DROP POLICY IF EXISTS "Admins and editors can insert songs"  ON public.songs;
+DROP POLICY IF EXISTS "songs_update"                         ON public.songs;
+DROP POLICY IF EXISTS "Admins and editors can update songs"  ON public.songs;
+DROP POLICY IF EXISTS "songs_delete"                         ON public.songs;
+DROP POLICY IF EXISTS "Admins and editors can delete songs"  ON public.songs;
+DROP POLICY IF EXISTS "songs_write_editor"                   ON public.songs;
+
+-- ---------------------------------------------------------------------------
+-- 2. One canonical policy per command
+-- ---------------------------------------------------------------------------
+
+-- Public read, matching the original intent of "Songs are publicly readable":
+-- the catalog is browsable without a session (apps/web serves public song pages,
+-- and Studio's SongsRepository documents reads as session-free). Soft-deleted
+-- rows are now genuinely excluded by RLS, not just by the client's filter.
+CREATE POLICY "songs_select"
+  ON public.songs FOR SELECT
+  USING (is_deleted = false);
+
+-- Writes are editor+ (packages/core's canDirectWrite). Scoped TO authenticated:
+-- has_min_role('editor') already returns false for anon (get_user_role() is NULL
+-- with no auth.uid(), which falls through to ELSE false), so this changes no
+-- behaviour — it just stops the policy from being evaluated for anon at all.
+CREATE POLICY "songs_insert"
+  ON public.songs FOR INSERT
+  TO authenticated
+  WITH CHECK (public.has_min_role('editor'));
+
+CREATE POLICY "songs_update"
+  ON public.songs FOR UPDATE
+  TO authenticated
+  USING (public.has_min_role('editor'))
+  WITH CHECK (public.has_min_role('editor'));
+
+CREATE POLICY "songs_delete"
+  ON public.songs FOR DELETE
+  TO authenticated
+  USING (public.has_min_role('editor'));

--- a/supabase/migrations/20260728000100_songs_status.down.sql
+++ b/supabase/migrations/20260728000100_songs_status.down.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- DOWN migration for 20260728000100_songs_status.sql
+--
+-- Reverts the schema cleanly: the status column, its constraint, its index, and
+-- the draft clause in songs_select all go away, leaving the table exactly as
+-- 20260728000000_songs_policy_consolidation.sql left it.
+--
+-- WARNING — this is schema-clean but NOT data-lossless. Dropping the column
+-- discards which songs were drafts, and because the restored policy no longer
+-- filters on status, every former draft becomes immediately visible to everyone
+-- including anon. If you are reverting only to change the editor UI and want to
+-- keep draft state, run just the DROP POLICY / CREATE POLICY block below and
+-- leave the column in place — an unused status column is harmless.
+--
+-- Run this BEFORE 20260728000000_songs_policy_consolidation.down.sql, since that
+-- file recreates songs_select from scratch.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Restore the consolidated SELECT policy (no status clause)
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "songs_select" ON public.songs;
+
+CREATE POLICY "songs_select"
+  ON public.songs FOR SELECT
+  USING (is_deleted = false);
+
+-- ---------------------------------------------------------------------------
+-- 2. Remove the column, its constraint and its index
+-- ---------------------------------------------------------------------------
+DROP INDEX IF EXISTS public.songs_status_idx;
+
+ALTER TABLE public.songs DROP CONSTRAINT IF EXISTS songs_status_check;
+
+ALTER TABLE public.songs DROP COLUMN IF EXISTS status;

--- a/supabase/migrations/20260728000100_songs_status.sql
+++ b/supabase/migrations/20260728000100_songs_status.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- GraceChords: draft/published status on public.songs (2026-07-28)
+--
+-- Adds the lifecycle column GraceChords Studio's editor needs, and teaches the
+-- SELECT policy to hide drafts from everyone below editor.
+--
+-- Requires 20260728000000_songs_policy_consolidation.sql to be applied first.
+-- Before that consolidation this migration would have been a NO-OP: the live
+-- table carried `songs_select USING (true)`, and because permissive policies are
+-- OR'd, that policy alone would have kept handing every draft to every anonymous
+-- visitor no matter what clause was added here.
+--
+-- Two states only — 'draft' and 'published'. public.personal_songs.status has
+-- four ('draft','submitted','published','archived') because it participates in
+-- the submission/review queue; this column deliberately does not.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. The column
+-- ---------------------------------------------------------------------------
+-- DEFAULT 'published' is load-bearing, not a stylistic choice. Every row that
+-- exists today is live content. With DEFAULT 'draft' the entire catalog would
+-- vanish from web, mobile and Studio the moment the policy below is created.
+-- NOT NULL + DEFAULT 'published' backfills every existing row correctly in the
+-- same statement, so no separate UPDATE is needed. New drafts set it explicitly.
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'published';
+
+-- Added separately so re-running the migration on a table that already has the
+-- column still installs the constraint.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.songs'::regclass
+      AND conname  = 'songs_status_check'
+  ) THEN
+    ALTER TABLE public.songs
+      ADD CONSTRAINT songs_status_check CHECK (status IN ('draft', 'published'));
+  END IF;
+END $$;
+
+-- The SELECT policy filters on status for every catalog query, including anon's.
+CREATE INDEX IF NOT EXISTS songs_status_idx ON public.songs (status);
+
+-- ---------------------------------------------------------------------------
+-- 2. Draft visibility
+-- ---------------------------------------------------------------------------
+-- Regular users and anon see published rows only. Editor+ additionally sees
+-- drafts, which is what lets Studio's Manage section list them.
+--
+-- Clause order matters for cost: `status = 'published'` short-circuits before
+-- has_min_role() is consulted, so the anon path never calls it. has_min_role()
+-- is STABLE SECURITY DEFINER, so on the editor path Postgres evaluates it once
+-- per query rather than once per row — the same property 20260609000000 was
+-- written to preserve.
+DROP POLICY IF EXISTS "songs_select" ON public.songs;
+
+CREATE POLICY "songs_select"
+  ON public.songs FOR SELECT
+  USING (
+    is_deleted = false
+    AND (status = 'published' OR public.has_min_role('editor'))
+  );


### PR DESCRIPTION
Phase 3 for GraceChords Studio: a role-gated **Manage** section with a plain-text ChordPro editor, a live preview, draft/published state, and hard delete.

## ⚠️ Read first — the migrations are already applied to production

I applied both migrations to the linked project during this session (with the maintainer's go-ahead) via `supabase db query --linked -f <file>`, so **there is nothing for a reviewer to apply.** Current live state, verified after the fact:

- `public.songs` has **4 policies** (one per command), down from 10.
- `status` exists, `NOT NULL DEFAULT 'published'`, with `songs_status_check` and `songs_status_idx`.
- 212 rows, 212 published, 0 drafts — **no catalog loss**.

Both `.down.sql` files were exercised on production and reverted cleanly (4 → 10 → 4 policies, column dropped and restored, 212 rows intact throughout), then the up migrations were re-applied. They are idempotent — each ran twice.

Relevant to how this repo actually operates: `supabase migration list --linked` reports **every** migration as unrecorded remotely, so `supabase db push` would try to replay all 38 from scratch, several of which are destructive (`TRUNCATE`, `DROP TABLE … CASCADE`). Don't run it. That's now written down in `AGENTS.md`.

## The security fix (migration 1 of 2)

`20260728000000_songs_policy_consolidation.sql` is not feature work and is reviewable on its own.

`public.songs` had accumulated **ten** policies across three naming generations, including `songs_select USING (true)`. Because permissive policies are **OR'd**, that one policy overrode both other SELECT policies: every row was readable by anyone, anon included, **including the 6 rows with `is_deleted = true`**. The `is_deleted = false` guarantee every client depends on was being enforced only by the client-side `.eq()` in each query, never by RLS.

This also meant the draft-visibility requirement was unachievable without consolidating first — a `status = 'published'` clause added to any one policy would have been a no-op while `USING (true)` remained.

Two other things fell out of the audit:

- **Effective DELETE was already `editor+`**, not `admin+`: `songs_delete`'s `has_min_role('admin')` was OR'd with two `editor+` grants. This migration makes that explicit rather than changing who can delete (which matches the maintainer's stated preference).
- The live write policies **existed nowhere in version control**. `apps/web`'s `EditorPage` and `apps/mobile`'s `useSongDraft` have been writing to `songs` in production via `upsertSong`, which only worked because of dashboard-created policies. They're now captured in a migration file.

`20260728000100_songs_status.sql` then adds the column and the draft clause. `DEFAULT 'published'` is load-bearing, not stylistic — `'draft'` would have emptied the catalog for web, mobile and Studio the moment the policy landed, and `NOT NULL DEFAULT` backfills every existing row in the same statement with no separate `UPDATE`.

Final policy:

```sql
USING (is_deleted = false AND (status = 'published' OR public.has_min_role('editor')))
```

Studio deliberately **never** filters on `status` client-side. An editor's library legitimately contains drafts (badged `DRAFT`); everyone else's does not, because the policy decided that. Duplicating the rule in the client is how you get a filter that disagrees with the policy — the exact class of bug this PR is fixing.

## Editor

- **The preview is the Viewer's renderer.** `SongEditorModel` calls the same `CoreBridge.render` and hands the `SongDoc` to the same `ChordChartView`. No editor-specific rendering path exists, so the preview cannot disagree with what a worshipper sees. `SongViewerView` is untouched — rendering was already decoupled one level down.
- **Debounce 300 ms**, trailing, skipped when the text matches what was last parsed. Measured, not guessed: a refresh (`renderToJSON` + `lintToJSON` + `JSONDecoder` → `SongDoc`) costs **~1.4 ms** on the longest song in the catalog (95 lines) and ~8 ms at ten times that size, so the bridge is not the constraint — SwiftUI's chart layout is the remainder, which I did not isolate.
- **Saving never moves publication state.** `SongWritePayload` omits `status` on update, making "editing a live song can't silently unpublish it" a property of the payload rather than a rule the UI has to remember. Publication moves only via explicit Publish/Unpublish (Unpublish exists because otherwise a mistakenly-published song could only be deleted).
- **A new song writes no row until first save.** `slug` is `UNIQUE NOT NULL` and core's `slugify` returns `''` for a title with no alphanumerics, so a row can't exist before there's a title. The slug is derived once and never re-derived on a title change — it's the song's public URL.
- **Delete is a real `DELETE`** and cascades: `setlist_songs.song_id` and `user_starred_songs.song_id` are both `ON DELETE CASCADE`, so the song leaves every personal and team setlist and every favourites list with it. The dialog names those consequences. The `editor_audit_log` row is written **before** the delete so it survives the `ON DELETE SET NULL` carrying `song_slug`/`song_title`.
- **Section, not a mode.** Manage is a role-gated section rather than a mode on the Library/Viewer split: `SongViewerView` installs `.focusedSceneObject(export)` and owns the File ▸ Export menu plus its own toolbar, and the two surfaces own different state (selected-for-reading vs. has-unsaved-changes).

## Bridge

`lintToJSON`, `hasMinRole`, `roleOrderJSON`, `slugify` — same subpath-import discipline (never the barrel, which pulls `@supabase/supabase-js`). Bundle went 6 → 8 modules with **nothing transitive**: `lint.ts`'s only runtime import is `./parser`, already bundled; `slug.ts` and `roles.js` import nothing.

`hasMinRole` and `slugify` are bridged rather than hand-ported because both have outputs that must match the other clients exactly — per `AGENTS.md`, `rbac/roles.js` is the single source of truth for gate checks, and a Swift copy of `ROLE_ORDER` is precisely what outlives a hierarchy change unnoticed (`collaborator` was removed from it in 2026-07).

`verify-bundle.mjs` grew: full `LintWarning[]` equality over the parser corpus plus 12 bodies written to trip each warning code; a check that every warning carries exactly the key set `LintWarning.swift` decodes (an added key would otherwise be silently dropped); lint-must-not-throw-where-the-parser-throws; the full role × minimum matrix including roles no longer in the hierarchy; and 16 slugify titles including the `''` contract Swift depends on before writing a row.

## Two fixes driven by the live data

- **Validation gates publishing, not saving.** 8 published songs have no tags and 5 have no key. Gating Save on core's full `validateSongForm` made all of them uneditable — an editor opening one to fix a typo would have had to invent a tag before Save enabled. Save now needs only a title (`NOT NULL`, and the slug derives from it); Publish enforces the full rule, keeping parity with web for what enters the catalog.
- **`warn:missing_title` / `warn:missing_key` suppressed** while the columns are set. `lintChordPro` assumes a standalone `.chordpro` file where those directives are the only home for that metadata; here it lives in columns (core's `canonicalizeForm` is explicit that it won't inject them). Result: both fired on **all 206 songs**, burying `warn:section_mismatch` and `warn:unknown_chord`. Filtered at the Studio boundary — core is correct for the input it documents, and `apps/web` has a test asserting that output. A row whose column *is* empty still gets the warning.

Also: typed tags now snap to the catalog's existing spelling. `songs.tags` is matched case-sensitively and the live data is Title Case (`Slow`, `Praise`), so my first cut's lowercasing would have minted a second `worship` beside `Worship` and split the library's tag filter.

## Verification

- ✅ Builds clean; no new warnings (the existing ones come from `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and point at untouched lines).
- ✅ `verify-bundle.mjs` — all checks pass, 144 `renderToJSON` document comparisons.
- ✅ `npm test` — 54 files, 224 tests.
- ✅ **RLS tested by impersonation** (`SET LOCAL ROLE` + `request.jwt.claims`, in rolled-back transactions, zero leftover rows): anon and a regular user see published only; an editor also sees drafts; soft-deleted invisible to all three.
- ✅ **Write permissions**: regular user refused on INSERT (42501), UPDATE (0 rows), DELETE (row survives). Editor allowed on insert-draft, publish, hard-delete. An UPDATE omitting `status` left a published song published. `status = 'archived'` rejected by CHECK.
- ✅ Runs, signs in, loads 212 songs, role gate resolves, preview renders, lint strip populates.

## What I could not verify — please click this once

**The create → save draft → reopen → publish → delete round trip was verified at the SQL layer, not through the Swift code path.** Synthetic clicks were good enough for screenshots but not reliable enough to trust a multi-step write flow, and I wasn't willing to report writes-to-production as verified on that basis. If something's wrong it'll be in `SongEditorModel.save()` or `ManageSongsView.open(_:)`.

That constraint did catch one real bug first: the editor model was being constructed inside `body`, which would have recreated it on every re-render and discarded each keystroke. It's now `@State`-owned and replaced only when the open song changes.

## Deliberately out of scope

Collaborator review/submission queue, soft-delete/revision history/undo, user management, capo suggestion, and **ChordPro syntax highlighting** — `TextEditor` can't style ranges, so it needs `NSViewRepresentable` over `NSTextView` with a custom `NSTextStorage` (attribute runs vs. the undo manager, IME marked-text ranges, re-highlight cost). Self-contained work, orthogonal to whether saving is correct; reasoning recorded in `apps/studio/README.md`. No changes to `apps/web` or `apps/mobile` beyond the RLS visibility change itself.

One pre-existing issue noted but not fixed (it would change existing web slugs): core's `slugify` mangles non-ASCII — `"Türkçe Şarkı"` → `t_rk_e_ark` — which matters given Turkish songs are in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
