### PR TITLE
fix(studio): opt in to supabase-swift's new initial-session behavior

### DIFF
--- a/apps/studio/GraceChords Studio/GraceChords Studio/Auth/AuthController.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Auth/AuthController.swift
@@ -69,6 +69,19 @@ final class AuthController: ObservableObject {
             if case .signedOut = event {
                 clear()
             } else if let session = session {
+                // An expired session is not a signed-in state. With
+                // `emitLocalSessionAsInitialSession` (set in AppServices) the SDK
+                // deliberately emits the stored session even when it has expired, and
+                // promises a `tokenRefreshed` — or a `signOut` if the refresh fails —
+                // to follow. So this waits for that verdict instead of showing the
+                // library behind a dead token and bouncing the user out on the first
+                // query that comes back PGRST301.
+                //
+                // Not `clear()`: the common launch case is a stored session an hour
+                // old, and dropping to the sign-in screen for the duration of a
+                // refresh that is about to succeed would flash a login prompt at
+                // someone who is signed in.
+                guard !session.isExpired else { continue }
                 let wasSignedIn = phase == .signedIn
                 apply(session: session)
                 // A token refresh fires this stream repeatedly for a session that

--- a/apps/studio/GraceChords Studio/GraceChords Studio/Services/AppServices.swift
+++ b/apps/studio/GraceChords Studio/GraceChords Studio/Services/AppServices.swift
@@ -21,9 +21,27 @@ final class AppServices {
     let bridgeErrorText: String?
 
     init(config: StudioConfig) {
+        // `emitLocalSessionAsInitialSession: true` opts in to what supabase-swift will
+        // do by default in its next major version, and silences the runtime notice it
+        // logs until you do. Under the old behaviour `.initialSession` carried a
+        // session only after a refresh had been attempted; under the new one the
+        // stored session is emitted as-is, expired or not, with a `tokenRefreshed` or
+        // `signOut` to follow.
+        //
+        // Opting in is only safe because AuthController skips expired sessions — it
+        // judges events by whether one carries a session, so without that guard this
+        // flag would let a dead token flip the app to signed-in. Change the two
+        // together or neither.
+        //
+        // The storage argument is omitted deliberately: this initializer defaults it
+        // to `AuthClient.Configuration.defaultLocalStorage`, the same Keychain store
+        // the no-options initializer used, so session persistence is unchanged.
         let client = SupabaseClient(
             supabaseURL: config.supabaseURL,
-            supabaseKey: config.supabaseAnonKey
+            supabaseKey: config.supabaseAnonKey,
+            options: SupabaseClientOptions(
+                auth: SupabaseClientOptions.AuthOptions(emitLocalSessionAsInitialSession: true)
+            )
         )
         self.client = client
         self.songs = SongsRepository(client: client)


### PR DESCRIPTION
Follow-up to #463. Clears the runtime notice supabase-swift logs on every Studio launch, and fixes the latent bug that notice was pointing at.

## The notice

```
Initial session emitted after attempting to refresh the local stored session.
This is incorrect behavior and will be fixed in the next major release since it's a breaking change.
To opt-in to the new behavior now, set `emitLocalSessionAsInitialSession: true` in your AuthClient configuration.
```

Diagnostic only — no functional impact today. It comes from `AuthClient.emitInitialSession`, which currently does `let session = try? await session` before emitting, so `.initialSession` carries either a **valid** session or `nil`. Under the new behavior it emits the stored session as-is, expired or not, followed by a `tokenRefreshed` (or `signOut` if the refresh fails).

## Why flipping the flag alone would have been a bug

`AuthController` judges auth events by *whether one carries a session* — which is correct under today's behavior and wrong under the new one. Opting in without a guard would have meant an expired stored session flipping the app to signed-in: the library would render behind a dead token until the first query came back `PGRST301`, then `SongsRepositoryError.sessionExpired` would bounce the user to sign-in. Self-correcting, but a visible flash of a broken app.

So the guard lands first, and the two changes are coupled deliberately (each file's comment says so):

```swift
guard !session.isExpired else { continue }
```

**Skipped, not treated as a sign-out.** The common launch case is a stored session an hour old — access tokens live 1h and `isExpired` has a 30s latency margin. Mapping expired → `signedOut` would flash a login prompt at someone who is signed in, for the duration of a refresh that's about to succeed. Waiting for the SDK's promised follow-up event is what its own docs prescribe: *"If this is the case, then expect a `tokenRefreshed` after."*

## Session persistence is unchanged

This was the risk worth checking, since getting it wrong signs everyone out. The options initializer used here is the non-Linux convenience overload, which defaults `storage` to `AuthClient.Configuration.defaultLocalStorage` — the same `KeychainLocalStorage` the no-options initializer passed. Storage is deliberately not named at the call site so it can't drift.

## Verification

Relaunched against the real project:

- ✅ Notice gone (0 occurrences in console output).
- ✅ **Session restored from Keychain** — app comes up signed in, no sign-in screen.
- ✅ Catalog loads (212 songs).
- ✅ Role gate still resolves — the Manage section is present, so `users.role` still reads correctly through the restored session.
- ✅ Builds clean, no new warnings.

Verified against supabase-swift **2.53.0** as pinned in `Package.resolved`; the flag's default flips in the next major, at which point this becomes a no-op rather than a behavior change.

Not touched: `apps/web` and `apps/mobile` use supabase-js, which has its own separate initial-session semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
