### PR TITLE
docs(studio): record the NSTableView reentrancy finding (recommend not fixing)

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -340,3 +340,44 @@ hidden (`.detailOnly`) and the detail column renders either the library or the
 viewer, with a manual back button in the viewer's toolbar. It stays one view
 hierarchy at both sizes, so crossing the threshold never resets search text,
 selection, or scroll position (all held in `LibraryViewModel`).
+
+### The NSTableView reentrancy warning at launch
+
+Every launch logs one line:
+
+```
+WARNING: Application performed a reentrant operation in its NSTableView delegate.
+This warning will become an assert in the future.
+```
+
+**It is cosmetic, it predates the editor, and it is not worth chasing.** Recorded
+here so nobody re-runs the investigation.
+
+It was bisected by controlled experiment — each candidate removed in isolation, the
+app relaunched, and the warning counted. Ruled out individually:
+
+| Removed | Warning |
+|---|---|
+| `SongLibraryView`'s `onGeometryChange` width mutation | still there |
+| `applyLayout`'s split-visibility mutation (zero-width guard) | still there |
+| `List(selection:)` binding | still there |
+| `Section` + header wrapper | still there |
+| `SongRow` (replaced with plain `Text`) | still there |
+| **206 rows → ~26 rows, structure byte-identical** | **gone** |
+
+So the trigger is **row count**, not anything our code does wrong: it is SwiftUI's
+`List`/`NSTableView` bridging materialising a large sectioned list into a sidebar in
+one pass. The only fix available to us would be to stop handing SwiftUI the whole
+catalog at once — paging or chunking the sidebar — which would put macOS selection,
+keyboard navigation, the A–Z index and search at risk to silence a log line. Not a
+trade worth making.
+
+Two things that investigation also settled, worth not re-deriving:
+
+- `applyLayout` receives exactly one width at launch (**1257**, never 0), so a
+  `width > 0` guard against a zero first pass is dead code. A `GeometryReader` here
+  does not report 0 before its first real layout.
+- "Will become an assert in the future" is AppKit's standard deprecation phrasing. If
+  a future macOS does make it fatal it will affect a great many SwiftUI apps at once,
+  and the remedy will be whatever Apple's guidance is then — not a bespoke
+  restructuring now.


### PR DESCRIPTION
Investigated the `NSTableView` reentrancy warning Studio logs on every launch. **Recommendation: don't fix it.** This PR is documentation only — no code change — because the evidence says the only available fix is worse than the warning.

Opening it as a PR rather than a comment so the finding lives next to the code and nobody repeats the seven builds it took.

## What it is

```
WARNING: Application performed a reentrant operation in its NSTableView delegate.
This warning will become an assert in the future.
```

## It is pre-existing — and I owe a correction

When the editor landed I claimed this was pre-existing *by reasoning*: `ManageSongsView` isn't constructed at launch, so it couldn't be Phase 3's. That reasoning was sound but untested. I've now actually built and run **af723f10a** (Phase 2, before any editor work) and it reproduces the warning identically. Same conclusion, but now measured rather than argued.

## Bisected, not guessed

Each candidate removed in isolation, app relaunched, warnings counted. Two of my own hypotheses died here — worth noting, because both looked convincing enough that I'd have "fixed" them and reported success:

| Removed | Warning |
|---|---|
| `SongLibraryView`'s `onGeometryChange` width mutation | still there |
| `applyLayout`'s split-visibility mutation (zero-width guard) | still there |
| `List(selection:)` binding | still there |
| `Section` + header wrapper | still there |
| `SongRow` (replaced with plain `Text`) | still there |
| **206 rows → ~26 rows, structure byte-identical** | **gone** |

The trigger is **row count**. Nothing our code does wrong — it's SwiftUI's `List`/`NSTableView` bridging materialising a large sectioned list into a sidebar in one pass.

## Why not fix it

The only lever we have is to stop handing SwiftUI the whole catalog at once — paging or chunking the sidebar. That puts macOS selection, keyboard navigation, the A–Z index and search at risk, in a list that currently works correctly, to silence one console line with no observed functional effect. Bad trade.

"Will become an assert in the future" is AppKit's standard deprecation phrasing. If a future macOS makes it fatal it will hit a great many SwiftUI apps simultaneously, and the remedy will be whatever Apple's guidance is then rather than a bespoke restructuring now.

## A dead end recorded on purpose

`applyLayout` receives exactly **one** width at launch — **1257, never 0**. I had assumed `GeometryReader` reports 0 on a first pass and briefly added a `guard width > 0` to stop a spurious narrow→wide flip. Instrumenting it (via `stderr` — `print` to a redirected file is buffered and `pkill` discards it) showed no such pass exists, so that guard was dead code and is **not** in this PR. Documented so the same guard doesn't get added later on the same wrong intuition.

## Not included, but noticed

`LibraryViewModel.sections` re-runs `LibrarySort.sections(...)` over the whole catalog on *every* access, and it's read more than once per body pass (the `ForEach`, plus `visibleCount` in the overlay, plus `presentLetters`). That's a genuine inefficiency worth caching — but it is not the cause of this warning and it isn't what was asked for, so it's left alone rather than smuggled in. Happy to do it as its own change if you want it.

## Verification

- Builds clean on a pristine tree — every probe and the dead guard removed, `git status` empty before committing.
- Only `apps/studio/README.md` changes; zero code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
