### PR TITLE
fix(mobile): open the tapped Daily Word reading, not the first one

### DIFF
--- a/apps/mobile/app/daily/reader.tsx
+++ b/apps/mobile/app/daily/reader.tsx
@@ -1,7 +1,11 @@
+import { useLocalSearchParams } from 'expo-router'
 import DailyWordScreen from '../../src/screens/DailyWordScreen'
 
 // The M'Cheyne Reader pushed from the Daily Word landing — it carries a back
 // chevron to the landing (the tab-root Reader in reader-direct mode does not).
+// The optional `passage` param is a core `passageId()`, so tapping a specific
+// reading on the landing opens ON that chapter instead of the day's first one.
 export default function DailyReader() {
-  return <DailyWordScreen showBackToLanding />
+  const { passage } = useLocalSearchParams<{ passage?: string }>()
+  return <DailyWordScreen showBackToLanding initialPassageId={passage} />
 }

--- a/apps/mobile/src/i18n/locales/en/reader.json
+++ b/apps/mobile/src/i18n/locales/en/reader.json
@@ -8,7 +8,6 @@
   "streakDays_one": "{{count}}-day streak",
   "streakDays_other": "{{count}}-day streak",
   "landingReadingHeader": "{{date}}'s reading · M'Cheyne",
-  "landingReadCta": "Read today's passages",
   "backToLanding": "Back to Daily Word",
   "reflection": {
     "landingHeader": "Your reflection",

--- a/apps/mobile/src/i18n/locales/es/reader.json
+++ b/apps/mobile/src/i18n/locales/es/reader.json
@@ -8,7 +8,6 @@
   "streakDays_one": "racha de {{count}} día",
   "streakDays_other": "racha de {{count}} días",
   "landingReadingHeader": "Lectura del {{date}} · M'Cheyne",
-  "landingReadCta": "Leer los pasajes de hoy",
   "backToLanding": "Volver a Palabra del día",
   "reflection": {
     "landingHeader": "Tu reflexión",

--- a/apps/mobile/src/i18n/locales/ko/reader.json
+++ b/apps/mobile/src/i18n/locales/ko/reader.json
@@ -8,7 +8,6 @@
   "streakDays_one": "{{count}}일 연속",
   "streakDays_other": "{{count}}일 연속",
   "landingReadingHeader": "{{date}} 읽기 · 맥체인",
-  "landingReadCta": "오늘의 본문 읽기",
   "backToLanding": "오늘의 말씀으로 돌아가기",
   "reflection": {
     "landingHeader": "나의 묵상",

--- a/apps/mobile/src/i18n/locales/tr/reader.json
+++ b/apps/mobile/src/i18n/locales/tr/reader.json
@@ -8,7 +8,6 @@
   "streakDays_one": "{{count}} günlük seri",
   "streakDays_other": "{{count}} günlük seri",
   "landingReadingHeader": "{{date}} okuması · M'Cheyne",
-  "landingReadCta": "Bugünün bölümlerini oku",
   "backToLanding": "Kutsal Kitap'a dön",
   "reflection": {
     "landingHeader": "Düşüncelerin",

--- a/apps/mobile/src/lib/__tests__/readerPassage.test.ts
+++ b/apps/mobile/src/lib/__tests__/readerPassage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { expandReadings, getPlanForDate, passageId } from '@gracechords/core'
+import { resolveInitialPassageIndex } from '../readerPassage'
+
+// Regression: tapping any reading on the Daily Word landing used to push the
+// Reader with no passage, so every row opened the day's FIRST chapter.
+describe('resolveInitialPassageIndex', () => {
+  // Aug 2 is the screenshot's day (Judges 16 · Acts 20 · Jeremiah 29 · Mark 15)
+  // and a normal 4-reading date; every date in the plan is exercised below.
+  const passages = expandReadings(getPlanForDate(new Date(2026, 7, 2)).readings)
+
+  it('resolves each of the day’s readings to its own index', () => {
+    expect(passages.length).toBeGreaterThan(1)
+    passages.forEach((p, i) => {
+      expect(resolveInitialPassageIndex(passages, passageId(p))).toBe(i)
+    })
+  })
+
+  it('does not collapse later readings onto the first one', () => {
+    const last = passages.length - 1
+    expect(resolveInitialPassageIndex(passages, passageId(passages[last]))).not.toBe(0)
+  })
+
+  it('falls back to the first passage with no id or an unknown id', () => {
+    expect(resolveInitialPassageIndex(passages, undefined)).toBe(0)
+    expect(resolveInitialPassageIndex(passages, '')).toBe(0)
+    expect(resolveInitialPassageIndex(passages, '99|999|all')).toBe(0)
+    expect(resolveInitialPassageIndex([], passageId(passages[0]))).toBe(0)
+  })
+
+  // Every plan day must round-trip, not just the one above — a passageId that
+  // isn't unique within a day would silently send two rows to one chapter.
+  it('round-trips every reading on every day of the plan', () => {
+    for (let day = 0; day < 365; day += 1) {
+      const date = new Date(2026, 0, 1 + day)
+      const list = expandReadings(getPlanForDate(date).readings)
+      list.forEach((p, i) => {
+        expect(resolveInitialPassageIndex(list, passageId(p))).toBe(i)
+      })
+    }
+  })
+})

--- a/apps/mobile/src/lib/readerPassage.ts
+++ b/apps/mobile/src/lib/readerPassage.ts
@@ -1,0 +1,16 @@
+import { passageId, type Passage } from '@gracechords/core'
+
+// Which of a day's readings the Reader opens on. The Daily Word landing hands
+// over the tapped row as a core `passageId()` rather than a list position, so
+// the Reader resolves it against its OWN expansion of the plan instead of two
+// lists having to agree on ordering.
+//
+// Falls back to the day's first passage whenever the id is missing (the Reader
+// opened as the tab root, or via the landing's list before this shipped) or
+// doesn't match anything (a stale deep link, or a midnight rollover between the
+// tap and the push landing the Reader on a different day's readings).
+export function resolveInitialPassageIndex(passages: readonly Passage[], id?: string): number {
+  if (!id) return 0
+  const i = passages.findIndex((p) => passageId(p) === id)
+  return i < 0 ? 0 : i
+}

--- a/apps/mobile/src/screens/DailyWordLandingScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordLandingScreen.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Alert, Image, Pressable, ScrollView, Text, View } fr
 import { useTranslation } from 'react-i18next'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { formatPassageLabel } from '@gracechords/core'
+import { formatPassageLabel, passageId, type Passage } from '@gracechords/core'
 import Screen from '../components/Screen'
 import Card from '../components/Card'
 import Button from '../components/Button'
@@ -98,7 +98,12 @@ export default function DailyWordLandingScreen() {
     }, [refresh]),
   )
 
-  const openReader = () => router.push('/daily/reader')
+  // Open the Reader ON the tapped reading. The passage travels as core's
+  // `passageId()` rather than a list index, so the Reader resolves it against
+  // its own copy of the day's plan (and falls back to the first passage if it
+  // can't match) instead of trusting two lists to stay in the same order.
+  const openReader = (passage: Passage) =>
+    router.push({ pathname: '/daily/reader', params: { passage: passageId(passage) } })
 
   const onDelete = () => {
     Alert.alert(tx('reflection.deleteTitle'), tx('reflection.deleteMessage'), [
@@ -195,7 +200,7 @@ export default function DailyWordLandingScreen() {
             {passages.map((p, i) => (
               <Pressable
                 key={`${p.bookNumber}-${p.chapter}-${i}`}
-                onPress={openReader}
+                onPress={() => openReader(p)}
                 accessibilityRole="button"
                 accessibilityLabel={formatPassageLabel(p)}
                 style={({ pressed }) => ({
@@ -245,13 +250,9 @@ export default function DailyWordLandingScreen() {
           </Card>
         )}
 
-        {passages.length > 0 ? (
-          <Button
-            title={tx('landingReadCta')}
-            onPress={openReader}
-            style={{ marginTop: t.spacing.md }}
-          />
-        ) : null}
+        {/* No "Read today's passages" CTA below the list: each row now opens the
+            Reader on its own chapter, so a button that could only ever open the
+            first one duplicated the list without adding a destination. */}
 
         {/* Shared Reflections — anonymous community feed (flag-gated, above the
             user's own reflection per the design decision). Under-13 users see

--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -38,6 +38,7 @@ import {
   useBibleTranslationPref,
 } from '../lib/bibleTranslationPref'
 import { markReadToday, streakDateKey } from '../lib/readingStreak'
+import { resolveInitialPassageIndex } from '../lib/readerPassage'
 import { useBibleTranslations } from '../lib/useBibleTranslations'
 import { useDailyHighlights } from '../lib/useDailyHighlights'
 import {
@@ -77,7 +78,14 @@ function chipLabel(passage: Passage) {
 // true only when the Reader was PUSHED from the landing (app/daily/reader.tsx);
 // as the Daily Word tab root (reader-direct mode) it is false and the layout is
 // unchanged from before the landing existed.
-export default function DailyWordScreen({ showBackToLanding = false }: { showBackToLanding?: boolean } = {}) {
+//
+// `initialPassageId` is a core `passageId()` naming which of today's readings to
+// open on — set when a specific reading was tapped on the landing. An unknown or
+// missing id falls back to the day's first passage.
+export default function DailyWordScreen({
+  showBackToLanding = false,
+  initialPassageId,
+}: { showBackToLanding?: boolean; initialPassageId?: string } = {}) {
   const t = useTheme()
   const router = useRouter()
   const { t: tx, i18n } = useTranslation('reader')
@@ -87,7 +95,12 @@ export default function DailyWordScreen({ showBackToLanding = false }: { showBac
   const { translations, groups, defaultTranslationId } = useBibleTranslations()
 
   const [date, setDate] = useState(() => new Date())
-  const [passageIndex, setPassageIndex] = useState(0)
+  const passages = useMemo(() => expandReadings(getPlanForDate(date).readings), [date])
+  // Seeded synchronously (not in an effect) so a passage tapped on the landing
+  // is the FIRST chapter fetched — no flash of the day's first reading.
+  const [passageIndex, setPassageIndex] = useState(() =>
+    resolveInitialPassageIndex(passages, initialPassageId),
+  )
   // The user's explicit, persisted translation pick ('' = none yet).
   const storedTranslationId = useBibleTranslationPref()
   // Highlights persist per passage (keyed by passageId), stored to disk and
@@ -102,7 +115,6 @@ export default function DailyWordScreen({ showBackToLanding = false }: { showBac
   // Copy FAB press feedback: 0 = resting, 1 = pressed (scale-down + dim).
   const fabPress = useRef(new Animated.Value(0)).current
 
-  const passages = useMemo(() => expandReadings(getPlanForDate(date).readings), [date])
   const currentPassage: Passage | null = passages[passageIndex] || passages[0] || null
 
   // Resolve the active translation: a stored pick always wins; with no prior
@@ -135,8 +147,14 @@ export default function DailyWordScreen({ showBackToLanding = false }: { showBac
   }, [chapter, currentPassage])
 
   // A new day starts on its first passage. Highlights are keyed by passage, so
-  // they survive date/chapter switches without being cleared here.
+  // they survive date/chapter switches without being cleared here. The mount run
+  // is skipped so it can't stomp on the `initialPassageId` seed above.
+  const dateSettled = useRef(false)
   useEffect(() => {
+    if (!dateSettled.current) {
+      dateSettled.current = true
+      return
+    }
     setPassageIndex(0)
   }, [date])
 


### PR DESCRIPTION
Every reading row on the Daily Word landing pushed `/daily/reader` with no
argument, and the Reader always started at `passageIndex` 0 — so tapping
"Jeremiah 29" opened Judges 16. The chapter chips were the only way to reach
the reading you actually asked for.

Rows now carry the tapped passage to the Reader as core's `passageId()` rather
than a list index, so the Reader resolves it against its own expansion of the
day's plan and falls back to the first passage if it can't match (stale deep
link, midnight rollover mid-navigation). The index is seeded synchronously in
`useState` instead of an effect, so the tapped chapter is the first one fetched
with no flash of the day's first reading; the date-change reset effect skips its
mount run so it can't stomp on that seed.

Drops the "Read today's passages" CTA: with each row opening its own chapter, a
button that could only ever open the first one duplicated the list without
adding a destination. Its `landingReadCta` string goes with it, in all four
locales.

Verified: typecheck, `expo export --platform ios`, i18n parity, and vitest
(268 tests) all pass. The new `resolveInitialPassageIndex` is covered by a
regression test that round-trips every reading on all 365 plan days.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012EZdrVGAFFb79PkXYeredB