### PR TITLE
feat(reader): finger-tracking chapter swipe with an arming edge chevron

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -454,6 +454,30 @@ duplicate logic here and never edit core internals to suit mobile.
   Settings, so they reset on relaunch. **Follow-up:** `apps/web`'s
   `features/readings` + `utils/bible` still hold their own copy of this logic;
   migrate web onto core's `bible` module to remove the duplication.
+  - **Swipe between chapters** is `src/components/reader/ChapterSwipe.tsx`
+    (Reanimated + RNGH), modelled on the Bible app's reader: the page **tracks
+    the finger**, a chevron pill slides in from the edge you pull away from and
+    **illuminates** (accent fill) once the commit threshold is crossed, crossing
+    it fires **one** light haptic (re-arming if you drag back under), and release
+    past it carries the page off and commits — short of it, it springs back. At
+    the first/last reading the drag rubber-bands against a short stop with no
+    pill and no haptic. The neighbouring chapter is not rendered during the drag;
+    the commit plays as carry-off → new content in from the opposite edge, and
+    that entrance is replayed for **every** content change (`contentKey`), which
+    is what makes chip taps and translation switches fade too. The pills are
+    geometric, not semantic — the right-edge pill always carries
+    `chevron.right`, which reads as forward in LTR and back in RTL — and they
+    are decorative (`pointerEvents="none"`, hidden from assistive tech): the
+    chapter chips above the reading are the accessible navigation.
+    - **The drag math is `src/lib/readerSwipe.ts`** — threshold, over-drag
+      slowing, the end-of-list rubber band, flick-to-commit — pure worklets, so
+      the *feel* is unit-tested with `npm run test`. Tune the numbers there, not
+      in the component; the component keeps only animation timings. Don't wrap
+      the pills in `GlassSurface`: their opacity animates to 0, which the glass
+      material can't survive (see the note under Primitives).
+    - `DailyWordScreen` prefetches the chapters on either side of the current
+      one so a committed swipe lands on text, not a spinner (`prefetchToday`
+      only warms today in the *default* translation).
 - **Offline downloads** (`src/lib/downloads/`, reached from Settings →
   `OfflineDownloadsScreen`) let users save a **whole Bible translation** for
   offline reading — every chapter is enumerated up front from core's

--- a/apps/mobile/src/components/reader/ChapterSwipe.tsx
+++ b/apps/mobile/src/components/reader/ChapterSwipe.tsx
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useRef, type ReactNode } from 'react'
+import { useWindowDimensions, View } from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import Animated, {
+  Easing,
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated'
+import * as Haptics from 'expo-haptics'
+import SymbolIcon from '../SymbolIcon'
+import { useTheme } from '../../theme/ThemeProvider'
+import {
+  dragTravel,
+  isForwardDrag,
+  shouldCommitSwipe,
+  swipeProgress,
+  swipeThreshold,
+} from '../../lib/readerSwipe'
+
+// Swipe-to-change-chapter for the Daily Word reader, modelled on the Bible-app
+// interaction the design brief points at:
+//
+//   • The page TRACKS THE FINGER — a horizontal drag translates the reading
+//     itself, so the gesture is direct manipulation rather than an invisible
+//     switch that only reveals itself on release.
+//   • A chevron pill slides in from the edge you are pulling away from (drag
+//     left → the pill enters from the right), dim at first and fully
+//     ILLUMINATED once the commit threshold is crossed. That is the whole
+//     affordance: it tells you a swipe is being tracked, which way it goes, and
+//     when it will actually take.
+//   • Crossing the threshold fires ONE light haptic; dragging back under it
+//     re-arms, so the notch can be felt both ways.
+//   • Release past the threshold (or a quick flick) carries the page off and
+//     commits; release short of it springs back and nothing changes.
+//   • At either end of the day's readings the drag rubber-bands against a short
+//     stop with no pill and no haptic — the wall is felt, not explained.
+//
+// The neighbouring chapter is NOT rendered during the drag (the reference app
+// doesn't either, and only one chapter is fetched at a time). The commit plays
+// as carry-off → new content in from the opposite edge, which the entrance
+// animation below owns for EVERY content change, swipe or not.
+
+// The drag arithmetic — thresholds, over-drag slowing, the end-of-list rubber
+// band, the flick-to-commit rule — lives in `src/lib/readerSwipe.ts` so the feel
+// is unit-tested. Only the animation timings below are local.
+
+/** Carry-off on commit, then the new page slides in from the opposite side. */
+const EXIT_FRACTION = 0.3
+const EXIT_MS = 160
+const EXIT_FADE_MS = 140
+const RETURN_MS = 220
+const ENTRY_OFFSET = 32
+const ENTRY_MS = 260
+const ENTRY_FADE_MS = 220
+/** Backstop: if a commit somehow doesn't change the content, un-hide the page. */
+const ENTRY_RECOVERY_MS = 500
+
+const EASE_OUT = Easing.out(Easing.cubic)
+
+const PILL_W = 40
+const PILL_H = 54
+/** Resting inset of the pill from the screen edge once fully in. */
+const PILL_INSET = 10
+
+export type ChapterSwipeProps = {
+  /** The reading itself (spinner / error / verses — whatever the screen renders). */
+  children: ReactNode
+  /**
+   * Changes whenever the rendered content changes (passage, translation, or
+   * load state). Each change plays the entrance: a slide-in from the trailing
+   * edge after a committed swipe, a plain cross-fade otherwise.
+   */
+  contentKey: string
+  canGoNext: boolean
+  canGoPrev: boolean
+  onGoNext: () => void
+  onGoPrev: () => void
+  /**
+   * Right-to-left reading order (e.g. Hebrew). Only the mapping from drag
+   * direction to next/previous flips; the pills stay geometric — the pill on
+   * the right edge always carries `chevron.right`, which reads as "forward" in
+   * LTR and "back" in RTL, matching where those chapters live on screen.
+   */
+  rtl?: boolean
+  /**
+   * Rendered above the page but OUTSIDE the moving layer — floating chrome
+   * (the copy FAB) should not slide or fade with the reading.
+   */
+  overlay?: ReactNode
+}
+
+export default function ChapterSwipe({
+  children,
+  contentKey,
+  canGoNext,
+  canGoPrev,
+  onGoNext,
+  onGoPrev,
+  rtl = false,
+  overlay,
+}: ChapterSwipeProps) {
+  const { width } = useWindowDimensions()
+  const threshold = swipeThreshold(width)
+
+  const dx = useSharedValue(0)
+  const pageOpacity = useSharedValue(1)
+  /** 1 while a commit is carrying the page off — further drags are ignored. */
+  const locked = useSharedValue(0)
+  /** Latch so the threshold haptic fires once per crossing, not per frame. */
+  const armed = useSharedValue(0)
+
+  // Which edge the next content should enter from: +1 = from the right (a
+  // forward swipe carried the old page off to the left), -1 = from the left,
+  // 0 = no slide (chip tap, translation switch, first load).
+  const entryFrom = useRef(0)
+  const recovery = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const tick = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {})
+  }, [])
+
+  // Play the arrival: `from` slides the new content in from that edge (a
+  // committed swipe), 0 just cross-fades it (chip tap, translation, first load).
+  const enter = useCallback(
+    (from: number) => {
+      locked.value = 0
+      armed.value = 0
+      dx.value = from * ENTRY_OFFSET
+      pageOpacity.value = 0
+      if (from) dx.value = withTiming(0, { duration: ENTRY_MS, easing: EASE_OUT })
+      pageOpacity.value = withTiming(1, { duration: ENTRY_FADE_MS })
+    },
+    [dx, pageOpacity, locked, armed],
+  )
+
+  // Committed: record which edge the replacement comes in from, then advance.
+  // The drag is gated on canGoNext/canGoPrev, so the passage really does change
+  // and the entrance below really does fire. The timer is a backstop only — it
+  // guarantees a carried-off page can never be left parked off-screen and
+  // invisible, whatever a host screen does with onGoNext/onGoPrev.
+  const advance = useCallback(
+    (forward: boolean) => {
+      entryFrom.current = forward ? 1 : -1
+      if (forward) onGoNext()
+      else onGoPrev()
+      const stranded = setTimeout(() => {
+        if (entryFrom.current !== 0) {
+          entryFrom.current = 0
+          enter(0)
+        }
+      }, ENTRY_RECOVERY_MS)
+      recovery.current = stranded
+    },
+    [onGoNext, onGoPrev, enter],
+  )
+
+  // The single owner of the entrance, for every content change.
+  useEffect(() => {
+    const from = entryFrom.current
+    entryFrom.current = 0
+    if (recovery.current) clearTimeout(recovery.current)
+    enter(from)
+  }, [contentKey, enter])
+
+  useEffect(() => () => { if (recovery.current) clearTimeout(recovery.current) }, [])
+
+  const pan = Gesture.Pan()
+    // Horizontal dominance: activate only on a sideways drag, and bail out the
+    // moment the finger goes vertical so the reading still scrolls normally.
+    .activeOffsetX([-14, 14])
+    .failOffsetY([-16, 16])
+    .onUpdate((e) => {
+      if (locked.value) return
+      const raw = e.translationX
+      const forward = isForwardDrag(raw, rtl)
+      const hasNeighbour = forward ? canGoNext : canGoPrev
+      dx.value = dragTravel(raw, threshold, hasNeighbour)
+
+      // The threshold haptic — one tick per crossing, and it re-arms on the way
+      // back so the notch can be felt in both directions. Never at a wall.
+      const nowArmed = hasNeighbour && Math.abs(dx.value) >= threshold ? 1 : 0
+      if (nowArmed !== armed.value) {
+        armed.value = nowArmed
+        if (nowArmed) runOnJS(tick)()
+      }
+    })
+    .onEnd((e) => {
+      if (locked.value) return
+      armed.value = 0
+      const travelled = Math.abs(dx.value)
+      const forward = isForwardDrag(dx.value, rtl)
+
+      if (
+        (forward ? canGoNext : canGoPrev) &&
+        shouldCommitSwipe(travelled, e.velocityX, threshold)
+      ) {
+        locked.value = 1
+        const exitTo = (dx.value < 0 ? -1 : 1) * width * EXIT_FRACTION
+        pageOpacity.value = withTiming(0, { duration: EXIT_FADE_MS })
+        dx.value = withTiming(exitTo, { duration: EXIT_MS, easing: EASE_OUT }, (finished) => {
+          if (finished) runOnJS(advance)(forward)
+        })
+        return
+      }
+      dx.value = withTiming(0, { duration: RETURN_MS, easing: EASE_OUT })
+    })
+    // A cancelled gesture (system pan-out, another handler winning) still has to
+    // drop the haptic latch and put the page back.
+    .onFinalize((_e, success) => {
+      armed.value = 0
+      if (!success && !locked.value) {
+        dx.value = withTiming(0, { duration: RETURN_MS, easing: EASE_OUT })
+      }
+    })
+
+  const pageStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: dx.value }],
+    opacity: pageOpacity.value,
+  }))
+
+  return (
+    <View style={{ flex: 1 }}>
+      <GestureDetector gesture={pan}>
+        <Animated.View style={[{ flex: 1 }, pageStyle]}>{children}</Animated.View>
+      </GestureDetector>
+
+      {/* Edge affordances. Geometric, not semantic: the right pill answers a
+          leftward drag whichever chapter that lands on. Both sit outside the
+          moving layer so they hold still while the page travels. */}
+      <EdgePill side="right" dx={dx} threshold={threshold} enabled={rtl ? canGoPrev : canGoNext} />
+      <EdgePill side="left" dx={dx} threshold={threshold} enabled={rtl ? canGoNext : canGoPrev} />
+
+      {overlay}
+    </View>
+  )
+}
+
+/**
+ * One edge chevron. It rides in from off-screen as the drag progresses, dim
+ * until the commit threshold, then cross-fades to an accent-filled "armed"
+ * state — the moment the haptic fires and letting go will change chapter.
+ * Purely decorative: the chapter chips above the reading are the accessible
+ * navigation, so this is hidden from assistive tech and takes no touches.
+ */
+function EdgePill({
+  side,
+  dx,
+  threshold,
+  enabled,
+}: {
+  side: 'left' | 'right'
+  dx: SharedValue<number>
+  threshold: number
+  enabled: boolean
+}) {
+  const t = useTheme()
+  // A right-edge pill answers a leftward (negative) drag, and vice versa.
+  const sign = side === 'right' ? -1 : 1
+  const offscreen = (PILL_W + PILL_INSET + 8) * -sign
+
+  const wrapStyle = useAnimatedStyle(() => {
+    // Same style keys every frame — Reanimated needs a stable shape.
+    const progress = swipeProgress(enabled ? dx.value * sign : 0, threshold)
+    return {
+      opacity: interpolate(progress, [0, 0.12, 1], [0, 0.55, 1]),
+      transform: [
+        { translateX: offscreen * (1 - progress) },
+        { scale: interpolate(progress, [0, 1], [0.88, 1]) },
+      ],
+    }
+  })
+
+  // Cross-fade to the armed look over the last stretch before the threshold.
+  const armedStyle = useAnimatedStyle(() => {
+    const travel = enabled ? dx.value * sign : 0
+    return {
+      opacity: travel <= 0 ? 0 : interpolate(travel / threshold, [0.8, 1], [0, 1], 'clamp'),
+    }
+  })
+
+  const face = {
+    width: PILL_W,
+    height: PILL_H,
+    borderRadius: t.radii.md,
+    borderWidth: 1,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  }
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        {
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          [side]: PILL_INSET,
+          justifyContent: 'center',
+        },
+        wrapStyle,
+      ]}
+    >
+      <View>
+        <View style={{ ...face, backgroundColor: t.colors.surfaceAlt, borderColor: t.colors.border }}>
+          <SymbolIcon
+            name={side === 'right' ? 'chevron.right' : 'chevron.left'}
+            size={19}
+            color={t.colors.muted}
+            weight="semibold"
+          />
+        </View>
+        <Animated.View
+          style={[
+            {
+              ...face,
+              position: 'absolute',
+              backgroundColor: t.colors.accentSoft,
+              borderColor: t.colors.accent,
+            },
+            armedStyle,
+          ]}
+        >
+          <SymbolIcon
+            name={side === 'right' ? 'chevron.right' : 'chevron.left'}
+            size={19}
+            color={t.colors.textAccent}
+            weight="semibold"
+          />
+        </Animated.View>
+      </View>
+    </Animated.View>
+  )
+}

--- a/apps/mobile/src/lib/__tests__/readerSwipe.test.ts
+++ b/apps/mobile/src/lib/__tests__/readerSwipe.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import {
+  END_MAX,
+  FLICK_VELOCITY,
+  OVERDRAG_MAX,
+  THRESHOLD_MAX,
+  THRESHOLD_MIN,
+  dragTravel,
+  isForwardDrag,
+  shouldCommitSwipe,
+  swipeProgress,
+  swipeThreshold,
+} from '../readerSwipe'
+
+// A representative phone width; 390 * 0.22 = 85.8, inside the clamp.
+const PHONE = 390
+const PHONE_THRESHOLD = swipeThreshold(PHONE)
+
+describe('swipeThreshold', () => {
+  it('scales with the window between the min and max clamps', () => {
+    expect(PHONE_THRESHOLD).toBeCloseTo(85.8)
+  })
+
+  it('clamps so a tiny window still needs a real drag', () => {
+    expect(swipeThreshold(200)).toBe(THRESHOLD_MIN)
+  })
+
+  it('clamps so a tablet does not demand an arm-length swipe', () => {
+    expect(swipeThreshold(1024)).toBe(THRESHOLD_MAX)
+  })
+})
+
+describe('isForwardDrag', () => {
+  it('treats a leftward drag as forward when reading left-to-right', () => {
+    expect(isForwardDrag(-40, false)).toBe(true)
+    expect(isForwardDrag(40, false)).toBe(false)
+  })
+
+  it('flips for right-to-left scripts', () => {
+    expect(isForwardDrag(-40, true)).toBe(false)
+    expect(isForwardDrag(40, true)).toBe(true)
+  })
+})
+
+describe('dragTravel', () => {
+  it('tracks the finger 1:1 up to the threshold, in both directions', () => {
+    expect(dragTravel(-30, PHONE_THRESHOLD, true)).toBe(-30)
+    expect(dragTravel(60, PHONE_THRESHOLD, true)).toBe(60)
+    expect(dragTravel(-PHONE_THRESHOLD, PHONE_THRESHOLD, true)).toBe(-PHONE_THRESHOLD)
+  })
+
+  it('slows past the threshold so the commit point reads as a detent', () => {
+    const past = dragTravel(-(PHONE_THRESHOLD + 100), PHONE_THRESHOLD, true)
+    expect(Math.abs(past)).toBeGreaterThan(PHONE_THRESHOLD)
+    expect(Math.abs(past)).toBeLessThan(PHONE_THRESHOLD + 100)
+  })
+
+  it('caps over-drag however far the finger goes', () => {
+    expect(Math.abs(dragTravel(-2000, PHONE_THRESHOLD, true))).toBe(PHONE_THRESHOLD + OVERDRAG_MAX)
+  })
+
+  it('never crosses the threshold at the first/last reading', () => {
+    for (const raw of [-40, -120, -400, -2000, 40, 120, 400, 2000]) {
+      const travel = Math.abs(dragTravel(raw, PHONE_THRESHOLD, false))
+      expect(travel).toBeLessThanOrEqual(END_MAX)
+      expect(travel).toBeLessThan(PHONE_THRESHOLD)
+    }
+  })
+
+  it('still moves a little at the wall, so the stop is felt not dead', () => {
+    expect(dragTravel(-100, PHONE_THRESHOLD, false)).toBeLessThan(0)
+  })
+
+  it('is monotonic and sign-preserving', () => {
+    let previous = 0
+    for (const raw of [-5, -50, -86, -150, -600]) {
+      const travel = dragTravel(raw, PHONE_THRESHOLD, true)
+      expect(travel).toBeLessThanOrEqual(previous)
+      previous = travel
+    }
+  })
+})
+
+describe('shouldCommitSwipe', () => {
+  it('commits a slow drag once it passes the threshold', () => {
+    expect(shouldCommitSwipe(PHONE_THRESHOLD, 0, PHONE_THRESHOLD)).toBe(true)
+    expect(shouldCommitSwipe(PHONE_THRESHOLD - 1, 0, PHONE_THRESHOLD)).toBe(false)
+  })
+
+  it('commits a fast flick from past halfway', () => {
+    const half = PHONE_THRESHOLD * 0.5
+    expect(shouldCommitSwipe(half + 1, -(FLICK_VELOCITY + 1), PHONE_THRESHOLD)).toBe(true)
+    expect(shouldCommitSwipe(half + 1, FLICK_VELOCITY + 1, PHONE_THRESHOLD)).toBe(true)
+  })
+
+  it('ignores a fast flick that barely moved', () => {
+    expect(shouldCommitSwipe(4, -3000, PHONE_THRESHOLD)).toBe(false)
+  })
+
+  it('ignores a slow drag that stopped short', () => {
+    expect(shouldCommitSwipe(PHONE_THRESHOLD * 0.9, 100, PHONE_THRESHOLD)).toBe(false)
+  })
+})
+
+describe('swipeProgress', () => {
+  it('runs 0 → 1 across the threshold and clamps beyond it', () => {
+    expect(swipeProgress(0, PHONE_THRESHOLD)).toBe(0)
+    expect(swipeProgress(PHONE_THRESHOLD / 2, PHONE_THRESHOLD)).toBeCloseTo(0.5)
+    expect(swipeProgress(PHONE_THRESHOLD, PHONE_THRESHOLD)).toBe(1)
+    expect(swipeProgress(PHONE_THRESHOLD * 3, PHONE_THRESHOLD)).toBe(1)
+  })
+
+  it('stays at 0 for a drag heading the other way', () => {
+    expect(swipeProgress(-50, PHONE_THRESHOLD)).toBe(0)
+  })
+})

--- a/apps/mobile/src/lib/readerSwipe.ts
+++ b/apps/mobile/src/lib/readerSwipe.ts
@@ -1,0 +1,79 @@
+// The arithmetic behind the reader's swipe-to-change-chapter gesture, kept out
+// of the component so the *feel* is a set of testable numbers rather than magic
+// constants buried in a worklet (`src/components/reader/ChapterSwipe.tsx`).
+//
+// Every function here is a Reanimated worklet — the gesture calls them on the UI
+// thread — but they are plain, dependency-free math, so `npm run test` exercises
+// them headless. The `'worklet'` directive is inert outside Reanimated.
+
+/** Commit distance: a share of the window, clamped so phones and tablets agree. */
+export const THRESHOLD_FRACTION = 0.22
+export const THRESHOLD_MIN = 64
+export const THRESHOLD_MAX = 120
+
+/** Drag past the threshold keeps moving, but slowed, so the notch is palpable. */
+export const OVERDRAG_RATE = 0.45
+export const OVERDRAG_MAX = 90
+
+/** Rubber band at the first/last reading: short, stiff, and it never commits. */
+export const END_RATE = 0.22
+export const END_MAX = 44
+
+/** A flick this fast commits even short of the distance threshold. */
+export const FLICK_VELOCITY = 900
+export const FLICK_MIN_FRACTION = 0.5
+
+/** How far the page must travel for a release to change chapter. */
+export function swipeThreshold(width: number): number {
+  'worklet'
+  return Math.min(THRESHOLD_MAX, Math.max(THRESHOLD_MIN, width * THRESHOLD_FRACTION))
+}
+
+/**
+ * Does a drag of `raw` px head toward the NEXT reading? Dragging left travels
+ * toward whatever sits to the right of the current page — the next chapter when
+ * reading left-to-right, the previous one in RTL.
+ */
+export function isForwardDrag(raw: number, rtl: boolean): boolean {
+  'worklet'
+  return rtl ? raw > 0 : raw < 0
+}
+
+/**
+ * How far the page actually moves for a finger displacement of `raw`.
+ *
+ *  • With a neighbour to go to: 1:1 up to the threshold, then slowed to
+ *    `OVERDRAG_RATE` and capped — the threshold is felt as a detent rather than
+ *    an invisible line.
+ *  • With no neighbour (first/last reading): a short, stiff rubber band that
+ *    tops out at `END_MAX`, so the wall is felt immediately.
+ */
+export function dragTravel(raw: number, threshold: number, hasNeighbour: boolean): number {
+  'worklet'
+  const magnitude = Math.abs(raw)
+  const sign = raw < 0 ? -1 : 1
+  if (!hasNeighbour) return sign * Math.min(END_MAX, magnitude * END_RATE)
+  if (magnitude <= threshold) return raw
+  return (
+    sign *
+    Math.min(threshold + OVERDRAG_MAX, threshold + (magnitude - threshold) * OVERDRAG_RATE)
+  )
+}
+
+/**
+ * Should releasing here change chapter? Either the page travelled past the
+ * threshold, or it was flicked hard enough from at least halfway — a fast flick
+ * reads as intent even when the finger didn't cover the distance.
+ */
+export function shouldCommitSwipe(travelled: number, velocityX: number, threshold: number): boolean {
+  'worklet'
+  if (travelled >= threshold) return true
+  return Math.abs(velocityX) > FLICK_VELOCITY && travelled > threshold * FLICK_MIN_FRACTION
+}
+
+/** 0 → 1 as the page approaches the commit threshold (drives the edge chevron). */
+export function swipeProgress(travelled: number, threshold: number): number {
+  'worklet'
+  if (travelled <= 0) return 0
+  return Math.min(1, travelled / threshold)
+}

--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Animated,
-  PanResponder,
   Pressable,
   ScrollView,
   Text,
@@ -28,11 +27,12 @@ import Screen from '../components/Screen'
 import SymbolIcon from '../components/SymbolIcon'
 import GlassSurface from '../components/GlassSurface'
 import EmptyState from '../components/EmptyState'
+import ChapterSwipe from '../components/reader/ChapterSwipe'
 import ReaderSettingsSheet from '../components/reader/ReaderSettingsSheet'
 import TranslationPickerSheet from '../components/reader/TranslationPickerSheet'
 import DatePickerSheet from '../components/reader/DatePickerSheet'
 import { useTheme } from '../theme/ThemeProvider'
-import { expandReadings, getPlanForDate } from '../lib/bibleSource'
+import { expandReadings, getPassage, getPlanForDate } from '../lib/bibleSource'
 import {
   defaultTranslationForLocale,
   setBibleTranslationPref,
@@ -103,7 +103,6 @@ export default function DailyWordScreen({
   const [sheet, setSheet] = useState<Sheet>('none')
   const [reloadToken, setReloadToken] = useState(0)
 
-  const fade = useRef(new Animated.Value(1)).current
   // Copy FAB press feedback: 0 = resting, 1 = pressed (scale-down + dim).
   const fabPress = useRef(new Animated.Value(0)).current
 
@@ -157,38 +156,40 @@ export default function DailyWordScreen({
     if (chapter && streakDateKey(date) === streakDateKey(new Date())) markReadToday()
   }, [chapter, date])
 
-  // Fade the reading region in whenever new chapter content arrives (chapter
-  // switch, translation switch, or first load). The Animated.View is persistent
-  // (wraps every state), so the animation never targets an unmounted node.
+  const changePassage = useCallback(
+    (next: number) => {
+      if (next < 0 || next >= passages.length) return
+      setPassageIndex((current) => (next === current ? current : next))
+    },
+    [passages.length],
+  )
+  const goNext = useCallback(() => changePassage(passageIndex + 1), [changePassage, passageIndex])
+  const goPrev = useCallback(() => changePassage(passageIndex - 1), [changePassage, passageIndex])
+
+  // Warm the chapters on either side so a committed swipe lands on real text
+  // instead of a spinner. `prefetchToday` only covers today in the DEFAULT
+  // translation; this covers whatever date/translation is actually open. Cached
+  // and in-flight chapters de-dupe inside `getPassage`, so this is cheap.
   useEffect(() => {
-    if (!chapter) return
-    fade.setValue(0)
-    Animated.timing(fade, { toValue: 1, duration: 200, useNativeDriver: true }).start()
-  }, [chapter, fade])
+    if (!selectedTranslation) return
+    for (const neighbour of [passages[passageIndex - 1], passages[passageIndex + 1]]) {
+      if (neighbour) getPassage({ passage: neighbour, translation: selectedTranslation }).catch(() => {})
+    }
+  }, [passages, passageIndex, selectedTranslation])
 
-  function changePassage(next: number) {
-    if (next < 0 || next >= passages.length || next === passageIndex) return
-    setPassageIndex(next)
-  }
-
-  const pan = useRef(
-    PanResponder.create({
-      onMoveShouldSetPanResponder: (_e, g) => Math.abs(g.dx) > 14 && Math.abs(g.dx) > Math.abs(g.dy) * 1.2,
-      onPanResponderRelease: (_e, g) => {
-        if (Math.abs(g.dx) < 50) return
-        const forward = g.dx < 0 ? 1 : -1
-        const dir = rtlRef.current ? -forward : forward
-        changePassageRef.current(indexRef.current + dir)
-      },
-    })
-  ).current
-  // Keep the PanResponder (created once) reading current values.
-  const rtlRef = useRef(rtl)
-  rtlRef.current = rtl
-  const indexRef = useRef(passageIndex)
-  indexRef.current = passageIndex
-  const changePassageRef = useRef(changePassage)
-  changePassageRef.current = changePassage
+  // Identifies exactly what the reading area is showing: the passage, the
+  // translation, and which of the four branches below is rendered. ChapterSwipe
+  // replays its entrance on every change, so each distinct view arrives with an
+  // animation (a settled one never re-animates) — this is what makes a chapter
+  // land with a fade whether it came from a swipe, a chip, or a first load.
+  const view = loading
+    ? 'loading'
+    : error
+      ? 'error'
+      : versesInScope.length === 0
+        ? 'empty'
+        : 'verses'
+  const contentKey = `${passageKey}|${selectedTranslation?.id ?? ''}|${view}`
 
   // Copy only the current chapter's selected verses; leave the highlights in
   // place so they persist through the day.
@@ -216,6 +217,56 @@ export default function DailyWordScreen({
   function toggle(num: number) {
     toggleVerse(passageKey, num)
   }
+
+  // Copy FAB — appears while a selection exists (no count badge). Handed to
+  // ChapterSwipe as its overlay so it stays put while the reading slides.
+  const copyFab =
+    selection.size > 0 ? (
+      <Animated.View
+        style={{
+          position: 'absolute',
+          bottom: insets.bottom + t.spacing.xl,
+          [rtl ? 'left' : 'right']: t.spacing.lg,
+          opacity: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.85] }),
+          transform: [
+            { scale: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.9] }) },
+          ],
+        }}
+      >
+        <Pressable
+          onPress={onCopy}
+          onPressIn={() =>
+            Animated.timing(fabPress, { toValue: 1, duration: 90, useNativeDriver: true }).start()
+          }
+          onPressOut={() => Animated.spring(fabPress, { toValue: 0, useNativeDriver: true }).start()}
+          accessibilityRole="button"
+          accessibilityLabel={tx('copyVerses', { count: selection.size })}
+          style={{ borderRadius: t.radii.pill }}
+        >
+          {/* Liquid Glass on iOS 26 (accent-tinted); solid accent fill on
+              iOS < 26 and Android via GlassSurface's fallback. */}
+          <GlassSurface
+            isInteractive
+            glassTint={t.colors.accent}
+            fallbackColor={t.colors.accent}
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: t.radii.pill,
+              alignItems: 'center',
+              justifyContent: 'center',
+              shadowColor: t.colors.accent,
+              shadowOpacity: 0.45,
+              shadowRadius: 12,
+              shadowOffset: { width: 0, height: 6 },
+              elevation: 8,
+            }}
+          >
+            <SymbolIcon name="doc.on.doc" size={23} color={t.colors.onAccent} />
+          </GlassSurface>
+        </Pressable>
+      </Animated.View>
+    ) : null
 
   const controlButton = {
     flexDirection: 'row' as const,
@@ -348,9 +399,21 @@ export default function DailyWordScreen({
         </ScrollView>
       </View>
 
-      {/* Reading area — one persistent Animated.View wraps every state so the
-          fade never targets an unmounted node. */}
-      <Animated.View style={{ flex: 1, opacity: fade }} {...pan.panHandlers}>
+      {/* Reading area. ChapterSwipe owns the horizontal drag (page tracks the
+          finger, edge chevron arms at the threshold, release commits) and the
+          entrance animation for every content change. Its moving layer wraps
+          every state, so an animation never targets an unmounted node; the copy
+          FAB goes in `overlay`, outside that layer, so it neither slides nor
+          fades with the reading. */}
+      <ChapterSwipe
+        contentKey={contentKey}
+        canGoNext={passageIndex < passages.length - 1}
+        canGoPrev={passageIndex > 0}
+        onGoNext={goNext}
+        onGoPrev={goPrev}
+        rtl={rtl}
+        overlay={copyFab}
+      >
         {loading ? (
           <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             <ActivityIndicator color={t.colors.accent} />
@@ -432,57 +495,7 @@ export default function DailyWordScreen({
               )}
           </ScrollView>
         )}
-
-        {/* Copy FAB — appears while a selection exists (no count badge). */}
-        {selection.size > 0 ? (
-          <Animated.View
-            style={{
-              position: 'absolute',
-              bottom: insets.bottom + t.spacing.xl,
-              [rtl ? 'left' : 'right']: t.spacing.lg,
-              opacity: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.85] }),
-              transform: [
-                { scale: fabPress.interpolate({ inputRange: [0, 1], outputRange: [1, 0.9] }) },
-              ],
-            }}
-          >
-            <Pressable
-              onPress={onCopy}
-              onPressIn={() =>
-                Animated.timing(fabPress, { toValue: 1, duration: 90, useNativeDriver: true }).start()
-              }
-              onPressOut={() =>
-                Animated.spring(fabPress, { toValue: 0, useNativeDriver: true }).start()
-              }
-              accessibilityRole="button"
-              accessibilityLabel={tx('copyVerses', { count: selection.size })}
-              style={{ borderRadius: t.radii.pill }}
-            >
-              {/* Liquid Glass on iOS 26 (accent-tinted); solid accent fill on
-                  iOS < 26 and Android via GlassSurface's fallback. */}
-              <GlassSurface
-                isInteractive
-                glassTint={t.colors.accent}
-                fallbackColor={t.colors.accent}
-                style={{
-                  width: 56,
-                  height: 56,
-                  borderRadius: t.radii.pill,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  shadowColor: t.colors.accent,
-                  shadowOpacity: 0.45,
-                  shadowRadius: 12,
-                  shadowOffset: { width: 0, height: 6 },
-                  elevation: 8,
-                }}
-              >
-                <SymbolIcon name="doc.on.doc" size={23} color={t.colors.onAccent} />
-              </GlassSurface>
-            </Pressable>
-          </Animated.View>
-        ) : null}
-      </Animated.View>
+      </ChapterSwipe>
 
       <TranslationPickerSheet
         visible={sheet === 'translations'}


### PR DESCRIPTION
The Daily Word reader's swipe was an invisible switch: nothing moved during
the drag, a 50px release threshold decided silently, and the only feedback
was the new chapter fading in afterwards. There was no way to tell a swipe
was being tracked, which way it would go, or whether it would take.

Rebuild it as direct manipulation, modelled on the Bible app's reader:

- The page tracks the finger — 1:1 up to the commit threshold (22% of the
  window, clamped 64–120), then slowed and capped so the threshold reads as
  a detent rather than an invisible line.
- A chevron pill slides in from the edge you pull away from, dim at first
  and cross-fading to an accent-filled "armed" state as the threshold
  approaches. Crossing it fires one light haptic, and dragging back under
  re-arms so the notch is felt both ways.
- Release past the threshold — or a quick flick from past halfway — carries
  the page off and commits; short of it, it springs back untouched.
- At the first/last reading the drag rubber-bands against a short stop with
  no pill and no haptic.

The neighbouring chapter isn't rendered during the drag; the commit plays as
carry-off then new content in from the opposite edge. That entrance is now
replayed for every content change (`contentKey`), which subsumes the old
chapter-arrival fade and covers chip taps and translation switches too. The
copy FAB moves out of the moving layer so it no longer slides or fades with
the reading, and `DailyWordScreen` prefetches the chapters on either side so
a committed swipe lands on text instead of a spinner.

The pills are geometric, not semantic — the right-edge pill always carries
`chevron.right`, which reads as forward in LTR and back in RTL — and they're
decorative (no touches, hidden from assistive tech): the chapter chips above
the reading remain the accessible navigation.

Drag math lives in `src/lib/readerSwipe.ts` as pure worklets so the feel is
unit-tested headless rather than buried in constants.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014vyfZK28Tenm3U8CgBme6s