### PR TITLE
feat(deeplinks): claim every web page for the native apps

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -223,10 +223,20 @@ duplicate logic here and never edit core internals to suit mobile.
   `choose-icon` is reachable both with and without a session (post-signup step —
   email confirmation may still be pending).
 - **Deep links / Universal Links.** iOS Universal Links are wired via
-  `ios.associatedDomains: ["applinks:gracechords.com"]` (apex only, no `www`) +
-  `app/+native-intent.tsx` `redirectSystemPath`, and the AASA file lives in the
-  **web** repo at `apps/web/public/.well-known/apple-app-site-association`.
-  Handled paths:
+  `ios.associatedDomains: ["applinks:gracechords.com"]` (apex only, no `www`);
+  Android App Links via `android.intentFilters` in `app.json`. Which paths each
+  platform claims lives in the **web** repo — the AASA file at
+  `apps/web/public/.well-known/apple-app-site-association` and `assetlinks.json`
+  beside it. **`apps/web/public/.well-known/README.md` holds the canonical claim
+  table**; those three files plus `app.json` must agree. Paths are enumerated,
+  never wildcarded across the domain, because Android has no exclusion
+  mechanism — auth (`/login`, `/auth/callback`, `/reset-password`, …), the
+  admin/editor portal, and the legal pages the app links *out* to are
+  deliberately unclaimed.
+  - **The mapping is `src/lib/deepLinks.ts`** (`resolveDeepLinkPath`, pure and
+    unit-tested — one case per claim-table row). `app/+native-intent.tsx` is a
+    thin `redirectSystemPath` wrapper over it. Add a claim in three places at
+    once: AASA, `android.intentFilters`, and `deepLinks.ts` (+ a test).
   - `/song/:id`, `/songs/:id` (id == slug) → `/viewer/:slug` (the app has no
     `/song` route).
   - Shared setlists `/setlist/<slugs>?toKeys=`, `/set/<CODE>`, and the
@@ -236,10 +246,20 @@ duplicate logic here and never edit core internals to suit mobile.
     split for the slug-list form; slugs resolve against the shared catalog, misses
     are dropped with a warning, and "Save to my setlists" creates a normal setlist
     row (default name "Imported setlist"). Shared links never carry a title.
-  Changing `associatedDomains` / `intentFilters` needs a **fresh native build**
-  (prebuild + EAS), not an OTA. **TODO(android)** — `android.intentFilters` are
-  wired but dormant until an Android signing key exists and its SHA-256 lands in
-  the web `assetlinks.json`.
+  - `/s/:code` → `/session/:code`. Index/landing pages map to their tab
+    (`/` → home, `/songs`, `/setlist` → `/setlists`, `/reading` → `/daily`), and
+    web-only pages with no counterpart (the blog) resolve to the home tab rather
+    than dead-ending. Anything unrecognised passes through unchanged, which is
+    what keeps `gracechords://` links working.
+  - **Build impact differs per platform.** Editing `associatedDomains` or
+    `intentFilters` needs a **fresh native build** (prebuild + EAS), not an OTA.
+    But adding a *path* is only an AASA edit on iOS — no new build, just a web
+    deploy (devices cache the AASA, so expect refresh lag). Android compiles its
+    filters into `AndroidManifest.xml`, so a path change there **does** need a
+    rebuild.
+  - **Known gap:** a deep link is lost when signed out. `app/_layout.tsx` treats
+    only the `session` segment as public, so any other inbound link redirects to
+    `/login` and the destination is discarded rather than resumed after sign-in.
 - **Auth flows.** Email/password plus native Google
   (`@react-native-google-signin/google-signin`) and Apple
   (`expo-apple-authentication`, iOS-only button) via

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -32,11 +32,23 @@
           "action": "VIEW",
           "autoVerify": true,
           "data": [
+            { "scheme": "https", "host": "gracechords.com", "path": "/" },
+            { "scheme": "https", "host": "gracechords.com", "pathPattern": "/*" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/songs" },
             { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/song/" },
             { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/songs/" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/setlist" },
             { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/setlist/" },
             { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/set/" },
-            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/worship/" }
+            { "scheme": "https", "host": "gracechords.com", "path": "/worship" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/worship/" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/s/" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/reading" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/songbook" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/about" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/profile" },
+            { "scheme": "https", "host": "gracechords.com", "path": "/posts" },
+            { "scheme": "https", "host": "gracechords.com", "pathPrefix": "/posts/" }
           ],
           "category": ["BROWSABLE", "DEFAULT"]
         }

--- a/apps/mobile/app/+native-intent.tsx
+++ b/apps/mobile/app/+native-intent.tsx
@@ -1,66 +1,14 @@
 // Remaps inbound deep-link / Universal Link paths to Expo Router routes.
 //
-// Songs: the web has /song/:id and /songs/:id (id == song slug), but the app's
-// song screen is viewer/[slug], so those paths are rewritten.
+// Native-only file; Expo Router ignores it on web. redirectSystemPath runs for
+// every externally-launched link, on both cold start (initial === true) and warm
+// start (initial === false).
 //
-// Shared setlists: the web shares a set as an ephemeral link the app can't route
-// to directly, so both forms are remapped to the import-preview screen
-// (setlist/import), which decodes + previews + saves a copy:
-//   - slug list:   /setlist/<slugs>?toKeys=  and  /worship/<slugs>?toKeys=
-//   - compact code: /set/<CODE>              and  /worship/set/<CODE>
-// /worship/* is imported as a plain setlist (we materialize a saved copy). The
-// app's own /setlist/<uuid> and /setlist/import routes are left untouched.
-//
-// Anything unrecognised is passed through unchanged. Native-only file; Expo
-// Router ignores it on web. redirectSystemPath runs for every externally-launched
-// link, on both cold start (initial === true) and warm start (initial === false).
+// The mapping itself lives in src/lib/deepLinks.ts so it stays RN-free and unit
+// tested; this file is only the router hook.
 
-// Raw (still-encoded) query value — keep per-item encoding intact so the import
-// parser can split on comma then decode each item (mirrors the web parser).
-function rawParam(search: string, key: string): string {
-  const m = new RegExp(`[?&]${key}=([^&]*)`).exec(search || '')
-  return m ? m[1] : ''
-}
+import { resolveDeepLinkPath } from '../src/lib/deepLinks'
 
 export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
-  try {
-    const url = new URL(path, 'https://gracechords.com')
-    const seg = url.pathname.split('/').filter(Boolean)
-
-    // /song/:id or /songs/:id -> /viewer/:id  (bare /songs falls through to the tab)
-    if ((seg[0] === 'song' || seg[0] === 'songs') && seg[1]) {
-      const slug = decodeURIComponent(seg.slice(1).join('/'))
-      return `/viewer/${encodeURIComponent(slug)}`
-    }
-
-    // /s/:code -> native live-session follower (session/[code]). Also handles the
-    // gracechords://s/:code custom-scheme link the web "open in app" banner uses.
-    if (seg[0] === 's' && seg[1]) {
-      return `/session/${encodeURIComponent(seg[1])}`
-    }
-
-    // Compact code form -> import preview.
-    if (seg[0] === 'set' && seg[1]) {
-      return `/setlist/import?code=${encodeURIComponent(seg[1])}`
-    }
-    if (seg[0] === 'worship' && seg[1] === 'set' && seg[2]) {
-      return `/setlist/import?code=${encodeURIComponent(seg[2])}`
-    }
-
-    // Slug-list form -> import preview. seg[1] is the comma-joined, per-item
-    // URI-encoded slug list; forward it and the raw toKeys value verbatim.
-    // Skip the app's own routes (/setlist/import, /setlist/<uuid> personal sets).
-    if (seg[0] === 'setlist' && seg[1] && seg[1] !== 'import') {
-      const toKeys = rawParam(url.search, 'toKeys')
-      return `/setlist/import?ids=${seg[1]}${toKeys ? `&toKeys=${toKeys}` : ''}`
-    }
-    if (seg[0] === 'worship' && seg[1]) {
-      const toKeys = rawParam(url.search, 'toKeys')
-      return `/setlist/import?ids=${seg[1]}${toKeys ? `&toKeys=${toKeys}` : ''}`
-    }
-
-    return path
-  } catch {
-    return path
-  }
+  return resolveDeepLinkPath(path)
 }

--- a/apps/mobile/src/lib/__tests__/deepLinks.test.ts
+++ b/apps/mobile/src/lib/__tests__/deepLinks.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { resolveDeepLinkPath } from '../deepLinks'
+
+const WEB = 'https://gracechords.com'
+
+describe('resolveDeepLinkPath', () => {
+  describe('direct parallels', () => {
+    it.each([
+      ['/', '/'],
+      ['/songs', '/songs'],
+      ['/setlist', '/setlists'],
+      ['/worship', '/setlists'],
+      ['/reading', '/daily'],
+      ['/songbook', '/songbook'],
+      ['/about', '/about'],
+      ['/profile', '/settings'],
+    ])('%s -> %s', (from, to) => {
+      expect(resolveDeepLinkPath(`${WEB}${from}`)).toBe(to)
+    })
+
+    it('resolves the bare origin to the home tab', () => {
+      expect(resolveDeepLinkPath(WEB)).toBe('/')
+    })
+  })
+
+  describe('song detail', () => {
+    it('rewrites /song/:id to the viewer', () => {
+      expect(resolveDeepLinkPath(`${WEB}/song/amazing-grace`)).toBe('/viewer/amazing-grace')
+    })
+
+    it('rewrites the /songs/:id alias to the viewer', () => {
+      expect(resolveDeepLinkPath(`${WEB}/songs/amazing-grace`)).toBe('/viewer/amazing-grace')
+    })
+
+    it('re-encodes a slug containing reserved characters', () => {
+      expect(resolveDeepLinkPath(`${WEB}/song/tis%20so%20sweet`)).toBe('/viewer/tis%20so%20sweet')
+    })
+  })
+
+  describe('shared setlists', () => {
+    it('maps the compact code form to the import preview', () => {
+      expect(resolveDeepLinkPath(`${WEB}/set/ABC123`)).toBe('/setlist/import?code=ABC123')
+    })
+
+    it('maps the /worship/set code mirror to the import preview', () => {
+      expect(resolveDeepLinkPath(`${WEB}/worship/set/ABC123`)).toBe('/setlist/import?code=ABC123')
+    })
+
+    it('forwards the slug list and raw toKeys verbatim', () => {
+      expect(resolveDeepLinkPath(`${WEB}/setlist/one,two?toKeys=G,A`)).toBe(
+        '/setlist/import?ids=one,two&toKeys=G,A',
+      )
+    })
+
+    it('keeps per-item encoding in the slug list intact', () => {
+      expect(resolveDeepLinkPath(`${WEB}/setlist/a%2Cb,two`)).toBe('/setlist/import?ids=a%2Cb,two')
+    })
+
+    it('maps the /worship slug-list mirror to the import preview', () => {
+      expect(resolveDeepLinkPath(`${WEB}/worship/one,two?toKeys=G`)).toBe(
+        '/setlist/import?ids=one,two&toKeys=G',
+      )
+    })
+
+    it('omits toKeys when the link carries none', () => {
+      expect(resolveDeepLinkPath(`${WEB}/setlist/one,two`)).toBe('/setlist/import?ids=one,two')
+    })
+  })
+
+  describe('live session', () => {
+    it('maps /s/:code to the follower screen', () => {
+      expect(resolveDeepLinkPath(`${WEB}/s/XYZ`)).toBe('/session/XYZ')
+    })
+
+    it('handles the gracechords:// custom-scheme form', () => {
+      expect(resolveDeepLinkPath('gracechords://s/XYZ')).toBe('/session/XYZ')
+    })
+  })
+
+  describe('no app parallel', () => {
+    it('sends the blog index to the home tab', () => {
+      expect(resolveDeepLinkPath(`${WEB}/posts`)).toBe('/')
+    })
+
+    it('sends a blog post to the home tab', () => {
+      expect(resolveDeepLinkPath(`${WEB}/posts/a-post-slug`)).toBe('/')
+    })
+  })
+
+  describe('passthrough', () => {
+    it('leaves the app-owned import route untouched', () => {
+      expect(resolveDeepLinkPath('/setlist/import?code=ABC')).toBe('/setlist/import?code=ABC')
+    })
+
+    it('leaves an unclaimed web path untouched', () => {
+      expect(resolveDeepLinkPath(`${WEB}/admin`)).toBe(`${WEB}/admin`)
+    })
+
+    it('leaves an unrecognised custom-scheme link untouched', () => {
+      expect(resolveDeepLinkPath('gracechords://daily')).toBe('gracechords://daily')
+    })
+  })
+})

--- a/apps/mobile/src/lib/deepLinks.ts
+++ b/apps/mobile/src/lib/deepLinks.ts
@@ -1,0 +1,97 @@
+// Maps an inbound deep-link / Universal Link path to an Expo Router route.
+//
+// The set of paths that reach here is defined by the claims in
+// apps/web/public/.well-known/apple-app-site-association (iOS) and
+// android.intentFilters in app.json (Android) — keep all three in sync.
+//
+// Direct parallels (song, session) rewrite to the app's own route name. Shared
+// setlists have no direct parallel: the web link is an ephemeral payload, so
+// every form lands on the import-preview screen, which decodes it, previews the
+// resolved songs, and saves a copy. Web pages with no app counterpart at all
+// (the blog) resolve to the home tab rather than dead-ending.
+//
+// Anything unrecognised passes through unchanged, which keeps internal
+// gracechords:// links working.
+
+const APP_SCHEME = 'gracechords://'
+
+// Raw (still-encoded) query value — keep per-item encoding intact so the import
+// parser can split on comma then decode each item (mirrors the web parser).
+function rawParam(search: string, key: string): string {
+  const m = new RegExp(`[?&]${key}=([^&]*)`).exec(search || '')
+  return m ? m[1] : ''
+}
+
+export function resolveDeepLinkPath(path: string): string {
+  try {
+    // The custom scheme carries no real host, but URL parses the first segment
+    // as one (gracechords://s/CODE -> host "s", path "/CODE"). Strip the scheme
+    // so the whole remainder is read as a path.
+    const href = path.startsWith(APP_SCHEME) ? `/${path.slice(APP_SCHEME.length)}` : path
+    const url = new URL(href, 'https://gracechords.com')
+    const seg = url.pathname.split('/').filter(Boolean)
+
+    // Home.
+    if (seg.length === 0) return '/'
+
+    // /song/:id or /songs/:id -> /viewer/:id
+    if ((seg[0] === 'song' || seg[0] === 'songs') && seg[1]) {
+      const slug = decodeURIComponent(seg.slice(1).join('/'))
+      return `/viewer/${encodeURIComponent(slug)}`
+    }
+
+    // /s/:code -> native live-session follower (session/[code]). Covers the
+    // gracechords://s/:code custom-scheme form too, via the strip above.
+    if (seg[0] === 's' && seg[1]) {
+      return `/session/${encodeURIComponent(seg[1])}`
+    }
+
+    // Compact code form -> import preview.
+    if (seg[0] === 'set' && seg[1]) {
+      return `/setlist/import?code=${encodeURIComponent(seg[1])}`
+    }
+    if (seg[0] === 'worship' && seg[1] === 'set' && seg[2]) {
+      return `/setlist/import?code=${encodeURIComponent(seg[2])}`
+    }
+
+    // Slug-list form -> import preview. seg[1] is the comma-joined, per-item
+    // URI-encoded slug list; forward it and the raw toKeys value verbatim.
+    // Skips the app's own /setlist/import. A personal /setlist/<uuid> is only
+    // ever reached by in-app navigation, which never routes through here.
+    if (seg[0] === 'setlist' && seg[1] && seg[1] !== 'import') {
+      const toKeys = rawParam(url.search, 'toKeys')
+      return `/setlist/import?ids=${seg[1]}${toKeys ? `&toKeys=${toKeys}` : ''}`
+    }
+    if (seg[0] === 'worship' && seg[1]) {
+      const toKeys = rawParam(url.search, 'toKeys')
+      return `/setlist/import?ids=${seg[1]}${toKeys ? `&toKeys=${toKeys}` : ''}`
+    }
+
+    // Index pages -> their tab. The web builder is singular, the app tab plural.
+    if (seg.length === 1) {
+      switch (seg[0]) {
+        case 'songs':
+          return '/songs'
+        case 'setlist':
+        case 'worship':
+          return '/setlists'
+        case 'reading':
+          return '/daily'
+        case 'songbook':
+          return '/songbook'
+        case 'about':
+          return '/about'
+        // The app has no /profile route — the profile card lives in Settings.
+        case 'profile':
+          return '/settings'
+      }
+    }
+
+    // Blog: web-only, so send readers to the home tab instead of nowhere.
+    if (seg[0] === 'posts') return '/'
+
+    return path
+  } catch {
+    return path
+  }
+}

--- a/apps/web/public/.well-known/README.md
+++ b/apps/web/public/.well-known/README.md
@@ -7,17 +7,60 @@ App Links) so eligible links open the app instead of the browser. `_headers`
 forces `Content-Type: application/json` for both files (Apple/Android require
 JSON, served over HTTPS, with no redirect).
 
-## `apple-app-site-association` (iOS — active)
-App ID `J7Y8NYZ48Q.com.gracechords.app`. Claims:
+## The claim table
+These three files must agree, and are the whole mechanism — there is no Smart
+App Banner meta tag. Safari renders its native "Open in the GraceChords app"
+banner for any claimed URL on its own, which is why an unclaimed page shows no
+banner at all.
 
-- `/song/*` and `/songs/*` → app song viewer (`viewer/[slug]`).
-- `/setlist/*`, `/set/*`, `/worship/*` → app shared-setlist import preview
-  (`setlist/import`), which decodes the shared payload, previews the resolved
-  songs, and saves the user a copy. The web "Share Set" button emits the
-  ephemeral slug-list form (`/setlist/<slug1>,<slug2>?toKeys=...`); the compact
-  `/set/<CODE>` and `/worship/set/<CODE>` forms decode through
-  `packages/core/src/setlists/setcode.js` `decodeSet`. When the app isn't
-  installed these paths open the web app as usual (Universal Links fallback).
+| Web path | App destination |
+|---|---|
+| `/` | home tab |
+| `/songs` | songs tab |
+| `/song/*`, `/songs/*` | `viewer/[slug]` |
+| `/setlist` | setlists tab (web singular, app plural) |
+| `/setlist/*` | `setlist/import` |
+| `/set/*` | `setlist/import` |
+| `/worship` | setlists tab |
+| `/worship/*`, `/worship/set/*` | `setlist/import` |
+| `/s/*` | `session/[code]` |
+| `/reading` | daily tab |
+| `/songbook` | `songbook` |
+| `/about` | `about` |
+| `/profile` | `settings` (the app has no `/profile` route) |
+| `/posts`, `/posts/*` | home tab (blog — no app parallel) |
+
+Paths are **enumerated, never wildcarded across the domain**: Android App Links
+have no exclusion mechanism, so enumerating is the only way the two platforms
+can stay in sync, and a future web-only page is not silently swallowed by the
+app.
+
+**Deliberately never claimed** — `/login`, `/signup`, `/auth/callback`,
+`/forgot-password`, `/reset-password` (claiming these would pull Supabase OAuth
+redirects and password-reset emails out of the browser mid-flow); `/admin`,
+`/editor`, `/portal/*` (role-gated browser tooling); `/privacy`, `/terms`,
+`/licenses`, `/delete-account` (the mobile About/Settings screens link *out* to
+these, so claiming them would bounce a user app → Safari → app home);
+`/bundle`; `/beta`; `/api/*`; `/.well-known/*`; static assets.
+
+## `apple-app-site-association` (iOS — active)
+App ID `J7Y8NYZ48Q.com.gracechords.app`. One `components` entry per row above;
+patterns are exact unless they end in `*`.
+
+Shared setlists have no direct app parallel — the web link is an ephemeral
+payload, so every form lands on the import preview (`setlist/import`), which
+decodes it, previews the resolved songs, and saves the user a copy. The web
+"Share Set" button emits the slug-list form
+(`/setlist/<slug1>,<slug2>?toKeys=...`); the compact `/set/<CODE>` and
+`/worship/set/<CODE>` forms decode through
+`packages/core/src/setlists/setcode.js` `decodeSet`. When the app isn't
+installed, every claimed path opens the web app as usual (Universal Links
+fallback).
+
+`ios.associatedDomains` is unchanged by path edits, so **adding a path here
+needs no new iOS build** — only a web deploy. Devices cache the AASA, so an
+existing install picks up new paths on Apple's refresh cycle or immediately on
+reinstall.
 
 ## `assetlinks.json` (Android — active)
 Package `com.gracechords.app`. Declares the Digital Asset Links statements
@@ -31,5 +74,15 @@ autofill saved credentials:
 `sha256_cert_fingerprints` lists both accepted release-key SHA-256
 fingerprints (e.g. from `keytool -list -v` or the Play Console app-signing
 page); keep them in sync with the keys actually used to sign shipping builds.
-The claimed song/setlist paths must also be present in
-`android.intentFilters` in `apps/mobile/app.json`.
+
+Every path in the claim table must also be present in `android.intentFilters`
+in `apps/mobile/app.json` — `path` for exact routes, `pathPrefix` for the `*`
+rows. The home row carries both `path: "/"` and `pathPattern: "/*"` because
+Android's `Uri.getPath()` returns `""` (not `"/"`) for a bare
+`https://gracechords.com`. Unlike iOS, **Android needs a fresh native build**
+(`npx expo prebuild` + EAS) for an intent-filter change — the filters are
+compiled into `AndroidManifest.xml`.
+
+The web→route mapping both platforms feed into lives in
+`apps/mobile/src/lib/deepLinks.ts` (unit-tested; `apps/mobile/app/+native-intent.tsx`
+is a thin wrapper over it).

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -5,12 +5,22 @@
       {
         "appIDs": ["J7Y8NYZ48Q.com.gracechords.app"],
         "components": [
+          { "/": "/", "comment": "Home -> home tab" },
+          { "/": "/songs", "comment": "Song library -> songs tab" },
           { "/": "/song/*", "comment": "Song detail -> viewer/[slug]" },
           { "/": "/songs/*", "comment": "Song detail alias -> viewer/[slug]" },
+          { "/": "/setlist", "comment": "Setlist builder -> setlists tab" },
           { "/": "/setlist/*", "comment": "Shared setlist (slug list) -> setlist import preview" },
           { "/": "/set/*", "comment": "Shared setlist (compact code) -> setlist import preview" },
+          { "/": "/worship", "comment": "Worship mode -> setlists tab" },
           { "/": "/worship/*", "comment": "Shared worship set -> setlist import preview" },
-          { "/": "/s/*", "comment": "Live session follower -> session/[code]" }
+          { "/": "/s/*", "comment": "Live session follower -> session/[code]" },
+          { "/": "/reading", "comment": "Daily Bible reading -> daily tab" },
+          { "/": "/songbook", "comment": "Songbook builder -> songbook" },
+          { "/": "/about", "comment": "About -> about" },
+          { "/": "/profile", "comment": "Profile -> settings (the app has no /profile route)" },
+          { "/": "/posts", "comment": "Blog index - no app parallel -> home tab" },
+          { "/": "/posts/*", "comment": "Blog post - no app parallel -> home tab" }
         ]
       }
     ]


### PR DESCRIPTION
Universal Links only claimed song and setlist paths, so the home page,
Daily Bible Reading, songbook, about, profile and the blog showed no
"Open in the GraceChords app" banner and never handed off to the app.
The banner is Safari's native Universal Link banner — there is no Smart
App Banner tag — so the claim files alone decide where it appears.

Claim every user-facing web path on both platforms, mapping each to its
app parallel (/reading -> daily tab, /setlist -> setlists tab, /profile
-> settings) and sending pages with no counterpart (the blog) to the
home tab. Paths stay enumerated rather than wildcarded: Android App
Links have no exclusion mechanism, so enumerating is the only way iOS
and Android stay in sync, and auth, the admin/editor portal and the
legal pages the app links out to are deliberately left unclaimed.

Also closes a pre-existing iOS/Android drift: /s/ (live session) was in
the AASA but missing from android.intentFilters.

The mapping moves to src/lib/deepLinks.ts so it is RN-free and unit
tested (+native-intent.tsx is now a thin wrapper), which covered a
latent bug: gracechords://s/CODE parses with "s" as the host, so the
custom-scheme form the old comment claimed to handle never resolved.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sc7hYexcd1UWBZsBvXEz3W