### PR TITLE
Add request budgets and improve error handling

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "GraceChords",
     "slug": "gracechords",
     "scheme": "gracechords",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -18,7 +18,9 @@ import {
   supabaseConfigError,
 } from '../src/lib/supabase'
 import { resolveInitialSession } from '../src/lib/authSession'
+import { setCurrentUserFromSession } from '../src/lib/currentUser'
 import { flushPendingSprite } from '../src/lib/profile'
+import { primeLaunchStorage } from '../src/lib/launchStorage'
 import { hydrateDefaults } from '../src/lib/defaults'
 import { hydrateBibleTranslationPref } from '../src/lib/bibleTranslationPref'
 import { prefetchToday } from '../src/lib/bibleSource'
@@ -191,23 +193,36 @@ export default function RootLayout() {
     // below so the first paint already reflects any enabled setting; `stop`
     // removes the OS listeners on unmount.
     const a11y = startAccessibilityFlags()
-    // Load app-wide defaults (theme/chord style) before the splash lifts so the
-    // resolved theme is applied on first paint — no light→dark flash. Runs in
-    // parallel with the session read; both must resolve before `ready`.
-    // Hydrate device-local stores (defaults, download manifest, recent-song
-    // history) alongside the session read. They must resolve before `ready` so
-    // the first paint has the resolved theme, offline reads know what's
-    // downloaded, and Home's "Continue" card can render synchronously.
+    // Hydrate the device-local stores (defaults, download manifest, recent-song
+    // history, …) alongside the session read. They must all resolve before
+    // `ready` so the first paint has the resolved theme (no light→dark flash),
+    // offline reads know what's downloaded, and Home's "Continue" card can render
+    // synchronously.
+    //
+    // Start the session read FIRST so it still overlaps the storage work below.
+    // primeLaunchStorage awaits a multiGet before any store hydrates, and if the
+    // session read were nested behind it the two would serialise and cold launch
+    // would regress — the whole point of batching is to be no slower.
+    const sessionRead = resolveInitialSession(supabase.auth)
+    // One AsyncStorage round trip for all 12 launch keys instead of 12 separate
+    // getItem calls. The stores themselves are untouched: they receive a
+    // KVStorage that answers from the batch, so every missing/null/malformed
+    // fallback is byte-for-byte what it was. See launchStorage.ts.
+    const hydrated = primeLaunchStorage(AsyncStorage).then((store) =>
+      Promise.all([
+        hydrateDefaults(store),
+        hydrateDownloads(store),
+        hydrateDrafts(store),
+        hydrateRecents(store),
+        hydrateReadingStreak(store),
+        hydrateReaderReminder(store),
+        hydrateViewerPrefs(store),
+        hydrateBibleTranslationPref(store),
+      ]),
+    )
     Promise.all([
-      resolveInitialSession(supabase.auth),
-      hydrateDefaults(AsyncStorage),
-      hydrateDownloads(AsyncStorage),
-      hydrateDrafts(AsyncStorage),
-      hydrateRecents(AsyncStorage),
-      hydrateReadingStreak(AsyncStorage),
-      hydrateReaderReminder(AsyncStorage),
-      hydrateViewerPrefs(AsyncStorage),
-      hydrateBibleTranslationPref(AsyncStorage),
+      sessionRead,
+      hydrated,
       // Load the Material Symbols subset fonts before the splash lifts so
       // Android never paints a missing glyph on first frame. iOS renders icons
       // through SF Symbols natively (SymbolIcon), so there is nothing to load
@@ -224,24 +239,38 @@ export default function RootLayout() {
       // Resolve the initial accessibility-flag query before the splash lifts so
       // the contrast overlay (if enabled) is applied on first paint — no flash.
       a11y.ready,
-    ]).then(([session, defaults]) => {
-      // Apply the stored language pick (null = follow device) while the splash
-      // is still up, so a non-device language never flashes on first paint.
-      applyLanguagePreference(defaults.language)
-      setSession(session)
-      setReady(true)
-      // Reconcile the OS-scheduled Daily Word reminder with the stored
-      // preference now that it (and the language) are loaded. Best-effort.
-      void syncReaderReminderOnLaunch()
-      // Start AppState-driven token auto-refresh only AFTER the persisted
-      // session is resolved. resolveInitialSession has already purged any
-      // stale/revoked refresh token from storage, so the immediate refresh tick
-      // can't fire against a dead token and log "Invalid Refresh Token: Refresh
-      // Token Not Found" on launch.
-      stopAutoRefresh = registerAuthAutoRefresh()
-    })
+    ])
+      .then(([session, [defaults]]) => {
+        // Apply the stored language pick (null = follow device) while the splash
+        // is still up, so a non-device language never flashes on first paint.
+        applyLanguagePreference(defaults.language)
+        setSession(session)
+        // Publish the resolved user to the shared store BEFORE `ready` flips, so
+        // any screen that mounts already sees a resolved auth state. This is the
+        // only source of user identity in the app — see src/lib/currentUser.ts.
+        setCurrentUserFromSession(session)
+        setReady(true)
+        // Reconcile the OS-scheduled Daily Word reminder with the stored
+        // preference now that it (and the language) are loaded. Best-effort.
+        void syncReaderReminderOnLaunch()
+        // Start AppState-driven token auto-refresh only AFTER the persisted
+        // session is resolved. resolveInitialSession has already purged any
+        // stale/revoked refresh token from storage, so the immediate refresh tick
+        // can't fire against a dead token and log "Invalid Refresh Token: Refresh
+        // Token Not Found" on launch.
+        stopAutoRefresh = registerAuthAutoRefresh()
+      })
+      // Every member above already resolves to a default on failure, so this is
+      // a backstop rather than a live failure path — but it was the one
+      // unprotected join in the launch path, and a rejection here would leave
+      // `ready` false forever. The 2 s route safety net below cannot help: it is
+      // gated on `if (!ready) return`, so it never arms. Same reasoning as build
+      // 12's Font.loadAsync().catch — lifting the splash into a signed-out app
+      // with default preferences beats holding it indefinitely.
+      .catch(() => setReady(true))
     const { data: sub } = supabase.auth.onAuthStateChange((event, next) => {
       setSession(next)
+      setCurrentUserFromSession(next)
       // A sprite picked before the session existed (email-confirmation flow,
       // or a transient write failure) is flushed on sign-in. Fire-and-forget:
       // a preference must never block auth.

--- a/apps/mobile/app/viewer/[slug].tsx
+++ b/apps/mobile/app/viewer/[slug].tsx
@@ -388,7 +388,10 @@ export default function ViewerScreen() {
             {tx('errors:couldntLoadSong')}
           </Text>
           <Text style={{ marginTop: t.spacing.sm, fontSize: 13.5, color: t.colors.muted, textAlign: 'center' }}>
-            {error || tx('errors:songNotFound')}
+            {/* `error` is an i18n key from useSong, never raw error text. A
+                missing row is not an error (useSong resolves it to song === null),
+                so the no-error branch is the not-found case. */}
+            {error ? tx(error) : tx('errors:songNotFound')}
           </Text>
         </View>
       ) : doc ? (

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gracechords/mobile",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/mobile/src/components/AccidentalToggle.tsx
+++ b/apps/mobile/src/components/AccidentalToggle.tsx
@@ -32,12 +32,20 @@ export default function AccidentalToggle({
 
   const cell = (v: Accidental, glyph: string, label: string) => {
     const selected = value === v
+    const first = v === 'sharp'
     return (
       <Pressable
         onPress={() => onChange(v)}
         accessibilityRole="button"
         accessibilityLabel={label}
         accessibilityState={{ selected }}
+        // 44pt touch target without changing the rendered 33 × 30 cell. Per-edge,
+        // not a scalar, for the same reason as SegmentedPill: the two cells are
+        // flush siblings with a 0pt gap, so symmetric slop would overlap the
+        // neighbour's visible bounds and make a near-boundary tap ambiguous.
+        // Interior edge gets zero; the outer edges carry the 12pt (33 + 12 = 45),
+        // and there is no interactive sibling outward — just the row's label.
+        hitSlop={{ top: 7, bottom: 7, left: first ? 12 : 0, right: first ? 0 : 12 }}
         style={{
           flexDirection: 'row',
           alignItems: 'center',

--- a/apps/mobile/src/components/AlphaScrubber.tsx
+++ b/apps/mobile/src/components/AlphaScrubber.tsx
@@ -105,7 +105,7 @@ export default function AlphaScrubber({
                   fontWeight: '600',
                   lineHeight: 15,
                   textAlign: 'center',
-                  color: active ? t.colors.accent : t.colors.off,
+                  color: active ? t.colors.textAccent : t.colors.off,
                 }}
               >
                 {letter}

--- a/apps/mobile/src/components/ExportSheet.tsx
+++ b/apps/mobile/src/components/ExportSheet.tsx
@@ -190,9 +190,9 @@ function SecondaryRow({
       </View>
       <View style={{ flex: 1 }}>
         <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
-        {subtitle ? <Text style={{ fontSize: 11.5, color: t.colors.muted }}>{subtitle}</Text> : null}
+        {subtitle ? <Text style={{ fontSize: 11.5, color: t.colors.sec }}>{subtitle}</Text> : null}
       </View>
-      <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+      <SymbolIcon name="chevron.right" size={14} color={t.colors.sec} />
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/FilterSortSheet.tsx
+++ b/apps/mobile/src/components/FilterSortSheet.tsx
@@ -83,7 +83,7 @@ function FilterSortContent({
             fontWeight: t.typography.overline.fontWeight,
             letterSpacing: t.typography.overline.letterSpacing,
             textTransform: 'uppercase',
-            color: t.colors.muted,
+            color: t.colors.sec,
             paddingBottom: t.spacing.sm,
           }}
         >
@@ -132,7 +132,7 @@ function FilterSortContent({
                 fontWeight: t.typography.overline.fontWeight,
                 letterSpacing: t.typography.overline.letterSpacing,
                 textTransform: 'uppercase',
-                color: t.colors.muted,
+                color: t.colors.sec,
                 paddingBottom: t.spacing.md,
                 marginTop: t.spacing.xl,
               }}

--- a/apps/mobile/src/components/ListRow.tsx
+++ b/apps/mobile/src/components/ListRow.tsx
@@ -113,7 +113,7 @@ export default function ListRow({
               style={{
                 marginTop: 2,
                 fontSize: t.typography.rowMeta.fontSize,
-                color: t.colors.muted,
+                color: t.colors.sec,
               }}
             >
               {trailingBottom}
@@ -137,7 +137,7 @@ export default function ListRow({
 
       {trailing}
 
-      {chevron ? <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} /> : null}
+      {chevron ? <SymbolIcon name="chevron.right" size={14} color={t.colors.sec} /> : null}
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/LoadingSkeleton.tsx
+++ b/apps/mobile/src/components/LoadingSkeleton.tsx
@@ -58,7 +58,7 @@ export default function LoadingSkeleton({ label }: { label?: string }) {
     <View style={{ paddingHorizontal: t.spacing.xl, paddingTop: t.spacing.md }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: t.spacing.lg }}>
         <ActivityIndicator size="small" color={t.colors.accent} />
-        <Text style={{ fontSize: 13, color: t.colors.muted }}>{displayLabel}</Text>
+        <Text style={{ fontSize: 13, color: t.colors.sec }}>{displayLabel}</Text>
       </View>
 
       {ROWS.map((row, i) => (

--- a/apps/mobile/src/components/PersonalChip.tsx
+++ b/apps/mobile/src/components/PersonalChip.tsx
@@ -34,7 +34,7 @@ export function PendingBadge() {
         borderColor: t.colors.border,
       }}
     >
-      <Text style={{ fontSize: 11, fontWeight: '700', color: t.colors.muted }}>Pending</Text>
+      <Text style={{ fontSize: 11, fontWeight: '700', color: t.colors.sec }}>Pending</Text>
     </View>
   )
 }

--- a/apps/mobile/src/components/Placeholder.tsx
+++ b/apps/mobile/src/components/Placeholder.tsx
@@ -25,7 +25,7 @@ export default function Placeholder({ title }: { title: string }) {
         </Text>
       </View>
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+        <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec }}>
           {tx('comingSoon')}
         </Text>
       </View>

--- a/apps/mobile/src/components/SectionHeader.tsx
+++ b/apps/mobile/src/components/SectionHeader.tsx
@@ -21,7 +21,7 @@ export default function SectionHeader({ label }: { label: string }) {
           fontSize: t.typography.sectionHeader.fontSize,
           fontWeight: t.typography.sectionHeader.fontWeight,
           letterSpacing: t.typography.sectionHeader.letterSpacing,
-          color: t.colors.muted,
+          color: t.colors.sec,
         }}
       >
         {label}

--- a/apps/mobile/src/components/SegmentedPill.tsx
+++ b/apps/mobile/src/components/SegmentedPill.tsx
@@ -33,14 +33,38 @@ export default function SegmentedPill<T extends string>({
         padding: 3,
       }}
     >
-      {options.map((opt) => {
+      {options.map((opt, i) => {
         const selected = opt.value === value
+        const first = i === 0
+        const last = i === options.length - 1
         return (
           <Pressable
             key={opt.value}
             onPress={() => onChange(opt.value)}
             accessibilityRole="button"
             accessibilityState={{ selected }}
+            // Reach the 44pt minimum touch target without changing the rendered
+            // 30pt cell. Vertical is free: rows are spacing.xl (24) apart and the
+            // cell sits inside 3pt of track padding, so vertically adjacent cells
+            // are 30pt apart and 7pt each still leaves 16pt of clearance.
+            //
+            // Horizontal is NOT free, and this is why the slop is per-edge rather
+            // than a scalar. Cells are flush siblings with a 0pt gap, so a
+            // symmetric hitSlop would make each cell's region overlap its
+            // neighbour's VISIBLE bounds — a tap 2pt inside one cell could select
+            // the other, and which one wins depends on hit-test ordering. Giving
+            // interior edges zero slop keeps every region disjoint (they share
+            // only a zero-width boundary), so the outcome cannot be ambiguous.
+            //
+            // Only the track's outer edges expand, where the neighbour is the
+            // row's label Text — non-interactive, and 12pt away.
+            //
+            // A consequence worth knowing: an interior cell reaches 44pt wide on
+            // its own text width alone (24 + label). True for every label in every
+            // shipped locale — the narrowest interior label is ko "보통" (~52pt) —
+            // but a very short future translation of a 3-option pill's MIDDLE
+            // option would need its own fix, since it can borrow no slop.
+            hitSlop={{ top: 7, bottom: 7, left: first ? 12 : 0, right: last ? 12 : 0 }}
             style={{
               height: 30,
               paddingHorizontal: 12,

--- a/apps/mobile/src/components/TextField.tsx
+++ b/apps/mobile/src/components/TextField.tsx
@@ -88,12 +88,12 @@ export default function TextField({
           borderColor: focused ? t.colors.accent : t.colors.border,
         }}
       >
-        <SymbolIcon name={icon} size={18} color={t.colors.muted} />
+        <SymbolIcon name={icon} size={18} color={t.colors.sec} />
         <TextInput
           value={value}
           onChangeText={onChangeText}
           placeholder={placeholder}
-          placeholderTextColor={t.colors.muted}
+          placeholderTextColor={t.colors.sec}
           secureTextEntry={secureTextEntry && !revealed}
           keyboardType={keyboardType}
           autoCapitalize={autoCapitalize}
@@ -117,12 +117,12 @@ export default function TextField({
             accessibilityLabel={revealed ? tx('hidePassword') : tx('showPassword')}
             hitSlop={8}
           >
-            <SymbolIcon name={revealed ? 'eye.slash' : 'eye'} size={18} color={t.colors.muted} />
+            <SymbolIcon name={revealed ? 'eye.slash' : 'eye'} size={18} color={t.colors.sec} />
           </Pressable>
         ) : null}
       </View>
       {helperText ? (
-        <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: t.spacing.xs + 2 }}>
+        <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: t.spacing.xs + 2 }}>
           {helperText}
         </Text>
       ) : null}

--- a/apps/mobile/src/components/VerseChart.tsx
+++ b/apps/mobile/src/components/VerseChart.tsx
@@ -54,7 +54,7 @@ export default function VerseChart({ verseRef }: { verseRef: string }) {
 
   if (failed) {
     return (
-      <Text style={{ color: t.colors.muted, textAlign: 'center', marginTop: t.spacing.xl }}>
+      <Text style={{ color: t.colors.sec, textAlign: 'center', marginTop: t.spacing.xl }}>
         —
       </Text>
     )
@@ -71,7 +71,7 @@ export default function VerseChart({ verseRef }: { verseRef: string }) {
     <View style={{ gap: 10, maxWidth: 760, alignSelf: 'center', width: '100%' }}>
       {lines.map((ln, i) => (
         <View key={i} style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-start' }}>
-          <Text style={{ minWidth: ln.showChapter ? 46 : 28, textAlign: 'right', color: t.colors.muted, fontWeight: '600' }}>
+          <Text style={{ minWidth: ln.showChapter ? 46 : 28, textAlign: 'right', color: t.colors.sec, fontWeight: '600' }}>
             {ln.showChapter ? `${ln.chapter}:${ln.number}` : `${ln.number}`}
           </Text>
           <Text style={{ flex: 1, color: t.colors.ink, fontSize: 18, lineHeight: 26 }}>{ln.text}</Text>

--- a/apps/mobile/src/components/ViewOptionsSheet.tsx
+++ b/apps/mobile/src/components/ViewOptionsSheet.tsx
@@ -32,7 +32,7 @@ function OverlineLabel({ children, first }: { children: string; first?: boolean 
         fontWeight: t.typography.overline.fontWeight,
         letterSpacing: t.typography.overline.letterSpacing,
         textTransform: 'uppercase',
-        color: t.colors.muted,
+        color: t.colors.sec,
         marginTop: first ? 0 : t.spacing.xl,
         marginBottom: t.spacing.sm,
       }}

--- a/apps/mobile/src/components/home/DailyWordCard.tsx
+++ b/apps/mobile/src/components/home/DailyWordCard.tsx
@@ -72,7 +72,7 @@ export default function DailyWordCard() {
           ))}
         </View>
       ) : (
-        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
           {tx('dailyWordCard.empty')}
         </Text>
       )}

--- a/apps/mobile/src/components/home/RecentSongsCard.tsx
+++ b/apps/mobile/src/components/home/RecentSongsCard.tsx
@@ -44,7 +44,7 @@ export default function RecentSongsCard() {
       </Text>
 
       {recents.length === 0 ? (
-        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
           {tx('recentSongsCard.empty')}
         </Text>
       ) : (

--- a/apps/mobile/src/components/reader/ChapterSwipe.tsx
+++ b/apps/mobile/src/components/reader/ChapterSwipe.tsx
@@ -13,6 +13,7 @@ import Animated, {
 import * as Haptics from 'expo-haptics'
 import SymbolIcon from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
+import { useAccessibilityFlags } from '../../lib/accessibilityFlags'
 import {
   dragTravel,
   isForwardDrag,
@@ -106,12 +107,28 @@ export default function ChapterSwipe({
   const { width } = useWindowDimensions()
   const threshold = swipeThreshold(width)
 
+  // Reduce Motion: the finger-tracking drag itself is DELIBERATELY untouched —
+  // direct manipulation is not animation, and both the HIG and WCAG 2.3.3 exempt
+  // it, so suppressing it would break the gesture rather than calm it. What goes
+  // is the motion that plays on its own: the carry-off, the slide-in, and the
+  // spring-back. A cross-fade stays, which is the HIG-preferred reduced-motion
+  // transition. Mirrors LoadingSkeleton / autoHideChrome / SplashOverlay.
+  const { reduceMotion } = useAccessibilityFlags()
+
   const dx = useSharedValue(0)
   const pageOpacity = useSharedValue(1)
   /** 1 while a commit is carrying the page off — further drags are ignored. */
   const locked = useSharedValue(0)
   /** Latch so the threshold haptic fires once per crossing, not per frame. */
   const armed = useSharedValue(0)
+  // The gesture callbacks are worklets and cannot read the flag store (a plain JS
+  // closure over module state), so mirror it into a shared value. Done this way
+  // rather than by capturing the boolean so it stays correct even if `pan` is
+  // ever wrapped in a useMemo that forgets the dependency.
+  const noMotion = useSharedValue(reduceMotion)
+  useEffect(() => {
+    noMotion.value = reduceMotion
+  }, [reduceMotion, noMotion])
 
   // Which edge the next content should enter from: +1 = from the right (a
   // forward swipe carried the old page off to the left), -1 = from the left,
@@ -129,12 +146,17 @@ export default function ChapterSwipe({
     (from: number) => {
       locked.value = 0
       armed.value = 0
-      dx.value = from * ENTRY_OFFSET
+      // Reduce Motion: land the new content in place — no offset, no slide.
+      const slide = Boolean(from) && !reduceMotion
+      dx.value = slide ? from * ENTRY_OFFSET : 0
       pageOpacity.value = 0
-      if (from) dx.value = withTiming(0, { duration: ENTRY_MS, easing: EASE_OUT })
+      if (slide) dx.value = withTiming(0, { duration: ENTRY_MS, easing: EASE_OUT })
+      // NOT gated on reduceMotion, and it must never be: pageOpacity was just
+      // hard-set to 0 on the line above, for every content change. Skipping this
+      // fade would leave the reading permanently invisible rather than unanimated.
       pageOpacity.value = withTiming(1, { duration: ENTRY_FADE_MS })
     },
-    [dx, pageOpacity, locked, armed],
+    [dx, pageOpacity, locked, armed, reduceMotion],
   )
 
   // Committed: record which edge the replacement comes in from, then advance.
@@ -199,6 +221,17 @@ export default function ChapterSwipe({
         shouldCommitSwipe(travelled, e.velocityX, threshold)
       ) {
         locked.value = 1
+        if (noMotion.value) {
+          // Reduce Motion: cut straight to the commit. The chapter change lives in
+          // the completion callback of the carry-off below, so this branch MUST
+          // still call advance() — dropping the animation without it would leave
+          // the reader on the same passage, silently. Same shape, same fix as
+          // SplashOverlay's reduced-motion branch: run the callback synchronously.
+          dx.value = 0
+          pageOpacity.value = 0
+          runOnJS(advance)(forward)
+          return
+        }
         const exitTo = (dx.value < 0 ? -1 : 1) * width * EXIT_FRACTION
         pageOpacity.value = withTiming(0, { duration: EXIT_FADE_MS })
         dx.value = withTiming(exitTo, { duration: EXIT_MS, easing: EASE_OUT }, (finished) => {
@@ -206,14 +239,16 @@ export default function ChapterSwipe({
         })
         return
       }
-      dx.value = withTiming(0, { duration: RETURN_MS, easing: EASE_OUT })
+      // Released without committing: put the page back. Instantly under Reduce
+      // Motion — it is undoing a finger drag, so there is nothing to animate.
+      dx.value = withTiming(0, { duration: noMotion.value ? 0 : RETURN_MS, easing: EASE_OUT })
     })
     // A cancelled gesture (system pan-out, another handler winning) still has to
     // drop the haptic latch and put the page back.
     .onFinalize((_e, success) => {
       armed.value = 0
       if (!success && !locked.value) {
-        dx.value = withTiming(0, { duration: RETURN_MS, easing: EASE_OUT })
+        dx.value = withTiming(0, { duration: noMotion.value ? 0 : RETURN_MS, easing: EASE_OUT })
       }
     })
 
@@ -312,7 +347,7 @@ function EdgePill({
           <SymbolIcon
             name={side === 'right' ? 'chevron.right' : 'chevron.left'}
             size={19}
-            color={t.colors.muted}
+            color={t.colors.sec}
             weight="semibold"
           />
         </View>

--- a/apps/mobile/src/components/reader/DatePickerSheet.tsx
+++ b/apps/mobile/src/components/reader/DatePickerSheet.tsx
@@ -101,7 +101,7 @@ function DatePickerContent({ value, onSelect }: DatePickerProps) {
           {WEEKDAYS.map((d, i) => (
             <Text
               key={i}
-              style={{ flex: 1, textAlign: 'center', fontSize: 11, fontWeight: '600', color: t.colors.muted }}
+              style={{ flex: 1, textAlign: 'center', fontSize: 11, fontWeight: '600', color: t.colors.sec }}
             >
               {d}
             </Text>

--- a/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
+++ b/apps/mobile/src/components/reader/ReaderSettingsSheet.tsx
@@ -58,7 +58,7 @@ function OverlineLabel({ children, first }: { children: string; first?: boolean 
         fontWeight: t.typography.overline.fontWeight,
         letterSpacing: t.typography.overline.letterSpacing,
         textTransform: 'uppercase',
-        color: t.colors.muted,
+        color: t.colors.sec,
         marginTop: first ? 0 : t.spacing.xl,
         marginBottom: t.spacing.sm,
       }}
@@ -122,7 +122,7 @@ function ReaderSettingsContent({ onClose, settings, onChange }: ReaderSettingsPr
             <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.ink }}>−</Text>
           </Pressable>
           <Text
-            style={{ minWidth: 44, textAlign: 'center', fontSize: 14, fontWeight: '600', color: t.colors.muted }}
+            style={{ minWidth: 44, textAlign: 'center', fontSize: 14, fontWeight: '600', color: t.colors.sec }}
           >
             {tx('settings.pt', { pt: settings.pt })}
           </Text>

--- a/apps/mobile/src/components/reader/TranslationPickerSheet.tsx
+++ b/apps/mobile/src/components/reader/TranslationPickerSheet.tsx
@@ -50,7 +50,7 @@ function TranslationPickerContent({ onClose, groups, selectedId, onSelect }: Tra
                 fontWeight: '700',
                 letterSpacing: 0.7,
                 textTransform: 'uppercase',
-                color: t.colors.muted,
+                color: t.colors.sec,
                 paddingHorizontal: t.spacing.lg,
                 paddingTop: t.spacing.md,
                 paddingBottom: t.spacing.xs,

--- a/apps/mobile/src/components/setlist/AddSongsModal.tsx
+++ b/apps/mobile/src/components/setlist/AddSongsModal.tsx
@@ -82,19 +82,19 @@ export default function AddSongsModal({
               height: 44,
             }}
           >
-            <SymbolIcon name="magnifyingglass" size={18} color={t.colors.muted} />
+            <SymbolIcon name="magnifyingglass" size={18} color={t.colors.sec} />
             <TextInput
               value={query}
               onChangeText={setQuery}
               placeholder={tx('addSongs.searchPlaceholder')}
-              placeholderTextColor={t.colors.muted}
+              placeholderTextColor={t.colors.sec}
               returnKeyType="search"
               autoCorrect={false}
               style={{ flex: 1, fontSize: 16, color: t.colors.ink, padding: 0 }}
             />
             {query ? (
               <Pressable onPress={() => setQuery('')} accessibilityRole="button" accessibilityLabel={tx('addSongs.clearSearch')} hitSlop={8}>
-                <SymbolIcon name="xmark.circle.fill" size={17} color={t.colors.muted} />
+                <SymbolIcon name="xmark.circle.fill" size={17} color={t.colors.sec} />
               </Pressable>
             ) : null}
           </View>
@@ -108,7 +108,7 @@ export default function AddSongsModal({
           keyboardDismissMode="interactive"
           ListEmptyComponent={
             <View style={{ alignItems: 'center', padding: t.spacing.xl }}>
-              <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+              <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec }}>
                 {trimmed ? tx('addSongs.noMatches', { query: query.trim() }) : tx('addSongs.emptyLibrary')}
               </Text>
             </View>

--- a/apps/mobile/src/components/setlist/AddVerseModal.tsx
+++ b/apps/mobile/src/components/setlist/AddVerseModal.tsx
@@ -78,7 +78,7 @@ export default function AddVerseModal({
               value={ref}
               onChangeText={(v) => { setRef(v); if (error) setError(null) }}
               placeholder={tx('setlist:verse.placeholder')}
-              placeholderTextColor={t.colors.muted}
+              placeholderTextColor={t.colors.sec}
               autoFocus
               autoCapitalize="words"
               returnKeyType="done"

--- a/apps/mobile/src/components/setlist/LibraryPane.tsx
+++ b/apps/mobile/src/components/setlist/LibraryPane.tsx
@@ -61,12 +61,12 @@ export default function LibraryPane({
             height: 44,
           }}
         >
-          <SymbolIcon name="magnifyingglass" size={18} color={t.colors.muted} />
+          <SymbolIcon name="magnifyingglass" size={18} color={t.colors.sec} />
           <TextInput
             value={query}
             onChangeText={setQuery}
             placeholder={tx('libraryPane.searchPlaceholder')}
-            placeholderTextColor={t.colors.muted}
+            placeholderTextColor={t.colors.sec}
             returnKeyType="search"
             autoCorrect={false}
             accessibilityLabel={tx('libraryPane.searchLibrary')}
@@ -79,7 +79,7 @@ export default function LibraryPane({
               accessibilityLabel={tx('addSongs.clearSearch')}
               hitSlop={8}
             >
-              <SymbolIcon name="xmark.circle.fill" size={17} color={t.colors.muted} />
+              <SymbolIcon name="xmark.circle.fill" size={17} color={t.colors.sec} />
             </Pressable>
           ) : null}
         </View>
@@ -98,7 +98,7 @@ export default function LibraryPane({
               <Text
                 style={{
                   fontSize: t.typography.body.fontSize,
-                  color: t.colors.muted,
+                  color: t.colors.sec,
                   textAlign: 'center',
                 }}
               >

--- a/apps/mobile/src/components/setlist/PerformerShareSheet.tsx
+++ b/apps/mobile/src/components/setlist/PerformerShareSheet.tsx
@@ -134,9 +134,9 @@ function PerformerShareContent({ onClose, songCount, initialScope, handlers }: P
       </View>
       <View style={{ flex: 1 }}>
         <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
-        {subtitle ? <Text style={{ fontSize: 11.5, color: t.colors.muted }}>{subtitle}</Text> : null}
+        {subtitle ? <Text style={{ fontSize: 11.5, color: t.colors.sec }}>{subtitle}</Text> : null}
       </View>
-      <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+      <SymbolIcon name="chevron.right" size={14} color={t.colors.sec} />
     </Pressable>
   )
 

--- a/apps/mobile/src/components/setlist/PruneSetlistsModal.tsx
+++ b/apps/mobile/src/components/setlist/PruneSetlistsModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import ListRow from '../ListRow'
 import SymbolIcon from '../SymbolIcon'
 import { useTheme } from '../../theme/ThemeProvider'
-import { errMessage } from '../../lib/errors'
+import { actionFailureMessage } from '../../lib/errors'
 import type { SetlistRow } from '../../lib/useSetlists'
 
 // Shown when the user hits their per-role personal setlist cap. Lists every
@@ -62,7 +62,7 @@ export default function PruneSetlistsModal({
       setSelected(new Set())
       onClose()
     } catch (err: unknown) {
-      Alert.alert(tx('alerts.couldNotDeleteMany'), errMessage(err))
+      Alert.alert(tx('alerts.couldNotDeleteMany'), actionFailureMessage('PruneSetlists.deleteMany', err, tx))
     } finally {
       setBusy(false)
     }

--- a/apps/mobile/src/components/setlist/PruneSetlistsModal.tsx
+++ b/apps/mobile/src/components/setlist/PruneSetlistsModal.tsx
@@ -114,7 +114,7 @@ export default function PruneSetlistsModal({
             paddingHorizontal: t.spacing.lg,
             paddingBottom: t.spacing.sm,
             fontSize: t.typography.body.fontSize,
-            color: t.colors.muted,
+            color: t.colors.sec,
           }}
         >
           {tx('prune.message', { count: setlists.length, limit })}

--- a/apps/mobile/src/components/setlist/SetlistTimeline.tsx
+++ b/apps/mobile/src/components/setlist/SetlistTimeline.tsx
@@ -175,7 +175,7 @@ const Row = memo(function Row({
                   justifyContent: 'center',
                 }}
               >
-                <SymbolIcon name="line.3.horizontal" size={17} color={t.colors.muted} />
+                <SymbolIcon name="line.3.horizontal" size={17} color={t.colors.sec} />
               </View>
             </GestureDetector>
 

--- a/apps/mobile/src/components/setlist/ShareSetSheet.tsx
+++ b/apps/mobile/src/components/setlist/ShareSetSheet.tsx
@@ -157,9 +157,9 @@ function SecondaryRow({
       </View>
       <View style={{ flex: 1 }}>
         <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>{label}</Text>
-        {subtitle ? <Text style={{ fontSize: 11.5, color: t.colors.muted }}>{subtitle}</Text> : null}
+        {subtitle ? <Text style={{ fontSize: 11.5, color: t.colors.sec }}>{subtitle}</Text> : null}
       </View>
-      <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+      <SymbolIcon name="chevron.right" size={14} color={t.colors.sec} />
     </Pressable>
   )
 }

--- a/apps/mobile/src/components/songbook/SongbookOptionsSheet.tsx
+++ b/apps/mobile/src/components/songbook/SongbookOptionsSheet.tsx
@@ -104,7 +104,7 @@ function SongbookOptionsContent({
             <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>
               {tx('songbook.tocLabel')}
             </Text>
-            <Text style={{ fontSize: 11.5, color: t.colors.muted, marginTop: 2 }}>
+            <Text style={{ fontSize: 11.5, color: t.colors.sec, marginTop: 2 }}>
               {tx('songbook.tocHint')}
             </Text>
           </View>
@@ -158,7 +158,7 @@ function SongbookOptionsContent({
                 accessibilityLabel={tx('songbook.removeCover')}
                 hitSlop={8}
               >
-                <SymbolIcon name="trash" size={16} color={t.colors.muted} />
+                <SymbolIcon name="trash" size={16} color={t.colors.sec} />
               </Pressable>
             </View>
           ) : (
@@ -193,7 +193,7 @@ function SongbookOptionsContent({
                 <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.ink }}>
                   {tx('songbook.addCover')}
                 </Text>
-                <Text style={{ fontSize: 11.5, color: t.colors.muted }}>{tx('songbook.coverHint')}</Text>
+                <Text style={{ fontSize: 11.5, color: t.colors.sec }}>{tx('songbook.coverHint')}</Text>
               </View>
             </Pressable>
           )}

--- a/apps/mobile/src/i18n/locales/en/errors.json
+++ b/apps/mobile/src/i18n/locales/en/errors.json
@@ -1,5 +1,13 @@
 {
   "_meta": { "reviewer": "", "reviewedAt": "" },
   "couldntLoadSong": "Couldn't load song",
-  "songNotFound": "This song could not be found."
+  "songNotFound": "This song could not be found.",
+  "load": {
+    "songs": "Can't load songs",
+    "setlists": "Can't load your sets",
+    "starred": "Can't load starred songs",
+    "lastSet": "Can't load your last set",
+    "reflection": "Can't load your reflection",
+    "hint": "Check your connection and try again."
+  }
 }

--- a/apps/mobile/src/i18n/locales/en/errors.json
+++ b/apps/mobile/src/i18n/locales/en/errors.json
@@ -2,6 +2,8 @@
   "_meta": { "reviewer": "", "reviewedAt": "" },
   "couldntLoadSong": "Couldn't load song",
   "songNotFound": "This song could not be found.",
+  "tryAgain": "Something went wrong. Please try again.",
+  "saveFailed": "Your latest changes haven't been saved. Check your connection and try again.",
   "load": {
     "songs": "Can't load songs",
     "setlists": "Can't load your sets",

--- a/apps/mobile/src/i18n/locales/es/errors.json
+++ b/apps/mobile/src/i18n/locales/es/errors.json
@@ -1,5 +1,13 @@
 {
   "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
   "couldntLoadSong": "No se pudo cargar la canción",
-  "songNotFound": "No se pudo encontrar esta canción."
+  "songNotFound": "No se pudo encontrar esta canción.",
+  "load": {
+    "songs": "No se pueden cargar las canciones",
+    "setlists": "No se pueden cargar tus repertorios",
+    "starred": "No se pueden cargar las canciones favoritas",
+    "lastSet": "No se puede cargar tu último repertorio",
+    "reflection": "No se puede cargar tu reflexión",
+    "hint": "Comprueba tu conexión e inténtalo de nuevo."
+  }
 }

--- a/apps/mobile/src/i18n/locales/es/errors.json
+++ b/apps/mobile/src/i18n/locales/es/errors.json
@@ -2,6 +2,8 @@
   "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
   "couldntLoadSong": "No se pudo cargar la canción",
   "songNotFound": "No se pudo encontrar esta canción.",
+  "tryAgain": "Algo salió mal. Inténtalo de nuevo.",
+  "saveFailed": "Tus últimos cambios no se han guardado. Comprueba tu conexión e inténtalo de nuevo.",
   "load": {
     "songs": "No se pueden cargar las canciones",
     "setlists": "No se pueden cargar tus repertorios",

--- a/apps/mobile/src/i18n/locales/ko/errors.json
+++ b/apps/mobile/src/i18n/locales/ko/errors.json
@@ -2,6 +2,8 @@
   "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
   "couldntLoadSong": "찬양곡을 불러올 수 없음",
   "songNotFound": "이 찬양곡을 찾을 수 없습니다.",
+  "tryAgain": "문제가 발생했습니다. 다시 시도해 주세요.",
+  "saveFailed": "최근 변경 사항이 저장되지 않았습니다. 연결을 확인한 후 다시 시도하세요.",
   "load": {
     "songs": "찬양곡을 불러올 수 없습니다",
     "setlists": "셋리스트를 불러올 수 없습니다",

--- a/apps/mobile/src/i18n/locales/ko/errors.json
+++ b/apps/mobile/src/i18n/locales/ko/errors.json
@@ -1,5 +1,13 @@
 {
   "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
   "couldntLoadSong": "찬양곡을 불러올 수 없음",
-  "songNotFound": "이 찬양곡을 찾을 수 없습니다."
+  "songNotFound": "이 찬양곡을 찾을 수 없습니다.",
+  "load": {
+    "songs": "찬양곡을 불러올 수 없습니다",
+    "setlists": "셋리스트를 불러올 수 없습니다",
+    "starred": "즐겨찾기 찬양곡을 불러올 수 없습니다",
+    "lastSet": "최근 셋리스트를 불러올 수 없습니다",
+    "reflection": "묵상을 불러올 수 없습니다",
+    "hint": "연결을 확인한 후 다시 시도하세요."
+  }
 }

--- a/apps/mobile/src/i18n/locales/tr/errors.json
+++ b/apps/mobile/src/i18n/locales/tr/errors.json
@@ -1,5 +1,13 @@
 {
   "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
   "couldntLoadSong": "İlahi yüklenemedi",
-  "songNotFound": "Bu ilahi bulunamadı."
+  "songNotFound": "Bu ilahi bulunamadı.",
+  "load": {
+    "songs": "İlahiler yüklenemiyor",
+    "setlists": "Set listeleri yüklenemiyor",
+    "starred": "Yıldızlı ilahiler yüklenemiyor",
+    "lastSet": "Son set yüklenemiyor",
+    "reflection": "Düşünceniz yüklenemiyor",
+    "hint": "Bağlantınızı kontrol edip tekrar deneyin."
+  }
 }

--- a/apps/mobile/src/i18n/locales/tr/errors.json
+++ b/apps/mobile/src/i18n/locales/tr/errors.json
@@ -2,6 +2,8 @@
   "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
   "couldntLoadSong": "İlahi yüklenemedi",
   "songNotFound": "Bu ilahi bulunamadı.",
+  "tryAgain": "Bir şeyler ters gitti. Tekrar deneyin.",
+  "saveFailed": "Son değişiklikleriniz kaydedilmedi. Bağlantınızı kontrol edip tekrar deneyin.",
   "load": {
     "songs": "İlahiler yüklenemiyor",
     "setlists": "Set listeleri yüklenemiyor",

--- a/apps/mobile/src/lib/__tests__/contrast.test.ts
+++ b/apps/mobile/src/lib/__tests__/contrast.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  darkColors,
+  darkContrastBoost,
+  lightColors,
+  lightContrastBoost,
+  typography,
+  type ThemeColors,
+} from '@gracechords/tokens/native'
+
+// The contrast facts this app's colour choices rest on, pinned.
+//
+// 1.0.1 promoted ~120 sites off `muted` and ~19 off `accent`-as-text because those
+// tokens sit below WCAG 1.4.3 on the backgrounds they are actually used on. That
+// reasoning is invisible in the diff — every changed line just says `sec` instead
+// of `muted` — so a later retune of `sec` or `textAccent` could silently undo the
+// whole batch with nothing failing. These tests are that alarm.
+//
+// Pure arithmetic over the real token module; no RN, no rendering.
+
+/** WCAG 2.1 relative luminance. */
+function luminance(hex: string): number {
+  const raw = hex.replace('#', '')
+  const full = raw.length === 3 ? raw.split('').map((c) => c + c).join('') : raw
+  const channels = [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16) / 255)
+  const linear = channels.map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4))
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+}
+
+/** WCAG 2.1 contrast ratio, 1–21. */
+export function contrastRatio(fg: string, bg: string): number {
+  const a = luminance(fg)
+  const b = luminance(bg)
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05)
+}
+
+/** WCAG 1.4.3: 4.5:1 normally, 3:1 for large text (≥24px, or ≥18.66px bold). */
+const NORMAL_TEXT = 4.5
+const LARGE_TEXT = 3
+/** WCAG 1.4.11, for icons and controls that carry meaning. */
+const NON_TEXT = 3
+
+const MODES: Array<{ name: string; colors: ThemeColors; boost: Partial<ThemeColors> }> = [
+  { name: 'light', colors: lightColors, boost: lightContrastBoost },
+  { name: 'dark', colors: darkColors, boost: darkContrastBoost },
+]
+
+/** Every surface body text is drawn on. */
+const BACKGROUNDS = ['bg', 'surface', 'surfaceAlt'] as const
+
+describe('contrastRatio', () => {
+  it('matches known reference values', () => {
+    expect(contrastRatio('#000000', '#FFFFFF')).toBeCloseTo(21, 1)
+    expect(contrastRatio('#FFFFFF', '#FFFFFF')).toBeCloseTo(1, 5)
+    // Order must not matter.
+    expect(contrastRatio('#15619A', '#F5F7F9')).toBeCloseTo(contrastRatio('#F5F7F9', '#15619A'), 10)
+  })
+})
+
+describe.each(MODES)('$name mode', ({ colors, boost }) => {
+  // The load-bearing assertion of the whole 1.0.1 accessibility batch. `sec` is
+  // what ~120 sites were promoted TO; if it ever drifts under 4.5:1 on any surface,
+  // that promotion silently stopped working.
+  it.each(BACKGROUNDS)('sec clears normal-text contrast on %s', (bg) => {
+    expect(contrastRatio(colors.sec, colors[bg])).toBeGreaterThanOrEqual(NORMAL_TEXT)
+  })
+
+  // What the 19 accent-as-text sites were promoted to. It is also the web app's
+  // link colour (`--gc-link` in tokens.css), which is why it is the right token.
+  it.each(BACKGROUNDS)('textAccent clears normal-text contrast on %s', (bg) => {
+    expect(contrastRatio(colors.textAccent, colors[bg])).toBeGreaterThanOrEqual(NORMAL_TEXT)
+  })
+
+  it('ink clears normal-text contrast everywhere', () => {
+    for (const bg of BACKGROUNDS) {
+      expect(contrastRatio(colors.ink, colors[bg])).toBeGreaterThanOrEqual(NORMAL_TEXT)
+    }
+  })
+
+  // The ramp's ORDER is the invariant, not any single number: ink is the most
+  // legible, sec sits below it, muted below that. This is what makes `muted` a
+  // meaningful "de-emphasised" token rather than a second `sec` — and it is the
+  // reason the fix was to move sites off `muted` rather than to brighten `muted`
+  // until it passed, which would have collapsed two levels into one.
+  it('keeps the text ramp ordered ink > sec > muted', () => {
+    const on = (c: string) => contrastRatio(c, colors.bg)
+    expect(on(colors.ink)).toBeGreaterThan(on(colors.sec))
+    expect(on(colors.sec)).toBeGreaterThan(on(colors.muted))
+  })
+
+  // Why `muted` is still correct only for decorative and disabled use.
+  //
+  // Note the surfaces: it fails on `surface` and `surfaceAlt` in BOTH modes, which
+  // is where muted text actually lives (cards, sheets, chips, search fields). Dark
+  // mode on `bg` alone reaches 4.80 — the one combination that passes, and the
+  // reason "dark mode is fine" is a tempting but wrong summary.
+  it.each(['surface', 'surfaceAlt'] as const)(
+    'muted is below normal-text contrast on %s',
+    (bg) => {
+      expect(contrastRatio(colors.muted, colors[bg])).toBeLessThan(NORMAL_TEXT)
+    },
+  )
+
+  // Justifies leaving accent-as-ICON and large accent text alone: both are held to
+  // 3:1, which accent already clears.
+  it.each(BACKGROUNDS)('accent clears the 3:1 non-text floor on %s', (bg) => {
+    expect(contrastRatio(colors.accent, colors[bg])).toBeGreaterThanOrEqual(NON_TEXT)
+    expect(contrastRatio(colors.accent, colors[bg])).toBeGreaterThanOrEqual(LARGE_TEXT)
+  })
+
+  it('danger clears normal-text contrast on bg and surface', () => {
+    expect(contrastRatio(colors.danger, colors.bg)).toBeGreaterThanOrEqual(NORMAL_TEXT)
+    expect(contrastRatio(colors.danger, colors.surface)).toBeGreaterThanOrEqual(NORMAL_TEXT)
+  })
+
+  it('textAccent stays legible on the accentSoft chips it is used on', () => {
+    expect(contrastRatio(colors.textAccent, colors.accentSoft)).toBeGreaterThanOrEqual(NORMAL_TEXT)
+  })
+
+  // Increase Contrast may only ever strengthen. A boost that weakened a token
+  // would be worse than no boost at all.
+  it('the Increase-Contrast overlay never lowers contrast', () => {
+    for (const key of Object.keys(boost) as Array<keyof ThemeColors>) {
+      const boosted = boost[key]
+      if (typeof boosted !== 'string' || !boosted.startsWith('#')) continue
+      const base = colors[key]
+      if (typeof base !== 'string' || !base.startsWith('#')) continue
+      expect(contrastRatio(boosted, colors.bg)).toBeGreaterThanOrEqual(
+        contrastRatio(base, colors.bg) - 0.001,
+      )
+    }
+  })
+
+  it('lifts muted over the normal-text floor when Increase Contrast is on', () => {
+    const boostedMuted = boost.muted as string
+    expect(contrastRatio(boostedMuted, colors.bg)).toBeGreaterThanOrEqual(NORMAL_TEXT)
+  })
+})
+
+describe('light mode specifics', () => {
+  it('muted fails on bg too — unlike dark mode, which reaches 4.80 there', () => {
+    expect(contrastRatio(lightColors.muted, lightColors.bg)).toBeLessThan(NORMAL_TEXT)
+    expect(contrastRatio(darkColors.muted, darkColors.bg)).toBeGreaterThanOrEqual(NORMAL_TEXT)
+  })
+
+  it('muted fails even the 3:1 large-text floor, so no size exempts it', () => {
+    // This is why the classification has no "large muted text is fine" category:
+    // in light mode there is no font size at which `muted` becomes compliant.
+    expect(contrastRatio(lightColors.muted, lightColors.bg)).toBeLessThan(LARGE_TEXT)
+  })
+
+  it('records white-on-accent as the accepted deviation it is', () => {
+    // Deliberately NOT raised: iOS system blue ships near 3.6:1, and #1F84C9
+    // cascades to apps/web, apps/studio, store assets and the brand monogram.
+    // Pinned so a change to `accent` is a conscious act, not a side effect.
+    const ratio = contrastRatio(lightColors.onAccent, lightColors.accent)
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT)
+    expect(ratio).toBeLessThan(NORMAL_TEXT)
+  })
+})
+
+describe('typography ramp vs the large-text threshold', () => {
+  // 24px at any weight, or 18.66px at ≥700, qualifies for the relaxed 3:1 ratio.
+  const isLargeText = (fontSize: number, fontWeight: string) =>
+    fontSize >= 24 || (fontSize >= 18.66 && Number(fontWeight) >= 700)
+
+  it('only largeTitle qualifies as large text; the rest are held to 4.5:1', () => {
+    // Worth pinning because it is easy to assume otherwise: `rowTitle` is 16.5/600
+    // and `sectionHeader` 13/700, so neither gets the relaxed ratio, and a
+    // semibold 600 is not "bold" for this purpose either way.
+    const large = Object.entries(typography)
+      .filter(([, s]) => isLargeText(s.fontSize, s.fontWeight))
+      .map(([name]) => name)
+    expect(large).toStrictEqual(['largeTitle'])
+  })
+
+  it('largeTitle is drawn in ink, so its relaxed ratio never has to be relied on', () => {
+    for (const colors of [lightColors, darkColors]) {
+      expect(contrastRatio(colors.ink, colors.bg)).toBeGreaterThanOrEqual(NORMAL_TEXT)
+    }
+  })
+})

--- a/apps/mobile/src/lib/__tests__/currentUser.test.ts
+++ b/apps/mobile/src/lib/__tests__/currentUser.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Session, User } from '@supabase/supabase-js'
+import {
+  getCurrentUserSnapshot,
+  resetCurrentUserForTests,
+  setCurrentUserFromSession,
+  subscribeCurrentUser,
+} from '../currentUser'
+
+function user(overrides: Partial<User> & { id: string }): User {
+  return {
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as User
+}
+
+function session(u: User | null): Session | null {
+  return u ? ({ access_token: 'token', user: u } as Session) : null
+}
+
+/** Count emissions across a publish. */
+function countEmissions(publish: () => void): number {
+  let notified = 0
+  const unsubscribe = subscribeCurrentUser(() => {
+    notified += 1
+  })
+  publish()
+  unsubscribe()
+  return notified
+}
+
+beforeEach(() => {
+  resetCurrentUserForTests()
+})
+
+describe('before the root publishes', () => {
+  it('reports unresolved with a null user', () => {
+    // A screen mounting here must be able to tell "not known yet" from "signed
+    // out" — useProfileSprite relies on it to avoid clearing a good sprite and
+    // immediately re-fetching it.
+    expect(getCurrentUserSnapshot()).toStrictEqual({ user: null, resolved: false })
+  })
+})
+
+describe('setCurrentUserFromSession', () => {
+  it('publishes the session user and marks auth resolved', () => {
+    const u = user({ id: 'u1', email: 'a@example.test' })
+    setCurrentUserFromSession(session(u))
+    expect(getCurrentUserSnapshot()).toStrictEqual({ user: u, resolved: true })
+  })
+
+  it('resolves to a null user for a signed-out session', () => {
+    setCurrentUserFromSession(null)
+    expect(getCurrentUserSnapshot()).toStrictEqual({ user: null, resolved: true })
+  })
+
+  it('notifies subscribers on each real identity change', () => {
+    expect(countEmissions(() => setCurrentUserFromSession(session(user({ id: 'u1' }))))).toBe(1)
+    expect(countEmissions(() => setCurrentUserFromSession(session(user({ id: 'u2' }))))).toBe(1)
+  })
+
+  it('publishes the first resolution even when it resolves to null', () => {
+    // Unresolved-null and resolved-null are different states, so the initial
+    // signed-out publish must not be swallowed by the equality guard.
+    expect(countEmissions(() => setCurrentUserFromSession(null))).toBe(1)
+  })
+
+  it('swallows a repeated signed-out publish', () => {
+    setCurrentUserFromSession(null)
+    expect(countEmissions(() => setCurrentUserFromSession(null))).toBe(0)
+  })
+
+  it('keeps a stable snapshot across an unchanged TOKEN_REFRESHED', () => {
+    // auth-js hands over a NEW User object on every refresh (~hourly) with
+    // identical content. Replacing state on those would re-render Home, Settings
+    // and the Daily Word landing for nothing, and would break the reference
+    // stability useSyncExternalStore requires of getSnapshot.
+    const first = user({ id: 'u1', email: 'a@example.test', user_metadata: { full_name: 'Ada L' } })
+    setCurrentUserFromSession(session(first))
+    const before = getCurrentUserSnapshot()
+
+    const refreshed = user({
+      id: 'u1',
+      email: 'a@example.test',
+      user_metadata: { full_name: 'Ada L' },
+    })
+    expect(refreshed).not.toBe(first)
+
+    expect(countEmissions(() => setCurrentUserFromSession(session(refreshed)))).toBe(0)
+    expect(getCurrentUserSnapshot()).toBe(before)
+  })
+
+  it.each([
+    ['display name', { full_name: 'Ada B' }],
+    ['legacy name field', { name: 'Ada B' }],
+    ['avatar', { avatar_url: 'b.png' }],
+  ])('publishes when the %s changes', (_label, changed) => {
+    const base = { full_name: 'Ada L', name: 'Ada L', avatar_url: 'a.png' }
+    setCurrentUserFromSession(session(user({ id: 'u1', user_metadata: { ...base } })))
+    const before = getCurrentUserSnapshot()
+    setCurrentUserFromSession(
+      session(user({ id: 'u1', user_metadata: { ...base, ...changed } })),
+    )
+    expect(getCurrentUserSnapshot()).not.toBe(before)
+  })
+
+  it('publishes when the email changes', () => {
+    setCurrentUserFromSession(session(user({ id: 'u1', email: 'a@example.test' })))
+    const before = getCurrentUserSnapshot()
+    setCurrentUserFromSession(session(user({ id: 'u1', email: 'b@example.test' })))
+    expect(getCurrentUserSnapshot()).not.toBe(before)
+  })
+
+  it('publishes a sign-out after a signed-in user', () => {
+    setCurrentUserFromSession(session(user({ id: 'u1' })))
+    expect(countEmissions(() => setCurrentUserFromSession(null))).toBe(1)
+    expect(getCurrentUserSnapshot()).toStrictEqual({ user: null, resolved: true })
+  })
+
+  it('publishes an account switch even when the metadata matches', () => {
+    // Same name, different account — useProfileSprite keys its cache reset on
+    // the id, so this must not be treated as unchanged.
+    const meta = { full_name: 'Ada L' }
+    setCurrentUserFromSession(session(user({ id: 'u1', user_metadata: { ...meta } })))
+    expect(
+      countEmissions(() =>
+        setCurrentUserFromSession(session(user({ id: 'u2', user_metadata: { ...meta } }))),
+      ),
+    ).toBe(1)
+    expect(getCurrentUserSnapshot().user?.id).toBe('u2')
+  })
+
+  it('stops notifying after unsubscribe', () => {
+    let notified = 0
+    const unsubscribe = subscribeCurrentUser(() => {
+      notified += 1
+    })
+    unsubscribe()
+    setCurrentUserFromSession(session(user({ id: 'u1' })))
+    expect(notified).toBe(0)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/errorCopy.test.ts
+++ b/apps/mobile/src/lib/__tests__/errorCopy.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Every user-facing failure message in the app is now an i18n KEY chosen in a
+// hook and rendered by a screen, which moves a whole class of bug from
+// "impossible" to "silent": i18next resolves a MISSING key to its last segment,
+// so a typo in 'errors:load.starred' renders the literal word "starred" to the
+// user in every language. Nothing else in the suite would catch that.
+//
+// This test scrapes the keys the source actually references and requires each one
+// to exist in every locale.
+
+const LIB = path.resolve(__dirname, '..')
+const SRC = path.resolve(LIB, '..')
+const LOCALES = path.join(SRC, 'i18n', 'locales')
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : walk(full)
+    return /\.tsx?$/.test(entry.name) ? [full] : []
+  })
+}
+
+/** Every namespace-prefixed errors key literal in src/ and app/, deduped. */
+function referencedErrorKeys(): string[] {
+  const roots = [SRC, path.resolve(SRC, '..', 'app')]
+  const found = new Set<string>()
+  for (const root of roots) {
+    for (const file of walk(root)) {
+      const source = fs.readFileSync(file, 'utf8')
+      for (const match of source.matchAll(/['"`]errors:([A-Za-z0-9_.]+)['"`]/g)) {
+        found.add(match[1])
+      }
+    }
+  }
+  return [...found].sort()
+}
+
+function loadLocale(locale: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(LOCALES, locale, 'errors.json'), 'utf8'))
+}
+
+function resolve(bundle: Record<string, unknown>, dotted: string): unknown {
+  return dotted.split('.').reduce<unknown>((node, segment) => {
+    if (!node || typeof node !== 'object') return undefined
+    return (node as Record<string, unknown>)[segment]
+  }, bundle)
+}
+
+const locales = fs
+  .readdirSync(LOCALES, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort()
+
+describe('errors namespace copy', () => {
+  it('finds the keys the app references', () => {
+    const keys = referencedErrorKeys()
+    // A guard on the guard: if the scrape silently matched nothing, every
+    // assertion below would vacuously pass.
+    expect(keys.length).toBeGreaterThanOrEqual(8)
+    expect(keys).toContain('load.hint')
+    expect(keys).toContain('tryAgain')
+    expect(keys).toContain('saveFailed')
+  })
+
+  it('has all four locales', () => {
+    expect(locales).toStrictEqual(['en', 'es', 'ko', 'tr'])
+  })
+
+  it.each(locales)('%s defines every referenced key as a non-empty string', (locale) => {
+    const bundle = loadLocale(locale)
+    const missing: string[] = []
+    for (const key of referencedErrorKeys()) {
+      const value = resolve(bundle, key)
+      if (typeof value !== 'string' || value.trim() === '') missing.push(key)
+    }
+    expect(missing).toStrictEqual([])
+  })
+
+  it.each(locales)('%s has no leftover placeholder copy', (locale) => {
+    const flat = JSON.stringify(loadLocale(locale))
+    expect(flat).not.toMatch(/TODO|FIXME|XXX/i)
+    // The tokens the request-deadline work exists to keep away from users.
+    expect(flat).not.toMatch(/request_timeout|RequestTimeoutError|AbortError|ABORT_ERR/)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/errors.test.ts
+++ b/apps/mobile/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  UserFacingError,
+  actionFailureMessage,
+  errMessage,
+  failureDetailKey,
+  reportFailure,
+  saveFailureKey,
+} from '../errors'
+import { RequestTimeoutError } from '../requestBudget'
+
+// A stand-in for a screen's `t`: echoes the key so assertions read as keys.
+const t = (key: string) => `t(${key})`
+
+// Supabase's PostgREST error shape — a plain object, not an Error instance.
+const pgError = (message: string, code = '42703') => ({
+  message,
+  details: '',
+  hint: '',
+  code,
+})
+
+/** How postgrest-js reshapes a thrown fetch error: name folded into message. */
+const flattened = (err: Error) => pgError(`${err.name}: ${err.message}`, '')
+
+let logged: string[]
+
+beforeEach(() => {
+  logged = []
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    logged.push(args.map(String).join(' '))
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('errMessage', () => {
+  it('reads Error instances, Supabase error objects and strings', () => {
+    expect(errMessage(new Error('boom'))).toBe('boom')
+    expect(errMessage(pgError('column does not exist'))).toBe('column does not exist')
+    expect(errMessage('plain')).toBe('plain')
+  })
+})
+
+describe('reportFailure', () => {
+  it('reports a real failure and logs the reason', () => {
+    expect(reportFailure('useSongList', pgError('column x does not exist'))).toBe(true)
+    expect(logged).toEqual(['[useSongList] failed: column x does not exist'])
+  })
+
+  it('names our own deadline in the log rather than echoing its message', () => {
+    expect(reportFailure('useSongList', new RequestTimeoutError(14000))).toBe(true)
+    expect(logged).toEqual(['[useSongList] failed: request timed out'])
+  })
+
+  it('stays silent for a deliberate cancellation', () => {
+    const abort = new Error('Aborted')
+    abort.name = 'AbortError'
+    expect(reportFailure('downloads', abort)).toBe(false)
+    expect(logged).toEqual([])
+  })
+})
+
+describe('failureDetailKey', () => {
+  it('points at connection advice when the deadline fired', () => {
+    expect(failureDetailKey('useSong', new RequestTimeoutError(14000))).toBe('errors:load.hint')
+  })
+
+  it("points at connection advice for React Native's bare network failure", () => {
+    // RN gives no code and no cause here — only this string.
+    const rnFailure = new TypeError('Network request failed')
+    expect(failureDetailKey('useSong', rnFailure)).toBe('errors:load.hint')
+  })
+
+  it('recognises a network failure after postgrest flattens it', () => {
+    expect(failureDetailKey('useSong', flattened(new TypeError('Network request failed')))).toBe(
+      'errors:load.hint',
+    )
+  })
+
+  it('falls back to generic copy for a real query error', () => {
+    // Telling someone to check their connection would be a lie here.
+    expect(failureDetailKey('useSong', pgError('column x does not exist'))).toBe('errors:tryAgain')
+  })
+
+  it('never returns the raw message', () => {
+    const key = failureDetailKey('useSong', pgError('column user_starred_songs.created_at ...'))
+    expect(key).not.toContain('created_at')
+    // …but the real reason is still logged for whoever is debugging.
+    expect(logged[0]).toContain('created_at')
+  })
+})
+
+describe('saveFailureKey', () => {
+  it('always says the changes are unsaved, whatever went wrong', () => {
+    // Mid-edit, the useful fact is "your work is not persisted" — not the cause.
+    // The debounced save retries itself, so there is nothing to tap.
+    expect(saveFailureKey('builder', new RequestTimeoutError(14000))).toBe('errors:saveFailed')
+    expect(saveFailureKey('builder', pgError('deadlock detected', '40P01'))).toBe(
+      'errors:saveFailed',
+    )
+  })
+
+  it('logs the real reason', () => {
+    saveFailureKey('useSetlistBuilder.save', pgError('deadlock detected', '40P01'))
+    expect(logged).toEqual(['[useSetlistBuilder.save] save failed: deadlock detected'])
+  })
+})
+
+describe('actionFailureMessage', () => {
+  it('replaces raw Postgres text with localized copy', () => {
+    const body = actionFailureMessage('Setlists.delete', pgError('violates foreign key'), t)
+    expect(body).toBe('t(errors:tryAgain)')
+    expect(body).not.toContain('foreign key')
+  })
+
+  it('gives connection advice on a timeout instead of the deadline token', () => {
+    const body = actionFailureMessage('SetlistBuilder.export', new RequestTimeoutError(14000), t)
+    expect(body).toBe('t(errors:load.hint)')
+    expect(body).not.toMatch(/timed out|RequestTimeoutError|\d{4}/)
+  })
+
+  it('passes a UserFacingError through verbatim', () => {
+    // api.ts's misconfigured-base-URL hint names the exact fix; replacing it with
+    // "Something went wrong" would strand whoever is testing a bad build.
+    const hint =
+      'The API rejected the request (405) — EXPO_PUBLIC_API_BASE_URL likely points at a ' +
+      'redirecting domain. Set it to the canonical one (e.g. https://www.gracechords.com).'
+    expect(actionFailureMessage('SongbookBuilder.export', new UserFacingError(hint), t)).toBe(hint)
+  })
+
+  it('strips the class-name prefix if a UserFacingError was flattened', () => {
+    const flat = flattened(new UserFacingError('Set the canonical base URL.'))
+    expect(actionFailureMessage('export', flat, t)).toBe('Set the canonical base URL.')
+  })
+
+  it('logs in every branch, so nothing fails silently', () => {
+    actionFailureMessage('a', pgError('boom'), t)
+    actionFailureMessage('b', new RequestTimeoutError(7000), t)
+    actionFailureMessage('c', new UserFacingError('fix your config'), t)
+    expect(logged).toHaveLength(3)
+    expect(logged[0]).toContain('[a]')
+    expect(logged[1]).toContain('request timed out')
+    expect(logged[2]).toContain('fix your config')
+  })
+})

--- a/apps/mobile/src/lib/__tests__/launchStorage.test.ts
+++ b/apps/mobile/src/lib/__tests__/launchStorage.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LAUNCH_STORAGE_KEYS, primeLaunchStorage, type BatchKVStorage } from '../launchStorage'
+import { DEFAULT_APP_DEFAULTS, hydrateDefaults } from '../defaults'
+import { hydrateBibleTranslationPref, getBibleTranslationPref } from '../bibleTranslationPref'
+import { hydrateRecents, getRecentlyOpened } from '../recents'
+import { hydrateReadingStreak, getReadingStreak, DEFAULT_READING_STREAK } from '../readingStreak'
+import { hydrateReaderReminder, getReaderReminder, DEFAULT_READER_REMINDER } from '../readerReminder'
+import { hydrateViewerPrefs, getColumnMode } from '../viewerPrefs'
+
+// The whole point of the facade is that the eight hydrate modules are unchanged,
+// so these tests assert the OUTCOME each module produces when fed through a
+// batch — not the facade in isolation. A silent change to any fallback here
+// would reset a real user's preference on upgrade.
+
+function makeStore(seed: Record<string, string> = {}) {
+  const data = new Map(Object.entries(seed))
+  const store: BatchKVStorage & { multiGetCalls: number; getItemCalls: string[] } = {
+    multiGetCalls: 0,
+    getItemCalls: [],
+    async multiGet(keys) {
+      store.multiGetCalls += 1
+      return keys.map((key) => [key, data.has(key) ? (data.get(key) as string) : null] as const)
+    },
+    async getItem(key) {
+      store.getItemCalls.push(key)
+      return data.has(key) ? (data.get(key) as string) : null
+    },
+    async setItem(key, value) {
+      data.set(key, value)
+    },
+    async removeItem(key) {
+      data.delete(key)
+    },
+  }
+  return { store, data }
+}
+
+describe('LAUNCH_STORAGE_KEYS', () => {
+  it('covers the 12 keys the splash gate reads', () => {
+    expect(LAUNCH_STORAGE_KEYS).toHaveLength(12)
+    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(12)
+  })
+})
+
+describe('primeLaunchStorage', () => {
+  it('reads every key in ONE multiGet and serves hydration from it', async () => {
+    const { store } = makeStore()
+    const primed = await primeLaunchStorage(store)
+    await Promise.all(LAUNCH_STORAGE_KEYS.map((key) => primed.getItem(key)))
+    expect(store.multiGetCalls).toBe(1)
+    expect(store.getItemCalls).toEqual([])
+  })
+
+  it('delegates a key outside the batch to the real store', async () => {
+    const { store } = makeStore({ 'gc.viewer.autoHideChrome': '1' })
+    const primed = await primeLaunchStorage(store)
+    await expect(primed.getItem('gc.viewer.autoHideChrome')).resolves.toBe('1')
+    expect(store.getItemCalls).toEqual(['gc.viewer.autoHideChrome'])
+  })
+
+  it('falls back to the real store when multiGet rejects', async () => {
+    // Today each module does its own getItem behind its own try/catch, so one
+    // failing read can only affect one module. A batch that reset all 12
+    // preferences to defaults at once would be a far worse failure.
+    const { store } = makeStore({ 'gc.defaults.theme': 'dark' })
+    store.multiGet = () => Promise.reject(new Error('storage unavailable'))
+    const primed = await primeLaunchStorage(store)
+    expect(primed).toBe(store)
+    await expect(hydrateDefaults(primed)).resolves.toMatchObject({ theme: 'dark' })
+  })
+
+  it('serves a primed key once, then defers to the real store', async () => {
+    // The hydrate modules keep whatever storage they were handed for
+    // write-through, for the app's whole lifetime — so the facade must stay
+    // correct long after launch, never answering from a stale snapshot.
+    const { store, data } = makeStore({ 'gc.defaults.theme': 'dark' })
+    const primed = await primeLaunchStorage(store)
+    await expect(primed.getItem('gc.defaults.theme')).resolves.toBe('dark')
+    data.set('gc.defaults.theme', 'light')
+    await expect(primed.getItem('gc.defaults.theme')).resolves.toBe('light')
+  })
+
+  it('writes through, and a later read sees the written value', async () => {
+    const { store, data } = makeStore({ 'gc.defaults.theme': 'dark' })
+    const primed = await primeLaunchStorage(store)
+    await primed.setItem('gc.defaults.theme', 'light')
+    expect(data.get('gc.defaults.theme')).toBe('light')
+    await expect(primed.getItem('gc.defaults.theme')).resolves.toBe('light')
+  })
+
+  it('removes through, and a later read sees the removal', async () => {
+    const { store, data } = makeStore({ 'gc.defaults.language': 'ko' })
+    const primed = await primeLaunchStorage(store)
+    await primed.removeItem('gc.defaults.language')
+    expect(data.has('gc.defaults.language')).toBe(false)
+    await expect(primed.getItem('gc.defaults.language')).resolves.toBeNull()
+  })
+
+  it('treats a pair missing from the multiGet response as null', async () => {
+    const { store } = makeStore()
+    store.multiGet = async () => [['gc.defaults.theme', 'dark'] as const]
+    const primed = await primeLaunchStorage(store)
+    await expect(primed.getItem('gc.defaults.theme')).resolves.toBe('dark')
+    // Not in the response at all — must read exactly like an absent key, which
+    // is what every module's missing-value branch already handles.
+    await expect(primed.getItem('gc.defaults.chordStyle')).resolves.toBeNull()
+  })
+})
+
+describe('fallbacks are unchanged, batched vs unbatched', () => {
+  // Each case runs the SAME module twice — once against the raw store, once
+  // against the primed facade — and requires identical results.
+  const cases: Array<{
+    name: string
+    seed: Record<string, string>
+    run: (store: BatchKVStorage | Awaited<ReturnType<typeof primeLaunchStorage>>) => Promise<unknown>
+  }> = [
+    {
+      name: 'defaults: all keys absent',
+      seed: {},
+      run: async (s) => hydrateDefaults(s),
+    },
+    {
+      name: 'defaults: all keys valid',
+      seed: {
+        'gc.defaults.theme': 'dark',
+        'gc.defaults.chordStyle': 'solfege',
+        'gc.defaults.keepAwake': '1',
+        'gc.defaults.language': 'ko',
+        'gc.defaults.dailyWordDestination': 'reader',
+      },
+      run: async (s) => hydrateDefaults(s),
+    },
+    {
+      name: 'defaults: every key malformed',
+      seed: {
+        'gc.defaults.theme': 'neon',
+        'gc.defaults.chordStyle': 'numbers',
+        'gc.defaults.keepAwake': 'true',
+        'gc.defaults.language': '   ',
+        'gc.defaults.dailyWordDestination': 'somewhere',
+      },
+      run: async (s) => hydrateDefaults(s),
+    },
+    {
+      name: 'recents: malformed JSON',
+      seed: { 'gc.recents.songs.v1': '{not json' },
+      run: async (s) => {
+        await hydrateRecents(s)
+        return getRecentlyOpened()
+      },
+    },
+    {
+      name: 'recents: valid rows plus one junk row',
+      seed: {
+        'gc.recents.songs.v1': JSON.stringify([
+          { slug: 'a', title: 'A', openedAt: '2026-01-01T00:00:00Z' },
+          { slug: 'b' },
+        ]),
+      },
+      run: async (s) => {
+        await hydrateRecents(s)
+        return getRecentlyOpened()
+      },
+    },
+    {
+      name: 'reading streak: wrong shape',
+      seed: { 'gc.readingStreak.v1': JSON.stringify({ enabled: 'yes' }) },
+      run: async (s) => {
+        await hydrateReadingStreak(s)
+        return getReadingStreak()
+      },
+    },
+    {
+      name: 'reader reminder: out-of-range hour is clamped',
+      seed: { 'gc.readerReminder.v1': JSON.stringify({ enabled: true, hour: 99, minute: -5 }) },
+      run: async (s) => {
+        await hydrateReaderReminder(s)
+        return getReaderReminder()
+      },
+    },
+    {
+      name: 'viewer prefs: malformed JSON',
+      seed: { 'gc.viewer.columnMode.v1': 'null' },
+      run: async (s) => {
+        await hydrateViewerPrefs(s)
+        return getColumnMode('anything')
+      },
+    },
+    {
+      name: 'bible translation: whitespace only',
+      seed: { 'gc.bible.translation.v1': '   ' },
+      run: async (s) => {
+        await hydrateBibleTranslationPref(s)
+        return getBibleTranslationPref()
+      },
+    },
+    {
+      name: 'bible translation: valid pick',
+      seed: { 'gc.bible.translation.v1': 'KJV' },
+      run: async (s) => {
+        await hydrateBibleTranslationPref(s)
+        return getBibleTranslationPref()
+      },
+    },
+  ]
+
+  for (const testCase of cases) {
+    it(testCase.name, async () => {
+      const direct = makeStore(testCase.seed)
+      const unbatched = await testCase.run(direct.store)
+
+      const batched = makeStore(testCase.seed)
+      const primed = await primeLaunchStorage(batched.store)
+      const viaBatch = await testCase.run(primed)
+
+      expect(viaBatch).toStrictEqual(unbatched)
+    })
+  }
+
+  it('pins the documented defaults so a drift shows up here', async () => {
+    const { store } = makeStore()
+    const primed = await primeLaunchStorage(store)
+    await expect(hydrateDefaults(primed)).resolves.toStrictEqual(DEFAULT_APP_DEFAULTS)
+    await hydrateReadingStreak(primed)
+    expect(getReadingStreak()).toStrictEqual(DEFAULT_READING_STREAK)
+    await hydrateReaderReminder(primed)
+    expect(getReaderReminder()).toStrictEqual(DEFAULT_READER_REMINDER)
+    await hydrateBibleTranslationPref(primed)
+    expect(getBibleTranslationPref()).toBe('')
+    await hydrateRecents(primed)
+    expect(getRecentlyOpened()).toStrictEqual([])
+    await hydrateViewerPrefs(primed)
+    expect(getColumnMode(undefined)).toBe('single')
+  })
+
+  it('keeps defaults.ts all-or-nothing on a per-key read failure', async () => {
+    // Pre-existing behaviour worth pinning: defaults.ts wraps its five reads in
+    // Promise.all, so one rejecting read discards all five. The batch must not
+    // quietly "improve" this into per-key degradation either.
+    const { store } = makeStore({ 'gc.defaults.theme': 'dark' })
+    const failing = {
+      ...store,
+      getItem: vi.fn(async (key: string) => {
+        if (key === 'gc.defaults.chordStyle') throw new Error('read failed')
+        return store.getItem(key)
+      }),
+    } as unknown as BatchKVStorage
+    await expect(hydrateDefaults(failing)).resolves.toStrictEqual(DEFAULT_APP_DEFAULTS)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/requestBudget.test.ts
+++ b/apps/mobile/src/lib/__tests__/requestBudget.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BACKGROUND_MS,
+  FOREGROUND_MS,
+  GATE_MS,
+  RequestTimeoutError,
+  isAbortError,
+  isRequestTimeout,
+  withDeadline,
+  withRequestBudget,
+  type FetchFn,
+} from '../requestBudget'
+
+// A fetch that never settles until aborted — the blackholed-network case. A
+// refusing network fails fast on its own; a HANGING one is what pins a socket
+// until the platform default, so it is what these tests model.
+function hangingFetch(): FetchFn {
+  return (_input, init) =>
+    new Promise((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return
+      const fail = () => {
+        const err = new Error('Aborted')
+        err.name = 'AbortError'
+        reject(err)
+      }
+      if (signal.aborted) fail()
+      else signal.addEventListener('abort', fail)
+    })
+}
+
+const okResponse = () => ({ ok: true, status: 200 }) as unknown as Response
+
+describe('budgets', () => {
+  it('orders the three budgets by how much the user is waiting', () => {
+    // The gate is the only budget the user experiences as "not launched", so it
+    // is the tightest; background work must yield to foreground work.
+    expect(GATE_MS).toBeLessThan(BACKGROUND_MS)
+    expect(BACKGROUND_MS).toBeLessThan(FOREGROUND_MS)
+  })
+
+  it("keeps the boot gate at build 12's shipped value", () => {
+    expect(GATE_MS).toBe(2500)
+  })
+})
+
+describe('withRequestBudget', () => {
+  it('rejects with RequestTimeoutError once the budget lapses', async () => {
+    vi.useFakeTimers()
+    try {
+      const bounded = withRequestBudget(hangingFetch(), () => 14000)
+      const pending = bounded('https://example.test/rest/v1/songs')
+      const assertion = expect(pending).rejects.toBeInstanceOf(RequestTimeoutError)
+      await vi.advanceTimersByTimeAsync(14000)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('passes a request through untouched when budgetFor returns null', async () => {
+    const inner = vi.fn(hangingFetch())
+    const bounded = withRequestBudget(inner, () => null)
+    void bounded('https://example.test/auth/v1/token?grant_type=refresh_token')
+    expect(inner).toHaveBeenCalledTimes(1)
+    // No signal is attached at all, so nothing can cancel it — this is exactly
+    // what keeps build 12's self-heal path alive.
+    expect(inner.mock.calls[0][1]?.signal).toBeUndefined()
+  })
+
+  it('does not disturb a successful request', async () => {
+    const bounded = withRequestBudget(async () => okResponse(), () => 14000)
+    await expect(bounded('https://example.test/rest/v1/songs')).resolves.toMatchObject({ ok: true })
+  })
+
+  it('clears its timer on success, so a resolved request cannot fire later', async () => {
+    vi.useFakeTimers()
+    try {
+      const bounded = withRequestBudget(async () => okResponse(), () => 100)
+      await bounded('https://example.test/rest/v1/songs')
+      // If the deadline timer survived, advancing past it would abort a request
+      // that already succeeded (and, in the real client, log a phantom failure).
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("surfaces a caller's own abort as an AbortError, not as a timeout", async () => {
+    const controller = new AbortController()
+    const bounded = withRequestBudget(hangingFetch(), () => 14000)
+    const pending = bounded('https://example.test/rest/v1/songs', { signal: controller.signal })
+    controller.abort()
+    await expect(pending).rejects.toSatisfy(
+      (err: unknown) => isAbortError(err) && !isRequestTimeout(err),
+    )
+  })
+
+  it('honours a signal that is already aborted before the call', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const bounded = withRequestBudget(hangingFetch(), () => 14000)
+    await expect(
+      bounded('https://example.test/rest/v1/songs', { signal: controller.signal }),
+    ).rejects.toSatisfy(isAbortError)
+  })
+
+  it('routes the URL to budgetFor so auth and data can differ', async () => {
+    const seen: string[] = []
+    const bounded = withRequestBudget(async () => okResponse(), (url) => {
+      seen.push(url)
+      return url.includes('grant_type=refresh_token') ? null : FOREGROUND_MS
+    })
+    await bounded('https://example.test/rest/v1/setlists')
+    await bounded('https://example.test/auth/v1/token?grant_type=refresh_token')
+    expect(seen).toEqual([
+      'https://example.test/rest/v1/setlists',
+      'https://example.test/auth/v1/token?grant_type=refresh_token',
+    ])
+  })
+})
+
+describe('RequestTimeoutError shape', () => {
+  // These are not cosmetic. postgrest-js short-circuits its retry loop only for
+  // name 'AbortError' or code 'ABORT_ERR'; every read this app makes is a GET,
+  // which postgrest retries 3x with 1s/2s/4s backoff by default. Without
+  // ABORT_ERR a single blackholed read costs ~63 s — worse than the platform
+  // default this whole module exists to avoid.
+  it('presents as ABORT_ERR so postgrest-js will not retry it', () => {
+    expect(new RequestTimeoutError(14000).code).toBe('ABORT_ERR')
+  })
+
+  it('carries a readable message, because two screens still render error text raw', () => {
+    const err = new RequestTimeoutError(14000)
+    expect(err.message).toBe('The request timed out.')
+    expect(err.message).not.toMatch(/\d{4}/)
+  })
+
+  it('keeps the budget available for logging', () => {
+    expect(new RequestTimeoutError(7000).budgetMs).toBe(7000)
+  })
+})
+
+describe('classification through a Supabase query', () => {
+  // postgrest-js discards `code` for client-side network errors and reshapes the
+  // failure as { message: '<name>: <message>' }, so the message prefix is the
+  // only surviving evidence. If this ever regresses, every error branch silently
+  // starts treating timeouts as ordinary query failures.
+  const flattened = (err: Error) => ({
+    message: `${err.name}: ${err.message}`,
+    details: '',
+    hint: 'Request was aborted (timeout or manual cancellation)',
+    code: '',
+  })
+
+  it('still recognises a timeout after postgrest flattens it', () => {
+    expect(isRequestTimeout(flattened(new RequestTimeoutError(14000)))).toBe(true)
+  })
+
+  it('still recognises a deliberate abort after postgrest flattens it', () => {
+    const abort = new Error('Aborted')
+    abort.name = 'AbortError'
+    expect(isAbortError(flattened(abort))).toBe(true)
+  })
+
+  it('does not mistake an ordinary query error for either', () => {
+    const pgError = {
+      message: 'column user_starred_songs.created_at does not exist',
+      details: '',
+      hint: '',
+      code: '42703',
+    }
+    expect(isRequestTimeout(pgError)).toBe(false)
+    expect(isAbortError(pgError)).toBe(false)
+  })
+
+  it('never classifies a timeout as a user-initiated abort', () => {
+    // reportLoadFailure checks isAbortError FIRST and stays silent when it is
+    // true, so a timeout leaking into that branch would hide a real failure.
+    const err = new RequestTimeoutError(14000)
+    expect(isAbortError(err)).toBe(false)
+    expect(isRequestTimeout(err)).toBe(true)
+  })
+
+  it('tolerates non-object failures', () => {
+    for (const value of [null, undefined, 'boom', 42]) {
+      expect(isRequestTimeout(value)).toBe(false)
+      expect(isAbortError(value)).toBe(false)
+    }
+  })
+})
+
+describe('withDeadline', () => {
+  it('stops waiting at the deadline without cancelling the work', async () => {
+    vi.useFakeTimers()
+    try {
+      let settled = false
+      const work = new Promise<string>((resolve) => {
+        setTimeout(() => {
+          settled = true
+          resolve('landed')
+        }, 30000)
+      })
+      const raced = withDeadline(work, BACKGROUND_MS, 'gave-up')
+      await vi.advanceTimersByTimeAsync(BACKGROUND_MS)
+      await expect(raced).resolves.toBe('gave-up')
+      // The underlying work is untouched and still completes — that is what lets
+      // a prefetch keep warming the cache for a reader that arrives later.
+      expect(settled).toBe(false)
+      await vi.advanceTimersByTimeAsync(30000)
+      expect(settled).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns the real result when the work wins', async () => {
+    await expect(withDeadline(Promise.resolve('landed'), 1000, 'gave-up')).resolves.toBe('landed')
+  })
+
+  it('clears its timer when the work wins', async () => {
+    vi.useFakeTimers()
+    try {
+      await withDeadline(Promise.resolve('landed'), 1000, 'gave-up')
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/mobile/src/lib/__tests__/requestBudget.test.ts
+++ b/apps/mobile/src/lib/__tests__/requestBudget.test.ts
@@ -175,7 +175,7 @@ describe('classification through a Supabase query', () => {
   })
 
   it('never classifies a timeout as a user-initiated abort', () => {
-    // reportLoadFailure checks isAbortError FIRST and stays silent when it is
+    // reportFailure checks isAbortError FIRST and stays silent when it is
     // true, so a timeout leaking into that branch would hide a real failure.
     const err = new RequestTimeoutError(14000)
     expect(isAbortError(err)).toBe(false)

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,9 +1,15 @@
 import { supabase } from './supabase'
+import { FOREGROUND_MS, withRequestBudget } from './requestBudget'
 
 // Shared client for the web app's Pages Functions API (/api/export/song,
 // /api/telegram/push).
 
 const base = process.env.EXPO_PUBLIC_API_BASE_URL
+
+// Export and Telegram pushes are foreground work — the user tapped a button and
+// is waiting on a sheet or a toast. Without a bound these ran to the ~60 s
+// platform default with nothing but a spinner.
+const budgetedFetch = withRequestBudget(fetch, () => FOREGROUND_MS)
 
 export function apiBase(): string {
   if (!base) {
@@ -30,11 +36,11 @@ export async function apiPost(path: string, body: unknown): Promise<Response> {
   }
   const payload = JSON.stringify(body)
 
-  let res = await fetch(`${apiBase()}${path}`, { method: 'POST', headers, body: payload })
+  let res = await budgetedFetch(`${apiBase()}${path}`, { method: 'POST', headers, body: payload })
   if (res.status === 405 && res.url) {
     const finalOrigin = new URL(res.url).origin
     if (finalOrigin !== new URL(apiBase()).origin) {
-      res = await fetch(`${finalOrigin}${path}`, { method: 'POST', headers, body: payload })
+      res = await budgetedFetch(`${finalOrigin}${path}`, { method: 'POST', headers, body: payload })
     }
   }
   return res

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { UserFacingError } from './errors'
 import { FOREGROUND_MS, withRequestBudget } from './requestBudget'
 
 // Shared client for the web app's Pages Functions API (/api/export/song,
@@ -50,7 +51,10 @@ export async function apiPost(path: string, body: unknown): Promise<Response> {
 // targeted hint for the redirect case a retry couldn't fix.
 export async function apiError(res: Response, fallback: string): Promise<Error> {
   if (res.status === 405) {
-    return new Error(
+    // UserFacingError so actionFailureMessage shows this verbatim instead of
+    // replacing it with generic copy: it names the exact misconfiguration and the
+    // exact fix, and whoever hits it is a developer or a tester on a bad build.
+    return new UserFacingError(
       'The API rejected the request (405) — EXPO_PUBLIC_API_BASE_URL likely points at a ' +
         'redirecting domain. Set it to the canonical one (e.g. https://www.gracechords.com).',
     )

--- a/apps/mobile/src/lib/authSession.ts
+++ b/apps/mobile/src/lib/authSession.ts
@@ -3,6 +3,7 @@
 // injected dep, like authFlows.ts. Type-only supabase imports erase at compile
 // time.
 import type { Session, SupabaseClient } from '@supabase/supabase-js'
+import { GATE_MS } from './requestBudget'
 
 type BootAuth = Pick<SupabaseClient['auth'], 'getSession' | 'signOut'>
 
@@ -65,7 +66,10 @@ export function silenceInvalidRefreshTokenLogs(
 // out iOS's URLSession timeout, up to 60 s, which presents as "the app does not
 // launch". 2.5 s is well above a healthy refresh (~0.2–0.6 s) and well below
 // anything a user reads as a failure to launch.
-export const INITIAL_SESSION_TIMEOUT_MS = 2500
+//
+// The value now comes from requestBudget.ts (as GATE_MS) so the app's whole
+// timeout budget reads in one place. Same number, same semantics as build 12.
+export const INITIAL_SESSION_TIMEOUT_MS = GATE_MS
 
 const TIMED_OUT = Symbol('gc.initialSessionTimeout')
 

--- a/apps/mobile/src/lib/bibleSource.ts
+++ b/apps/mobile/src/lib/bibleSource.ts
@@ -15,6 +15,13 @@ import {
 // avoid an import cycle.
 import { readLocalChapter } from './downloads/resolver'
 import { getDownloadsSnapshot } from './downloads/manifest'
+import {
+  BACKGROUND_MS,
+  FOREGROUND_MS,
+  withDeadline,
+  withRequestBudget,
+  type FetchFn,
+} from './requestBudget'
 
 // Source seam for Daily Word passage content. Today it reads from the
 // Cloudflare R2 bucket that also serves the web app's Bible JSON; the accessor
@@ -40,13 +47,50 @@ export function r2Base(): string {
 export { getPlanForDate, expandReadings }
 export type { BibleTranslation, ChapterData, Passage }
 
+// A chapter read the reader is waiting on. This budget is used even when the
+// launch prefetch started the request, because getPassage de-dupes in flight —
+// a reader that joins a prefetch's promise must not inherit a shorter deadline.
+const chapterFetch = withRequestBudget(fetch, () => FOREGROUND_MS)
+
+// The manifest is only ever needed before a chapter, never on its own, and it
+// has a built-in ESV fallback — so it yields sockets rather than holding them.
+const manifestFetch = withRequestBudget(fetch, () => BACKGROUND_MS)
+
 // ── Translation manifest (memoized for the app's lifetime) ──────────────────
 let translationsPromise: Promise<TranslationsResult> | null = null
 
-/** Load and normalize the translation manifest from the active source (once). */
+/**
+ * Load and normalize the translation manifest from the active source (once).
+ *
+ * A SUCCESS is memoized for the app's lifetime (the manifest is effectively
+ * immutable); a FAILURE is not. fetchBibleTranslations never rejects — it
+ * swallows everything and returns the built-in ESV-only fallback — so without
+ * this the first bad network call would pin the translation picker to ESV until
+ * the next launch, and the reader's Retry button only re-fetches the chapter,
+ * never the manifest. Bounding the request made that outcome arrive sooner,
+ * which is what surfaced it. `loaded` is set by the probe below because the
+ * fallback is otherwise indistinguishable from a real one-translation manifest.
+ */
 export function getTranslations(): Promise<TranslationsResult> {
   if (!translationsPromise) {
-    translationsPromise = fetchBibleTranslations(r2Base()).then(withDownloadedTranslations)
+    let loaded = true
+    const probe = (async (input, init) => {
+      try {
+        const res = await manifestFetch(input, init)
+        if (!res.ok) loaded = false
+        return res
+      } catch (err) {
+        loaded = false
+        throw err
+      }
+    }) as FetchFn
+    const attempt = fetchBibleTranslations(r2Base(), probe)
+      .then(withDownloadedTranslations)
+      .then((result) => {
+        if (!loaded && translationsPromise === attempt) translationsPromise = null
+        return result
+      })
+    translationsPromise = attempt
   }
   return translationsPromise
 }
@@ -130,6 +174,12 @@ const fetchRemoteChapter = ({ passage, translation }: PassageQuery): Promise<Cha
     dataRoot: translation.dataRoot,
     bookNumber: passage.bookNumber,
     chapter: passage.chapter,
+    // No `signal` here on purpose: this request is shared through the in-flight
+    // map in getPassage, so a caller-owned AbortController would cancel a fetch
+    // another subscriber is still waiting on. The deadline lives inside
+    // chapterFetch instead, where it belongs to the request rather than to any
+    // one caller. Callers drop results with a cooperative `alive` flag.
+    fetchImpl: chapterFetch,
   })
 
 /**
@@ -182,7 +232,19 @@ export async function prefetchToday(): Promise<void> {
     const translation = translations.find((x) => x.id === id) || translations[0]
     if (!translation) return
     const passages = expandReadings(getPlanForDate(today).readings)
-    await Promise.all(passages.map((passage) => getPassage({ passage, translation }).catch(() => {})))
+    // Stop WAITING at the background budget, but do not cancel: the underlying
+    // chapter requests are shared with the reader through getPassage's in-flight
+    // map, so they keep their own (longer) budget and still warm the cache if
+    // they land. This only bounds how long the launch-time warm-up stays
+    // pending — it is already fire-and-forget from app/_layout.tsx and never
+    // gated the splash.
+    await withDeadline(
+      Promise.all(
+        passages.map((passage) => getPassage({ passage, translation }).catch(() => {})),
+      ).then(() => undefined),
+      BACKGROUND_MS,
+      undefined,
+    )
   } catch {
     // best-effort warm-up
   }

--- a/apps/mobile/src/lib/currentUser.ts
+++ b/apps/mobile/src/lib/currentUser.ts
@@ -1,0 +1,126 @@
+import { useSyncExternalStore } from 'react'
+import type { Session, User } from '@supabase/supabase-js'
+
+// The single source for "who is signed in".
+//
+// It makes NO network request and holds NO auth subscription of its own. The root
+// layout already resolves exactly one session at launch and already owns the one
+// onAuthStateChange subscription, so both places it sets a session also call
+// setCurrentUserFromSession — see app/_layout.tsx. Identity therefore has one
+// source, and it is the same session the splash gate resolved.
+//
+// What this replaces: a per-component hook that called supabase.auth.getUser()
+// AND opened its own onAuthStateChange. Home mounted it twice (directly, and
+// again inside useProfileSprite), so opening Home cost two round trips to
+// /auth/v1/user plus two extra subscriptions, and Settings cost two more.
+//
+// getUser() vs the session's user, stated plainly because it is a real trade:
+// getUser() validates the token server-side and returns the current server-side
+// record; the session's `user` is the snapshot from the last token issuance. So a
+// display name or email changed on the web now lags on mobile by up to one token
+// refresh (<=1 h) or a relaunch. For a greeting and an avatar that is fine, and
+// it buys the case that matters more — offline. getUser() cannot answer without a
+// network, so an offline launch used to greet a signed-in user as "friend"; the
+// session can answer from storage, so it now greets them by name.
+//
+// No authorization depends on this. RLS decides access server-side, and a
+// rejected token still fails every query, so a stale cached name is cosmetic.
+//
+// Module-level store + useSyncExternalStore, the same pattern as defaults.ts and
+// eight other stores in src/lib. RN-free, so it unit-tests headless.
+
+export type CurrentUserState = {
+  user: User | null
+  /**
+   * False only before the root layout has resolved the session. Screens that
+   * must not act on "signed out" until auth is known should check this — the
+   * root publishes before `ready` flips, so in practice a mounted screen always
+   * sees true, but a screen mounted outside that gate (or a test) can tell the
+   * difference between "no user" and "not known yet".
+   */
+  resolved: boolean
+}
+
+const UNRESOLVED: CurrentUserState = { user: null, resolved: false }
+
+let state: CurrentUserState = UNRESOLVED
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+/**
+ * Subscribe to identity changes. Exported because useSyncExternalStore needs a
+ * stable reference and because it is the seam the unit tests observe — a
+ * non-React consumer should read getCurrentUserSnapshot instead.
+ */
+export function subscribeCurrentUser(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function getSnapshot(): CurrentUserState {
+  return state
+}
+
+/**
+ * True when two User objects carry the same identity as far as this app's UI is
+ * concerned.
+ *
+ * This matters because auth-js hands over a NEW User object on every
+ * TOKEN_REFRESHED — roughly hourly — with identical content. Replacing state
+ * then would re-render Home, Settings and the Daily Word landing for nothing,
+ * and would break the reference stability useSyncExternalStore requires of
+ * getSnapshot. Compared fields are exactly the ones read by getDisplayName
+ * (greetings.ts) and useProfileSprite.
+ */
+function sameIdentity(a: User | null, b: User | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.id !== b.id || a.email !== b.email) return false
+  const am = (a.user_metadata ?? {}) as Record<string, unknown>
+  const bm = (b.user_metadata ?? {}) as Record<string, unknown>
+  return am.full_name === bm.full_name && am.name === bm.name && am.avatar_url === bm.avatar_url
+}
+
+/**
+ * Publish the signed-in user. Called ONLY from app/_layout.tsx, from the two
+ * places that already own a session: the launch hydration join and the
+ * onAuthStateChange callback.
+ */
+export function setCurrentUserFromSession(session: Session | null): void {
+  const next = session?.user ?? null
+  if (state.resolved && sameIdentity(state.user, next)) return
+  state = { user: next, resolved: true }
+  emit()
+}
+
+/** Synchronous read, safe before the root has published (returns unresolved). */
+export function getCurrentUserSnapshot(): CurrentUserState {
+  return state
+}
+
+/**
+ * The signed-in user, or null. Same signature as the hook this replaces, so call
+ * sites are unchanged.
+ */
+export function useCurrentUser(): User | null {
+  return useSyncExternalStore(subscribeCurrentUser, getSnapshot, getSnapshot).user
+}
+
+/** The user plus whether auth has resolved yet. */
+export function useCurrentUserState(): CurrentUserState {
+  return useSyncExternalStore(subscribeCurrentUser, getSnapshot, getSnapshot)
+}
+
+/**
+ * Test-only: drop back to the unresolved state so each test starts clean.
+ * Production code must go through setCurrentUserFromSession.
+ */
+export function resetCurrentUserForTests(): void {
+  state = UNRESOLVED
+  listeners.clear()
+}

--- a/apps/mobile/src/lib/downloads/service.ts
+++ b/apps/mobile/src/lib/downloads/service.ts
@@ -6,10 +6,13 @@ import { downloadBibleTranslation } from './downloader'
 import { getDownloadsSnapshot, removeDownload, upsertDownload } from './manifest'
 import { translationDirRel } from './paths'
 import type { AbortToken, BibleDownload, DownloadProgress } from './types'
+import { FOREGROUND_MS, withRequestBudget } from '../requestBudget'
 
 // App-facing download controller. Wires the pure downloader/manifest to the real
 // device: expo-file-system blobs, the global fetch, and expo-network for the
 // "Wi-Fi only" preference. Kept thin — all logic lives in the pure modules.
+
+const chapterFetch = withRequestBudget(fetch, () => FOREGROUND_MS)
 
 export class WifiRequiredError extends Error {
   constructor() {
@@ -45,7 +48,12 @@ export async function startBibleDownload(
   const { version } = await getTranslations()
   const record = await downloadBibleTranslation(translation, version, r2Base(), {
     blobStore: expoBlobStore,
-    fetchImpl: (url) => fetch(url),
+    // Bounded per chapter, so a single stalled request cannot freeze a
+    // 1189-chapter download behind a stopped progress bar. downloadBibleTranslation
+    // already retries transient failures with backoff, so a stall now becomes a
+    // retry rather than a hang; a user cancel still arrives via `signal`
+    // (AbortToken) and is reported as a cancellation, not a timeout.
+    fetchImpl: (url) => chapterFetch(url),
     onProgress: opts.onProgress,
     signal: opts.signal,
   })

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -8,7 +8,7 @@ import { isAbortError, isRequestTimeout } from './requestBudget'
 // output: it has leaked raw Postgres text to users before (`column
 // user_starred_songs.created_at does not exist`), and with request deadlines in
 // place it would now also surface `request_timeout_14000`. Log it, and show the
-// caller's own localized copy instead — see reportLoadFailure.
+// caller's own localized copy instead — see reportFailure.
 export function errMessage(err: unknown): string {
   if (err instanceof Error) return err.message
   if (err && typeof err === 'object' && 'message' in err) {
@@ -18,7 +18,7 @@ export function errMessage(err: unknown): string {
 }
 
 /**
- * Log a failed read, and report whether the UI should show an error for it.
+ * Log a failed read or write, and report whether the UI should show an error.
  *
  * Returns false for a deliberate cancellation (a user-cancelled download, or any
  * caller-supplied abort), which must never be presented to the user as a
@@ -30,9 +30,99 @@ export function errMessage(err: unknown): string {
  *
  * `scope` is the hook or screen name, e.g. 'useStarredSongs'.
  */
-export function reportLoadFailure(scope: string, err: unknown): boolean {
+export function reportFailure(scope: string, err: unknown): boolean {
   if (isAbortError(err)) return false
-  const reason = isRequestTimeout(err) ? 'request timed out' : errMessage(err)
-  console.error(`[${scope}] load failed: ${reason}`)
+  console.error(`[${scope}] failed: ${describeReason(err)}`)
   return true
+}
+
+/** What to write in the log: our own deadline named as such, else the raw text. */
+function describeReason(err: unknown): string {
+  return isRequestTimeout(err) ? 'request timed out' : errMessage(err)
+}
+
+/**
+ * An error whose message was WRITTEN FOR whoever is holding the device, and is
+ * therefore safe to display verbatim. Everything else is diagnostic and gets
+ * replaced with localized copy.
+ *
+ * Used sparingly — currently only for api.ts's misconfigured-base-URL hint,
+ * which tells a developer or tester exactly what to fix and would be worthless
+ * as "Something went wrong".
+ */
+export class UserFacingError extends Error {
+  readonly name = 'UserFacingError'
+}
+
+function isUserFacingError(err: unknown): boolean {
+  if (err instanceof UserFacingError) return true
+  if (!err || typeof err !== 'object') return false
+  const e = err as { name?: unknown; message?: unknown }
+  return e.name === 'UserFacingError' || errMessage(err).startsWith('UserFacingError:')
+}
+
+/**
+ * React Native's fetch rejects with a bare `TypeError: Network request failed`
+ * on a refused or unreachable host — no code, no cause, nothing but the string.
+ * Matching on it is unlovely, but it is the difference between telling a user to
+ * check their connection and telling them nothing useful, and it is the most
+ * common real failure this app sees.
+ */
+function isNetworkFailure(err: unknown): boolean {
+  const message = errMessage(err).toLowerCase()
+  return (
+    message.includes('network request failed') ||
+    message.includes('failed to fetch') ||
+    message.includes('network error')
+  )
+}
+
+const OFFLINE_DETAIL_KEY = 'errors:load.hint'
+const GENERIC_DETAIL_KEY = 'errors:tryAgain'
+
+/**
+ * Log a failure and return the i18n key for the DETAIL line beneath a
+ * surface-specific heading — "check your connection" when we can tell the
+ * network is the problem, a generic apology otherwise.
+ *
+ * For hooks that render their own heading (`errors:load.*`), use
+ * reportFailure instead; this is for the second line.
+ */
+export function failureDetailKey(scope: string, err: unknown): string {
+  const offline = isRequestTimeout(err) || isNetworkFailure(err)
+  console.error(`[${scope}] failed: ${describeReason(err)}`)
+  return offline ? OFFLINE_DETAIL_KEY : GENERIC_DETAIL_KEY
+}
+
+/**
+ * Body text for an Alert after a failed ACTION (a save, delete, export, send).
+ *
+ * These alerts used to pass errMessage(err) straight through, which showed users
+ * raw Postgres text — and, once requests gained deadlines, would have shown them
+ * "RequestTimeoutError: The request timed out." The localized title above the
+ * body already says what failed; this says what to do about it.
+ *
+ * `t` is injected so this module stays i18n-free and unit-testable headless.
+ */
+export function actionFailureMessage(
+  scope: string,
+  err: unknown,
+  t: (key: string) => string,
+): string {
+  if (isUserFacingError(err)) {
+    console.error(`[${scope}] failed: ${errMessage(err)}`)
+    return errMessage(err).replace(/^UserFacingError:\s*/, '')
+  }
+  return t(failureDetailKey(scope, err))
+}
+
+/**
+ * Body text for a failed SAVE, where the user is mid-edit and the thing they need
+ * to know is that their work is not persisted — not what went wrong. Separate
+ * from actionFailureMessage because a debounced save retries itself, so there is
+ * nothing for the user to tap.
+ */
+export function saveFailureKey(scope: string, err: unknown): string {
+  console.error(`[${scope}] save failed: ${describeReason(err)}`)
+  return 'errors:saveFailed'
 }

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -1,10 +1,38 @@
+import { isAbortError, isRequestTimeout } from './requestBudget'
+
 // Supabase errors are plain objects ({ message, details, hint, code }), not Error
 // instances — so `String(err)` yields "[object Object]". Extract a readable
 // message across Error instances, Supabase error objects, and strings.
+//
+// This is a DIAGNOSTIC extractor, not a user-facing sanitiser. Do not render its
+// output: it has leaked raw Postgres text to users before (`column
+// user_starred_songs.created_at does not exist`), and with request deadlines in
+// place it would now also surface `request_timeout_14000`. Log it, and show the
+// caller's own localized copy instead — see reportLoadFailure.
 export function errMessage(err: unknown): string {
   if (err instanceof Error) return err.message
   if (err && typeof err === 'object' && 'message' in err) {
     return String((err as { message: unknown }).message)
   }
   return String(err)
+}
+
+/**
+ * Log a failed read, and report whether the UI should show an error for it.
+ *
+ * Returns false for a deliberate cancellation (a user-cancelled download, or any
+ * caller-supplied abort), which must never be presented to the user as a
+ * failure — that is the one abort case the app can produce that is not a
+ * timeout. Returns true for a real failure, including one of our own deadlines,
+ * which is logged as such so a timeout is distinguishable from a query error in
+ * the console without being distinguishable in the UI (to the user, "no network"
+ * and "too slow" are the same problem with the same fix).
+ *
+ * `scope` is the hook or screen name, e.g. 'useStarredSongs'.
+ */
+export function reportLoadFailure(scope: string, err: unknown): boolean {
+  if (isAbortError(err)) return false
+  const reason = isRequestTimeout(err) ? 'request timed out' : errMessage(err)
+  console.error(`[${scope}] load failed: ${reason}`)
+  return true
 }

--- a/apps/mobile/src/lib/greetings.ts
+++ b/apps/mobile/src/lib/greetings.ts
@@ -1,6 +1,4 @@
-import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { supabase } from './supabase'
 
 // The greeting PHRASES live in the home locale namespace
 // (src/i18n/locales/<lng>/home.json — greeting.* and the editable subGreetings
@@ -40,17 +38,4 @@ export function getDisplayName(user: User | null): string | null {
   const email = user?.email
   if (email) return email.split('@')[0]
   return null
-}
-
-/** Track the current auth user (for the greeting). Mirrors the root auth wiring. */
-export function useCurrentUser(): User | null {
-  const [user, setUser] = useState<User | null>(null)
-  useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setUser(data.user ?? null))
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null)
-    })
-    return () => sub.subscription.unsubscribe()
-  }, [])
-  return user
 }

--- a/apps/mobile/src/lib/launchStorage.ts
+++ b/apps/mobile/src/lib/launchStorage.ts
@@ -1,0 +1,103 @@
+// One AsyncStorage round trip for the whole splash gate.
+//
+// The launch path hydrates eight device-local stores before first paint, and
+// between them they read 12 keys with 12 separate getItem calls (five in
+// defaults.ts alone). This module reads all 12 in a single multiGet and hands
+// back a KVStorage-shaped facade served from the result.
+//
+// The point of the facade — rather than teaching each store to accept a
+// pre-read value — is that NOT ONE LINE of parsing, validation or fallback logic
+// in those stores changes. Every key backs a user preference, and a silent
+// behaviour change here would reset people's settings on upgrade. Equivalence is
+// established by construction instead of by review.
+//
+// RN-free (storage is injected, like defaults.ts) so it unit-tests headless.
+
+export type KVStorage = {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+/** AsyncStorage's shape, narrowed to what this module uses. */
+export type BatchKVStorage = KVStorage & {
+  multiGet(keys: string[]): Promise<readonly (readonly [string, string | null])[]>
+}
+
+/**
+ * Every key read inside the splash-gating Promise.all in app/_layout.tsx, in
+ * hydration order. Each one is owned by the module listed beside it, which is
+ * also where its fallback lives — this list must stay in sync with those reads,
+ * but a key MISSING from this list is harmless: the facade simply delegates that
+ * getItem to the real store, exactly as today.
+ *
+ * Deliberately excluded: GoTrue's own session key (read behind the auth
+ * navigator lock and bounded by GATE_MS, not by us), gc.pendingSprite (only read
+ * on a SIGNED_IN event), and the screen-scoped keys in autoHideChrome.ts and
+ * useDailyHighlights.ts, which are not on the launch path.
+ */
+export const LAUNCH_STORAGE_KEYS = [
+  'gc.defaults.theme', // defaults.ts             → 'system'
+  'gc.defaults.chordStyle', // defaults.ts             → 'letters'
+  'gc.defaults.keepAwake', // defaults.ts             → false ('1' is the only true)
+  'gc.defaults.language', // defaults.ts             → null (follow device)
+  'gc.defaults.dailyWordDestination', // defaults.ts   → 'landing'
+  'gc.downloads.v1', // downloads/manifest.ts   → DEFAULT_DOWNLOADS_STATE
+  'gc.songdrafts.v1', // drafts/draftsStore.ts   → DEFAULT_DRAFTS_STATE
+  'gc.recents.songs.v1', // recents.ts              → []
+  'gc.readingStreak.v1', // readingStreak.ts        → DEFAULT_READING_STREAK
+  'gc.readerReminder.v1', // readerReminder.ts       → DEFAULT_READER_REMINDER
+  'gc.viewer.columnMode.v1', // viewerPrefs.ts       → EMPTY (default 'single')
+  'gc.bible.translation.v1', // bibleTranslationPref.ts → '' (no prior choice)
+] as const
+
+/**
+ * Read `keys` in one batch and return a KVStorage that serves those reads from
+ * memory.
+ *
+ * Behaviour that is deliberately identical to 12 separate getItem calls:
+ *
+ * - A key absent from storage yields null, which is what every store's
+ *   missing-value branch already handles. multiGet reports an absent key as
+ *   [key, null], and a pair missing from the response falls to null too.
+ * - A REJECTING multiGet returns the raw store untouched, so each module does
+ *   its own getItem behind its own try/catch just as it does today. Without
+ *   this, one failed batch would reset all 12 preferences to defaults at once —
+ *   a far worse failure than the per-module degradation we have now.
+ *
+ * The facade is a correct KVStorage for the app's whole lifetime, not just for
+ * the launch read: the stores keep whatever storage they were handed for
+ * write-through (`storage = store` in each hydrate function), so setDefaultTheme
+ * will call this object hours later. Writes therefore delegate to the real
+ * store, and each primed read is consumed once so any later read goes straight
+ * to the real store rather than to a stale snapshot.
+ */
+export async function primeLaunchStorage(
+  store: BatchKVStorage,
+  keys: readonly string[] = LAUNCH_STORAGE_KEYS,
+): Promise<KVStorage> {
+  let primed: Map<string, string | null>
+  try {
+    const pairs = await store.multiGet([...keys])
+    primed = new Map(pairs.map(([key, value]) => [key, value ?? null]))
+  } catch {
+    return store
+  }
+
+  return {
+    getItem: async (key) => {
+      if (!primed.has(key)) return store.getItem(key)
+      const value = primed.get(key) ?? null
+      primed.delete(key)
+      return value
+    },
+    setItem: (key, value) => {
+      primed.delete(key)
+      return store.setItem(key, value)
+    },
+    removeItem: (key) => {
+      primed.delete(key)
+      return store.removeItem(key)
+    },
+  }
+}

--- a/apps/mobile/src/lib/requestBudget.ts
+++ b/apps/mobile/src/lib/requestBudget.ts
@@ -1,0 +1,197 @@
+// The app's ONE network timeout policy. Every timeout number the app uses lives
+// here; no call site invents its own.
+//
+// Kept RN-free (no react-native / AsyncStorage imports) so it unit-tests headless
+// under vitest, like authSession.ts. `fetch`, AbortController and setTimeout are
+// the only globals it touches, and all three exist in node and in React Native.
+//
+// Why this exists: before it, exactly one network operation in the whole app was
+// bounded (the boot session read). Everything else — every Supabase query, both
+// api.ts fetches, every R2 chapter read, all 1189 downloader requests — ran on
+// the platform default, up to ~60 s on iOS. A request that never settles is an
+// infinite spinner, and an infinite spinner is indistinguishable from a hung app.
+
+/**
+ * Boot session read. Nothing is on screen — the native splash is still up, so
+ * this is the only budget the user experiences as "the app has not launched".
+ *
+ * Unchanged from build 12; it lives here rather than in authSession.ts so the
+ * whole budget reads in one place. See resolveInitialSession for why a race
+ * (not a catch) and why a timeout degrades to signed out.
+ */
+export const GATE_MS = 2500
+
+/**
+ * A request the user is watching a spinner for.
+ *
+ * Derived from the slowest connection that must still SUCCEED, not from what
+ * feels fast. On congested cellular with a cold socket: DNS 1 RTT + TCP 1 RTT +
+ * TLS 1.3 1 RTT + request 1 RTT is ~4.8 s at a 1.2 s RTT, and moving a ~60 KB
+ * chapter JSON at ~80 kbit/s adds ~6 s — call it 11 s for a request that would
+ * have worked. +30% margin → 14 s. Still 4x faster than iOS's ~60 s default.
+ *
+ * Biasing this number down buys nothing the user can see (a spinner is a spinner
+ * either way) and costs real failures on slow-but-working links. The value of a
+ * bound here is that the screen is GUARANTEED to reach a terminal state, not
+ * that it reaches it quickly.
+ */
+export const FOREGROUND_MS = 14000
+
+/**
+ * Speculative work the user never sees and never waits for.
+ *
+ * Shorter than FOREGROUND on purpose: abandoning it frees the socket and the
+ * cellular radio for the request the user IS waiting on, and a prefetch that has
+ * not landed by the time the user could plausibly reach the screen has no value
+ * left to deliver. 7 s is the floor of "launch finished and the user tapped
+ * through to Daily Word".
+ */
+export const BACKGROUND_MS = 7000
+
+/**
+ * Thrown when OUR deadline fired. Never thrown for a caller's own abort — see
+ * withRequestBudget.
+ *
+ * Two details here are load-bearing and were both established by reading the
+ * installed client source, not assumed:
+ *
+ * `code = 'ABORT_ERR'`. postgrest-js retries a failed fetch on idempotent
+ * methods — RETRYABLE_METHODS is ['GET','HEAD','OPTIONS'], retry defaults to ON,
+ * DEFAULT_MAX_RETRIES is 3, backoff 1s/2s/4s — and short-circuits that loop only
+ * for `fetchError.name === 'AbortError' || fetchError.code === 'ABORT_ERR'`.
+ * Every read this app makes is a GET, so a custom code would have had each
+ * timeout retried three more times: 14+1+14+2+14+4+14 ≈ 63 s for one blackholed
+ * read, WORSE than the ~60 s platform default this exists to fix. Presenting as
+ * ABORT_ERR makes postgrest rethrow immediately, so one budget means one budget.
+ *
+ * A HUMAN-READABLE message, not a token. postgrest discards `code` for
+ * client-side network errors (it deliberately reserves that field for PostgREST
+ * and Postgres codes) and reshapes the failure as
+ * `{ message: '<name>: <message>' }`, so the message is the only channel that
+ * survives a Supabase query. Two screens still render that text directly —
+ * app/viewer/[slug].tsx and SetlistBuilderScreen — so it has to read as a
+ * sentence rather than as `request_timeout_14000`.
+ */
+export class RequestTimeoutError extends Error {
+  readonly name = 'RequestTimeoutError'
+  readonly code = 'ABORT_ERR'
+  constructor(readonly budgetMs: number) {
+    super('The request timed out.')
+  }
+}
+
+/**
+ * True when a failure was our deadline, whether or not the Error survived.
+ *
+ * The message check is not laziness: a timeout inside a Supabase query reaches
+ * the caller as a plain object whose `name` is gone and whose `code` postgrest
+ * has blanked, leaving `message` prefixed with the constructor name as the only
+ * evidence. Direct fetch callers (R2, api.ts, the downloader) still get the real
+ * instance and match on the first two checks.
+ */
+export function isRequestTimeout(err: unknown): boolean {
+  if (err instanceof RequestTimeoutError) return true
+  if (!err || typeof err !== 'object') return false
+  const e = err as { name?: unknown; message?: unknown }
+  if (e.name === 'RequestTimeoutError') return true
+  return typeof e.message === 'string' && e.message.startsWith('RequestTimeoutError:')
+}
+
+/**
+ * True for a cancellation someone asked for deliberately (a user-cancelled
+ * download, or a caller-supplied signal) rather than a failure. These must never
+ * be shown to the user as an error.
+ *
+ * Note the app has no unmount-driven aborts by design: hooks use a cooperative
+ * `alive` boolean instead, because bibleSource's getPassage shares one in-flight
+ * promise between the launch prefetch and the reader — a component-owned
+ * AbortController there would cancel a request another subscriber is still
+ * waiting on. So in practice this only fires for the downloads cancel path.
+ */
+export function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  if (isRequestTimeout(err)) return false
+  const e = err as { name?: unknown; message?: unknown }
+  if (e.name === 'AbortError') return true
+  // Same flattening caveat as isRequestTimeout: a Supabase query keeps only the
+  // message, with the original error's name prefixed onto it.
+  return typeof e.message === 'string' && e.message.startsWith('AbortError:')
+}
+
+/**
+ * Deliberately the same shape as the global `fetch`, so the real one is
+ * assignable with no cast and a wrapped one is assignable wherever a fetch is
+ * expected — including core's narrower `FetchLike` (which takes a string URL and
+ * reads only ok/status/json off the response).
+ */
+export type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+function urlOf(input: string | URL | Request): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  return String((input as Request).url ?? input)
+}
+
+/**
+ * Wrap a fetch so every request gets a deadline. Returns a drop-in fetch.
+ *
+ * `budgetFor` receives the request URL and returns the budget in ms, or null to
+ * leave that request on the platform default.
+ *
+ * A caller's own `signal` (a user cancel) is forwarded and still surfaces as a
+ * plain AbortError. ONLY our timer produces a RequestTimeoutError, which is the
+ * whole timeout-vs-cancellation distinction. It is tracked with a boolean rather
+ * than AbortSignal.reason because React Native's AbortController does not
+ * reliably carry a reason.
+ */
+export function withRequestBudget(
+  fetchImpl: FetchFn,
+  budgetFor: (url: string) => number | null,
+): FetchFn {
+  return async (input, init) => {
+    const budgetMs = budgetFor(urlOf(input))
+    if (budgetMs == null) return fetchImpl(input, init)
+
+    const controller = new AbortController()
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, budgetMs)
+
+    const callerSignal = init?.signal
+    const relayAbort = () => controller.abort()
+    if (callerSignal) {
+      if (callerSignal.aborted) controller.abort()
+      else callerSignal.addEventListener('abort', relayAbort)
+    }
+
+    try {
+      return await fetchImpl(input, { ...init, signal: controller.signal })
+    } catch (err) {
+      if (timedOut) throw new RequestTimeoutError(budgetMs)
+      throw err
+    } finally {
+      clearTimeout(timer)
+      callerSignal?.removeEventListener('abort', relayAbort)
+    }
+  }
+}
+
+/**
+ * Stop WAITING on a promise after `ms`, without cancelling it — the same
+ * race-not-catch shape as resolveInitialSession.
+ *
+ * For work whose result is optional and whose underlying requests are shared:
+ * the launch-time Daily Word prefetch stops being awaited at BACKGROUND_MS, but
+ * its in-flight chapter requests keep their own (longer) budget and still
+ * populate the cache if they land, so a reader that joins one is not
+ * shortchanged.
+ */
+export function withDeadline<T>(work: Promise<T>, ms: number, onLapse: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(onLapse), ms)
+  })
+  return Promise.race([work, deadline]).finally(() => clearTimeout(timer))
+}

--- a/apps/mobile/src/lib/supabase.ts
+++ b/apps/mobile/src/lib/supabase.ts
@@ -4,6 +4,7 @@ import { AppState } from 'react-native'
 import { createGcSupabase } from '@gracechords/core'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { silenceInvalidRefreshTokenLogs } from './authSession'
+import { FOREGROUND_MS, withRequestBudget } from './requestBudget'
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL
 const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
@@ -34,10 +35,37 @@ if (!supabaseConfigError) {
   silenceInvalidRefreshTokenLogs()
 }
 
+// Which requests this client bounds, and which it deliberately does not.
+//
+// The TOKEN REFRESH is left on the platform default on purpose. Build 12 races
+// the boot getSession() against GATE_MS and degrades to signed out, then depends
+// on that same in-flight refresh SETTLING later so the onAuthStateChange
+// subscription in app/_layout.tsx can adopt the corrected session — see
+// authSession.ts. A deadline on that request would compete with the race and
+// close the self-heal window, and nobody is waiting on it: the splash lifted at
+// 2.5 s. (Verified in @supabase/auth-js that an aborted fetch becomes
+// AuthRetryableFetchError, which _callRefreshToken explicitly does NOT treat as
+// grounds for _removeSession — so this exclusion is defence in depth, not the
+// thing standing between a live user and being signed out.)
+//
+// Everything else is bounded: sign-in and sign-up (grant_type=password /
+// id_token hit the same /auth/v1/token path), getUser, and every PostgREST
+// query and mutation. Those all have someone watching a spinner.
+function supabaseRequestBudget(requestUrl: string): number | null {
+  if (requestUrl.includes('grant_type=refresh_token')) return null
+  return FOREGROUND_MS
+}
+
 // Consume the SAME core factory the web app uses. We inject AsyncStorage as the
 // native session store; persistSession + autoRefreshToken default to true in
 // the factory. detectSessionInUrl is irrelevant on native (no URL redirect),
 // so turn it off — the factory defaults it to true for the web.
+//
+// `global.fetch` is the one seam that reaches every request the client makes:
+// supabase-js hands it to GoTrue, PostgREST, storage and functions alike, so a
+// single wrapper bounds ~40 query sites plus all of auth without touching any of
+// them. Per-call .abortSignal() would have to be threaded through every call
+// site and would still miss GoTrue entirely.
 //
 // When config is missing we skip client creation (createClient itself throws on
 // an undefined url) and export a null client. The app root short-circuits to the
@@ -50,6 +78,9 @@ export const supabase: SupabaseClient = supabaseConfigError
       storage: AsyncStorage,
       auth: {
         detectSessionInUrl: false,
+      },
+      global: {
+        fetch: withRequestBudget(fetch, supabaseRequestBudget),
       },
     })
 

--- a/apps/mobile/src/lib/useLastSet.ts
+++ b/apps/mobile/src/lib/useLastSet.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import { useFocusEffect } from 'expo-router'
 import { fetchLastSetSummary, summarizeSet } from '@gracechords/core'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { reportLoadFailure } from './errors'
 
 // Summary of the user's most recently edited setlist for Home's "Last set"
 // card (replaces the getLastSet() stub that lived in recents.ts).
@@ -16,46 +16,63 @@ export type Setlist = {
   updatedAt?: string
 }
 
-// The most recently updated personal setlist, summarized. Refetches whenever
-// the owning screen regains focus so edits in the builder show up on Home.
+// i18n key for the user-facing failure — never the raw error. See errors.ts.
+const LOAD_ERROR_KEY = 'errors:load.lastSet'
+
+// The most recently updated personal setlist, summarized.
+//
+// Refetches on every focus of the owning screen, deliberately. Setlists are
+// server-only and every write funnels through three core functions reached from
+// ten mobile call sites, three of which bypass the useSetlists wrapper and call
+// core directly (SetlistBuilderScreen's newSet, and both writes in
+// SetlistImportScreen). A mount-only fetch plus mutation-driven invalidation
+// would be correct only while every one of those sites remembers to signal, and
+// the cost of one missed signal is a permanently stale card — worse than the one
+// `setlists` query per tab switch this would save. Left as focus-driven on
+// purpose; revisit if a shared setlist store ever lands.
 export function useLastSet() {
   const [lastSet, setLastSet] = useState<Setlist | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  useFocusEffect(
-    useCallback(() => {
-      let alive = true
-      fetchLastSetSummary(supabase)
-        .then((data: Awaited<ReturnType<typeof fetchLastSetSummary>>) => {
-          if (!alive) return
-          if (!data) {
-            setLastSet(null)
-            setError(null)
-            return
-          }
-          const summary = summarizeSet(data.entries)
-          setLastSet({
-            id: data.id,
-            name: data.name,
-            songCount: summary.songCount,
-            durationMin: summary.durationMin,
-            keys: summary.keys ?? undefined,
-            updatedAt: data.updated_at,
-          })
+  const load = useCallback(() => {
+    let alive = true
+    fetchLastSetSummary(supabase)
+      .then((data: Awaited<ReturnType<typeof fetchLastSetSummary>>) => {
+        if (!alive) return
+        if (!data) {
+          setLastSet(null)
           setError(null)
+          return
+        }
+        const summary = summarizeSet(data.entries)
+        setLastSet({
+          id: data.id,
+          name: data.name,
+          songCount: summary.songCount,
+          durationMin: summary.durationMin,
+          keys: summary.keys ?? undefined,
+          updatedAt: data.updated_at,
         })
-        .catch((err: unknown) => {
-          if (alive) setError(errMessage(err))
-        })
-        .finally(() => {
-          if (alive) setLoading(false)
-        })
-      return () => {
-        alive = false
-      }
-    }, []),
-  )
+        setError(null)
+      })
+      .catch((err: unknown) => {
+        // A failed refetch deliberately leaves the previous `lastSet` in place:
+        // with the error now consumed by Home, that reads as stale-with-warning
+        // rather than as a silent lie. Before 1.0.1 Home discarded `error`
+        // entirely, so a failure rendered nothing at all — indistinguishable
+        // from "no setlists yet", with no way to retry.
+        if (reportLoadFailure('useLastSet', err) && alive) setError(LOAD_ERROR_KEY)
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
 
-  return { lastSet, loading, error }
+  useFocusEffect(load)
+
+  return { lastSet, loading, error, retry: load }
 }

--- a/apps/mobile/src/lib/useLastSet.ts
+++ b/apps/mobile/src/lib/useLastSet.ts
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 import { useFocusEffect } from 'expo-router'
 import { fetchLastSetSummary, summarizeSet } from '@gracechords/core'
 import { supabase } from './supabase'
-import { reportLoadFailure } from './errors'
+import { reportFailure } from './errors'
 
 // Summary of the user's most recently edited setlist for Home's "Last set"
 // card (replaces the getLastSet() stub that lived in recents.ts).
@@ -62,7 +62,7 @@ export function useLastSet() {
         // rather than as a silent lie. Before 1.0.1 Home discarded `error`
         // entirely, so a failure rendered nothing at all — indistinguishable
         // from "no setlists yet", with no way to retry.
-        if (reportLoadFailure('useLastSet', err) && alive) setError(LOAD_ERROR_KEY)
+        if (reportFailure('useLastSet', err) && alive) setError(LOAD_ERROR_KEY)
       })
       .finally(() => {
         if (alive) setLoading(false)

--- a/apps/mobile/src/lib/useProfileSprite.ts
+++ b/apps/mobile/src/lib/useProfileSprite.ts
@@ -1,7 +1,7 @@
 import { useEffect, useSyncExternalStore } from 'react'
 import type { ImageSourcePropType } from 'react-native'
 import { supabase } from './supabase'
-import { useCurrentUser } from './greetings'
+import { useCurrentUserState } from './currentUser'
 import { fetchSpritePreference } from './profile'
 import { SPRITE_SOURCES, type SpriteId } from './sprites'
 
@@ -14,6 +14,15 @@ import { SPRITE_SOURCES, type SpriteId } from './sprites'
 let cachedUserId: string | null = null
 let cachedSprite: SpriteId | null = null
 const listeners = new Set<() => void>()
+
+// The read is shared across consumers, not just the result. Four screens use this
+// hook (Home, Settings, the Daily Word landing, the sprite picker) and each used
+// to issue its own `users.preferences` select on mount, because the effect fires
+// per hook instance and cachedSprite is only populated once a fetch resolves.
+// `fetchedUserId` records who we have already read for; `inFlight` coalesces
+// concurrent mounts into one request.
+let fetchedUserId: string | null = null
+let inFlight: Promise<void> | null = null
 
 function emit() {
   for (const l of listeners) l()
@@ -34,27 +43,43 @@ export function setLocalSprite(id: SpriteId | null): void {
 }
 
 export function useProfileSprite(): { spriteId: SpriteId | null; source: ImageSourcePropType | null } {
-  const user = useCurrentUser()
+  const { user, resolved } = useCurrentUserState()
   const spriteId = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 
   useEffect(() => {
+    // Don't touch the cache before auth is known: a null user here would mean
+    // "not resolved yet", not "signed out", and clearing on it would drop a
+    // perfectly good sprite (and then re-fetch it).
+    if (!resolved) return
     const uid = user?.id ?? null
     // Reset the cache when the account changes (sign out / switch user).
     if (uid !== cachedUserId) {
       cachedUserId = uid
+      fetchedUserId = null
+      inFlight = null
       setLocalSprite(null)
     }
     if (!uid) return
-    let alive = true
-    fetchSpritePreference(supabase, uid)
-      .then((id) => {
-        if (alive && id && id in SPRITE_SOURCES) setLocalSprite(id as SpriteId)
-      })
-      .catch(() => {})
-    return () => {
-      alive = false
+    if (fetchedUserId === uid) return
+    if (!inFlight) {
+      inFlight = fetchSpritePreference(supabase, uid)
+        .then((id) => {
+          // Ignore a late result for an account we have since switched away from.
+          if (cachedUserId !== uid) return
+          fetchedUserId = uid
+          if (id && id in SPRITE_SOURCES) setLocalSprite(id as SpriteId)
+        })
+        .catch(() => {
+          // A failed read is indistinguishable from "no sprite picked" — the
+          // caller falls back to the `person` glyph. Left un-surfaced on purpose:
+          // it is a cosmetic preference, not content. Not marked as fetched, so
+          // the next mount retries.
+        })
+        .finally(() => {
+          inFlight = null
+        })
     }
-  }, [user?.id])
+  }, [user?.id, resolved])
 
   return { spriteId, source: spriteId ? SPRITE_SOURCES[spriteId] : null }
 }

--- a/apps/mobile/src/lib/useReader.ts
+++ b/apps/mobile/src/lib/useReader.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { getCachedPassage, getPassage, type BibleTranslation, type ChapterData, type Passage } from './bibleSource'
-import { errMessage } from './errors'
+import { failureDetailKey } from './errors'
 
 // Session-ephemeral reader typography preferences. Per the Daily Word spec these
 // "could also live in Profile → reader preferences," but they are not tied to
@@ -80,7 +80,13 @@ export function usePassageChapter(
         if (alive) setState({ chapter, loading: false, error: null })
       })
       .catch((err: unknown) => {
-        if (alive) setState({ chapter: null, loading: false, error: errMessage(err) })
+        // The reader renders its own localized copy and only reads this for
+        // truthiness, so the value was never shown — but it held raw error text,
+        // which made it a trap for anyone who later decided to render it, and
+        // nothing logged reader failures at all. An i18n key closes both.
+        if (alive) {
+          setState({ chapter: null, loading: false, error: failureDetailKey('usePassageChapter', err) })
+        }
       })
 
     return () => {

--- a/apps/mobile/src/lib/useReflections.ts
+++ b/apps/mobile/src/lib/useReflections.ts
@@ -9,7 +9,10 @@ import {
   type Reflection,
 } from '@gracechords/core'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { reportLoadFailure } from './errors'
+
+// i18n key for the user-facing failure — never the raw error. See errors.ts.
+const LOAD_ERROR_KEY = 'errors:load.reflection'
 
 // Private per-user reflections for the Daily Word landing + journal. Same plain
 // loading/error/data pattern as useSetlists — no React Query. All reads/writes
@@ -48,7 +51,7 @@ export function useTodayReflection(dateKey: string = reflectionDateKey(new Date(
       setReflection(row)
       setError(null)
     } catch (err: unknown) {
-      setError(errMessage(err))
+      if (reportLoadFailure('useTodayReflection', err)) setError(LOAD_ERROR_KEY)
     } finally {
       setLoading(false)
     }
@@ -107,7 +110,7 @@ export function useReflectionList() {
       setReflections(rows)
       setError(null)
     } catch (err: unknown) {
-      setError(errMessage(err))
+      if (reportLoadFailure('useReflectionList', err)) setError(LOAD_ERROR_KEY)
     } finally {
       setLoading(false)
     }

--- a/apps/mobile/src/lib/useReflections.ts
+++ b/apps/mobile/src/lib/useReflections.ts
@@ -9,7 +9,7 @@ import {
   type Reflection,
 } from '@gracechords/core'
 import { supabase } from './supabase'
-import { reportLoadFailure } from './errors'
+import { reportFailure } from './errors'
 
 // i18n key for the user-facing failure — never the raw error. See errors.ts.
 const LOAD_ERROR_KEY = 'errors:load.reflection'
@@ -51,7 +51,7 @@ export function useTodayReflection(dateKey: string = reflectionDateKey(new Date(
       setReflection(row)
       setError(null)
     } catch (err: unknown) {
-      if (reportLoadFailure('useTodayReflection', err)) setError(LOAD_ERROR_KEY)
+      if (reportFailure('useTodayReflection', err)) setError(LOAD_ERROR_KEY)
     } finally {
       setLoading(false)
     }
@@ -110,7 +110,7 @@ export function useReflectionList() {
       setReflections(rows)
       setError(null)
     } catch (err: unknown) {
-      if (reportLoadFailure('useReflectionList', err)) setError(LOAD_ERROR_KEY)
+      if (reportFailure('useReflectionList', err)) setError(LOAD_ERROR_KEY)
     } finally {
       setLoading(false)
     }

--- a/apps/mobile/src/lib/useSetlistBuilder.ts
+++ b/apps/mobile/src/lib/useSetlistBuilder.ts
@@ -8,7 +8,7 @@ import {
   updateSetlist,
 } from '@gracechords/core'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { failureDetailKey, saveFailureKey } from './errors'
 import { useSongList, type Song } from './useSongList'
 
 // The song metadata a row needs to render (no chart body / tags). Comes from
@@ -109,7 +109,12 @@ export function useSetlistBuilder(setlistId: string) {
       })
       setError(null)
     } catch (err: unknown) {
-      setError(errMessage(err))
+      // A SAVE failure, not a load failure — the distinction matters here because
+      // the user is mid-edit and needs to know their work is not persisted. The
+      // debounced save retries on the next edit (and on flushSave), so the copy
+      // says "haven't been saved" rather than offering a button. An i18n key, not
+      // raw error text: the builder renders this line directly.
+      setError(saveFailureKey('useSetlistBuilder.save', err))
     } finally {
       inFlight.current = false
       if (trailing.current) {
@@ -170,7 +175,7 @@ export function useSetlistBuilder(setlistId: string) {
         })
         .catch((err: unknown) => {
           if (alive) {
-            setError(errMessage(err))
+            setError(failureDetailKey('useSetlistBuilder.load', err))
             setLoading(false)
           }
         })

--- a/apps/mobile/src/lib/useSetlists.ts
+++ b/apps/mobile/src/lib/useSetlists.ts
@@ -6,7 +6,11 @@ import {
   personalSetlistLimit,
 } from '@gracechords/core'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { getCurrentUserSnapshot } from './currentUser'
+import { reportLoadFailure } from './errors'
+
+// i18n key for the user-facing failure — never the raw error. See errors.ts.
+const LOAD_ERROR_KEY = 'errors:load.setlists'
 
 // A setlist row as the Setlists tab needs it: metadata plus a song count
 // (flattened from the PostgREST `setlist_songs(count)` relationship embed).
@@ -56,7 +60,7 @@ export function useSetlists() {
       )
       setError(null)
     } catch (err: unknown) {
-      setError(errMessage(err))
+      if (reportLoadFailure('useSetlists', err)) setError(LOAD_ERROR_KEY)
     } finally {
       setLoading(false)
     }
@@ -109,8 +113,11 @@ export function useSetlists() {
 // fails — the DB trigger remains the real gate, so a lenient default only risks
 // one extra blocked insert, never an over-cap save.
 async function fetchUserLimit(): Promise<number> {
-  const { data: userData } = await supabase.auth.getUser()
-  const userId = userData?.user?.id
+  // The id comes from the shared session-backed store rather than
+  // auth.getUser(), which is a round trip to /auth/v1/user on every Setlists
+  // focus. The ROLE is still read from the DB below — that is the authoritative
+  // bit; the id is just a key.
+  const userId = getCurrentUserSnapshot().user?.id
   if (!userId) return personalSetlistLimit('user')
   const { data, error } = await supabase
     .from('users')

--- a/apps/mobile/src/lib/useSetlists.ts
+++ b/apps/mobile/src/lib/useSetlists.ts
@@ -7,7 +7,7 @@ import {
 } from '@gracechords/core'
 import { supabase } from './supabase'
 import { getCurrentUserSnapshot } from './currentUser'
-import { reportLoadFailure } from './errors'
+import { reportFailure } from './errors'
 
 // i18n key for the user-facing failure — never the raw error. See errors.ts.
 const LOAD_ERROR_KEY = 'errors:load.setlists'
@@ -60,7 +60,7 @@ export function useSetlists() {
       )
       setError(null)
     } catch (err: unknown) {
-      if (reportLoadFailure('useSetlists', err)) setError(LOAD_ERROR_KEY)
+      if (reportFailure('useSetlists', err)) setError(LOAD_ERROR_KEY)
     } finally {
       setLoading(false)
     }

--- a/apps/mobile/src/lib/useSong.ts
+++ b/apps/mobile/src/lib/useSong.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { fetchSongBySlug, fetchPersonalSongById } from '@gracechords/core'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { failureDetailKey } from './errors'
 
 // Shape of a single song row as the Viewer needs it: the Library metadata plus
 // the renderable ChordPro body (which the list query deliberately omits).
@@ -70,7 +70,10 @@ export function useSong(slug: string | undefined) {
         }
       })
       .catch((err: unknown) => {
-        if (alive) setError(errMessage(err))
+        // An i18n KEY, not raw error text. The Viewer renders this as the detail
+        // line under its localized "Couldn't load song" heading, so raw Supabase
+        // text (or a request-deadline message) used to land in front of the user.
+        if (alive) setError(failureDetailKey('useSong', err))
       })
       .finally(() => {
         if (alive) setLoading(false)
@@ -106,7 +109,7 @@ export function usePersonalSong(id: string | undefined) {
         }
       })
       .catch((err: unknown) => {
-        if (alive) setError(errMessage(err))
+        if (alive) setError(failureDetailKey('usePersonalSong', err))
       })
       .finally(() => {
         if (alive) setLoading(false)

--- a/apps/mobile/src/lib/useSongList.ts
+++ b/apps/mobile/src/lib/useSongList.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import { fetchSongList, fetchPersonalSongs } from '@gracechords/core'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { reportLoadFailure } from './errors'
+
+// i18n key for the user-facing failure. The hook owns it because the hook knows
+// which surface it feeds; the screen renders it through its own `t`. Never the
+// raw error — see errors.ts.
+const LOAD_ERROR_KEY = 'errors:load.songs'
 
 // Shape of a song row as the Library needs it. The base fetchSongList selects
 // only id/slug/title/artist/default_key, so we widen the column list to also
@@ -95,7 +100,7 @@ export function useSongList() {
         setError(null)
       })
       .catch((err: unknown) => {
-        if (alive) setError(errMessage(err))
+        if (reportLoadFailure('useSongList', err) && alive) setError(LOAD_ERROR_KEY)
       })
       .finally(() => {
         if (alive) setLoading(false)

--- a/apps/mobile/src/lib/useSongList.ts
+++ b/apps/mobile/src/lib/useSongList.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { fetchSongList, fetchPersonalSongs } from '@gracechords/core'
 import { supabase } from './supabase'
-import { reportLoadFailure } from './errors'
+import { reportFailure } from './errors'
 
 // i18n key for the user-facing failure. The hook owns it because the hook knows
 // which surface it feeds; the screen renders it through its own `t`. Never the
@@ -100,7 +100,7 @@ export function useSongList() {
         setError(null)
       })
       .catch((err: unknown) => {
-        if (reportLoadFailure('useSongList', err) && alive) setError(LOAD_ERROR_KEY)
+        if (reportFailure('useSongList', err) && alive) setError(LOAD_ERROR_KEY)
       })
       .finally(() => {
         if (alive) setLoading(false)

--- a/apps/mobile/src/lib/useStarredSongs.ts
+++ b/apps/mobile/src/lib/useStarredSongs.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { supabase } from './supabase'
-import { errMessage } from './errors'
+import { reportLoadFailure } from './errors'
 import type { Song } from './useSongList'
 
 // The fields the Home "Starred songs" rows need. A subset of the full Song.
@@ -11,11 +11,12 @@ export type StarredSong = Pick<
 
 const SONG_COLUMNS = 'id, slug, title, artist, default_key, time_signature'
 
-// User-facing fallback shown in the Home section if the read fails. Deliberately
-// generic: never surface raw Supabase/Postgres error text to the UI (that once
-// leaked `column user_starred_songs.created_at does not exist`). The real error is
-// logged for debugging.
-const LOAD_ERROR = 'Couldn’t load your starred songs.'
+// i18n key for the user-facing failure. Deliberately generic: never surface raw
+// Supabase/Postgres error text to the UI (that once leaked `column
+// user_starred_songs.created_at does not exist`). The real error is logged for
+// debugging by reportLoadFailure. Was a hardcoded English string until 1.0.1 —
+// it showed untranslated in es/ko/tr.
+const LOAD_ERROR_KEY = 'errors:load.starred'
 
 // Read the current user's starred songs. Two steps rather than a PostgREST embed
 // (`songs!inner(...)`): first the star rows (newest first), then the songs by id.
@@ -29,8 +30,14 @@ export function useStarredSongs() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
+  // Extracted from the mount effect so the Home card can offer a Retry. Before
+  // 1.0.1 a failed read stayed failed until the app relaunched: the effect had
+  // `[]` deps, Home has no RefreshControl, and Home's focus effect only bumps a
+  // tick for the local recents cache.
+  const load = useCallback(() => {
     let alive = true
+    setLoading(true)
+    setError(null)
     ;(async () => {
       try {
         const { data: sessionData } = await supabase.auth.getSession()
@@ -80,9 +87,9 @@ export function useStarredSongs() {
           setError(null)
         }
       } catch (err: unknown) {
-        // Log the real error for debugging; show a generic message to the user.
-        console.error('[useStarredSongs] Failed to load starred songs:', errMessage(err))
-        if (alive) setError(LOAD_ERROR)
+        // Logs the real error for debugging and returns false for a deliberate
+        // cancellation, which must not surface as a failure.
+        if (reportLoadFailure('useStarredSongs', err) && alive) setError(LOAD_ERROR_KEY)
       } finally {
         if (alive) setLoading(false)
       }
@@ -92,5 +99,7 @@ export function useStarredSongs() {
     }
   }, [])
 
-  return { songs, loading, error }
+  useEffect(() => load(), [load])
+
+  return { songs, loading, error, reload: load }
 }

--- a/apps/mobile/src/lib/useStarredSongs.ts
+++ b/apps/mobile/src/lib/useStarredSongs.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { supabase } from './supabase'
-import { reportLoadFailure } from './errors'
+import { reportFailure } from './errors'
 import type { Song } from './useSongList'
 
 // The fields the Home "Starred songs" rows need. A subset of the full Song.
@@ -14,7 +14,7 @@ const SONG_COLUMNS = 'id, slug, title, artist, default_key, time_signature'
 // i18n key for the user-facing failure. Deliberately generic: never surface raw
 // Supabase/Postgres error text to the UI (that once leaked `column
 // user_starred_songs.created_at does not exist`). The real error is logged for
-// debugging by reportLoadFailure. Was a hardcoded English string until 1.0.1 —
+// debugging by reportFailure. Was a hardcoded English string until 1.0.1 —
 // it showed untranslated in es/ko/tr.
 const LOAD_ERROR_KEY = 'errors:load.starred'
 
@@ -89,7 +89,7 @@ export function useStarredSongs() {
       } catch (err: unknown) {
         // Logs the real error for debugging and returns false for a deliberate
         // cancellation, which must not surface as a failure.
-        if (reportLoadFailure('useStarredSongs', err) && alive) setError(LOAD_ERROR_KEY)
+        if (reportFailure('useStarredSongs', err) && alive) setError(LOAD_ERROR_KEY)
       } finally {
         if (alive) setLoading(false)
       }

--- a/apps/mobile/src/screens/AboutScreen.tsx
+++ b/apps/mobile/src/screens/AboutScreen.tsx
@@ -124,7 +124,7 @@ export default function AboutScreen() {
             marginTop: t.spacing.xl,
             textAlign: 'center',
             fontSize: 12.5,
-            color: t.colors.muted,
+            color: t.colors.sec,
           }}
         >
           {tx('common:copyright', { range: copyrightRange() })}
@@ -156,7 +156,7 @@ export default function AboutScreen() {
           style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
         >
           <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('common:settings')}</Text>
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('common:settings')}</Text>
         </Pressable>
       </GlassSurface>
     </Screen>

--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -202,7 +202,7 @@ export default function AuthScreen() {
           {/* Divider */}
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: t.spacing.md }}>
             <View style={{ flex: 1, height: 1, backgroundColor: t.colors.border }} />
-            <Text style={{ fontSize: 12.5, color: t.colors.muted }}>{tx('orContinueWith')}</Text>
+            <Text style={{ fontSize: 12.5, color: t.colors.sec }}>{tx('orContinueWith')}</Text>
             <View style={{ flex: 1, height: 1, backgroundColor: t.colors.border }} />
           </View>
 
@@ -252,7 +252,7 @@ export default function AuthScreen() {
           </View>
 
           {isSignup ? (
-            <Text style={{ fontSize: 12.5, color: t.colors.muted, textAlign: 'center' }}>
+            <Text style={{ fontSize: 12.5, color: t.colors.sec, textAlign: 'center' }}>
               {tx('terms.prefix')}
               <Text style={{ color: t.colors.textAccent }}>{tx('terms.terms')}</Text>
               {tx('terms.and')}

--- a/apps/mobile/src/screens/CapoCalculatorScreen.tsx
+++ b/apps/mobile/src/screens/CapoCalculatorScreen.tsx
@@ -79,7 +79,7 @@ export default function CapoCalculatorScreen({ embedded }: { embedded?: boolean 
               fontSize: 44,
               fontWeight: '700',
               letterSpacing: -0.5,
-              color: fret === 0 ? t.colors.muted : t.colors.accent,
+              color: fret === 0 ? t.colors.sec : t.colors.accent,
             }}
           >
             {fret === 0 ? tx('capo.resultNone') : tx('capo.result', { fret })}
@@ -88,7 +88,7 @@ export default function CapoCalculatorScreen({ embedded }: { embedded?: boolean 
             style={{
               marginTop: t.spacing.xs,
               fontSize: t.typography.body.fontSize,
-              color: t.colors.muted,
+              color: t.colors.sec,
               textAlign: 'center',
             }}
           >
@@ -139,7 +139,7 @@ export default function CapoCalculatorScreen({ embedded }: { embedded?: boolean 
             style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
           >
             <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('nav:utilities')}</Text>
           </Pressable>
         )}
         <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('capo.title')}</Text>

--- a/apps/mobile/src/screens/DailyWordLandingScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordLandingScreen.tsx
@@ -159,7 +159,7 @@ export default function DailyWordLandingScreen() {
             fontWeight: '700',
             letterSpacing: 0.9,
             textTransform: 'uppercase',
-            color: t.colors.muted,
+            color: t.colors.sec,
             marginTop: t.spacing.xl,
             marginBottom: t.spacing.md,
           }}
@@ -202,7 +202,7 @@ export default function DailyWordLandingScreen() {
                 >
                   {formatPassageLabel(p)}
                 </Text>
-                <SymbolIcon name="chevron.right" size={13} color={t.colors.muted} />
+                <SymbolIcon name="chevron.right" size={13} color={t.colors.sec} />
               </Pressable>
             ))}
           </Card>
@@ -213,7 +213,7 @@ export default function DailyWordLandingScreen() {
                 paddingVertical: 16,
                 paddingHorizontal: t.spacing.lg,
                 fontSize: t.typography.rowSubtitle.fontSize,
-                color: t.colors.muted,
+                color: t.colors.sec,
               }}
             >
               {tx('empty.subtitle')}
@@ -232,7 +232,7 @@ export default function DailyWordLandingScreen() {
             fontWeight: '700',
             letterSpacing: 0.9,
             textTransform: 'uppercase',
-            color: t.colors.muted,
+            color: t.colors.sec,
             marginTop: t.spacing.xl,
             marginBottom: t.spacing.md,
           }}
@@ -304,7 +304,7 @@ export default function DailyWordLandingScreen() {
                 style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
               >
                 <SymbolIcon name="square.and.pencil" size={14} color={t.colors.accent} />
-                <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.accent }}>
+                <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.textAccent }}>
                   {tx('reflection.edit')}
                 </Text>
               </Pressable>
@@ -356,11 +356,11 @@ export default function DailyWordLandingScreen() {
               <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.ink }}>
                 {tx('reflection.composeCta')}
               </Text>
-              <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 1 }}>
+              <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 1 }}>
                 {tx('reflection.composeHint')}
               </Text>
             </View>
-            <SymbolIcon name="chevron.right" size={13} color={t.colors.muted} />
+            <SymbolIcon name="chevron.right" size={13} color={t.colors.sec} />
           </Pressable>
         )}
 
@@ -377,7 +377,7 @@ export default function DailyWordLandingScreen() {
             paddingVertical: t.spacing.xs,
           }}
         >
-          <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.accent }}>
+          <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.textAccent }}>
             {tx('reflection.viewAll')}
           </Text>
           <SymbolIcon name="chevron.right" size={12} color={t.colors.accent} weight="semibold" />

--- a/apps/mobile/src/screens/DailyWordLandingScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordLandingScreen.tsx
@@ -37,7 +37,7 @@ function ordinal(n: number): string {
 export default function DailyWordLandingScreen() {
   const t = useTheme()
   const router = useRouter()
-  const { t: tx, i18n } = useTranslation(['reader', 'home'])
+  const { t: tx, i18n } = useTranslation(['reader', 'home', 'common', 'errors'])
   const insets = useSafeAreaInsets()
   const { source: spriteSource } = useProfileSprite()
 
@@ -59,7 +59,7 @@ export default function DailyWordLandingScreen() {
   const streak = useReadingStreak()
   const streakCount = currentStreak(streak, today)
 
-  const { reflection, loading, refresh, remove } = useTodayReflection()
+  const { reflection, loading, error, refresh, remove } = useTodayReflection()
 
   // Re-read the reflection when the landing regains focus so a just-composed or
   // just-deleted entry (on the pushed compose/journal screens) shows correctly.
@@ -244,6 +244,22 @@ export default function DailyWordLandingScreen() {
           <View style={{ paddingVertical: t.spacing.xl, alignItems: 'center' }}>
             <ActivityIndicator color={t.colors.accent} />
           </View>
+        ) : error ? (
+          // Before 1.0.1 there was no error branch here: the hook returned
+          // `error` and the screen never read it, so a failed read fell through
+          // to the compose CTA below — telling the user they hadn't written
+          // today when in fact we could not tell. Tapping it then attempted a
+          // second same-day write, which the DB rejects (DuplicateReflectionError).
+          // `error` is an i18n key from the hook, never raw error text.
+          <Card style={{ alignItems: 'flex-start', gap: t.spacing.sm }}>
+            <Text style={{ fontSize: 15, fontWeight: '600', color: t.colors.ink }}>
+              {tx(error)}
+            </Text>
+            <Text style={{ fontSize: 13, lineHeight: 19, color: t.colors.sec }}>
+              {tx('errors:load.hint')}
+            </Text>
+            <Button title={tx('common:retry')} onPress={() => void refresh()} fullWidth={false} />
+          </Card>
         ) : reflection ? (
           <Card style={{ padding: 0, overflow: 'hidden' }}>
             <Text

--- a/apps/mobile/src/screens/DailyWordScreen.tsx
+++ b/apps/mobile/src/screens/DailyWordScreen.tsx
@@ -204,7 +204,7 @@ export default function DailyWordScreen({
   const fontSize = readerFontSize(settings.pt)
   const lineHeight = readerLineHeight(settings.pt, settings.lineSpacing)
   const fontFamily = settings.typeface === 'serif' ? 'Georgia' : undefined
-  const numStyle = { fontSize: Math.round(fontSize * 0.72), fontWeight: '700' as const, color: t.colors.accent }
+  const numStyle = { fontSize: Math.round(fontSize * 0.72), fontWeight: '700' as const, color: t.colors.textAccent }
   const readingBase = {
     fontSize,
     lineHeight,
@@ -299,7 +299,7 @@ export default function DailyWordScreen({
             style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
           >
             <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>
               {tx('landingTitle')}
             </Text>
           </Pressable>
@@ -326,7 +326,7 @@ export default function DailyWordScreen({
             <Text style={{ fontSize: 14, fontWeight: '600', letterSpacing: -0.2, color: t.colors.ink }}>
               {translationLabel}
             </Text>
-            <SymbolIcon name="chevron.down" size={11} color={t.colors.muted} weight="semibold" />
+            <SymbolIcon name="chevron.down" size={11} color={t.colors.sec} weight="semibold" />
           </Pressable>
         </View>
 
@@ -336,7 +336,7 @@ export default function DailyWordScreen({
           accessibilityLabel={tx('chooseDate')}
           style={controlButton}
         >
-          <SymbolIcon name="calendar" size={15} color={t.colors.muted} />
+          <SymbolIcon name="calendar" size={15} color={t.colors.sec} />
           <Text style={{ fontSize: 14, fontWeight: '600', letterSpacing: -0.2, color: t.colors.ink }}>
             {formatDateLabel(date, i18n.language)}
           </Text>

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -19,12 +19,8 @@ import DailyWordCard from '../components/home/DailyWordCard'
 import RecentSongsCard from '../components/home/RecentSongsCard'
 import { cardStyle } from '../components/home/cardStyle'
 import { useTheme } from '../theme/ThemeProvider'
-import {
-  getDisplayName,
-  pickSubGreetingIndex,
-  timeGreetingKey,
-  useCurrentUser,
-} from '../lib/greetings'
+import { getDisplayName, pickSubGreetingIndex, timeGreetingKey } from '../lib/greetings'
+import { useCurrentUser } from '../lib/currentUser'
 import { useIsTabletWidth } from '../lib/useIsTabletWidth'
 import { useProfileSprite } from '../lib/useProfileSprite'
 import { getRecentlyOpened } from '../lib/recents'
@@ -46,13 +42,18 @@ function songMeta(song: Song, tx: Translator): string {
 
 export default function HomeScreen() {
   const t = useTheme()
-  const { t: tx } = useTranslation(['home', 'common'])
+  const { t: tx } = useTranslation(['home', 'common', 'errors'])
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const isTablet = useIsTabletWidth()
   const user = useCurrentUser()
   const { source: spriteSource } = useProfileSprite()
-  const { songs: starred, loading: starredLoading, error: starredError } = useStarredSongs()
+  const {
+    songs: starred,
+    loading: starredLoading,
+    error: starredError,
+    reload: reloadStarred,
+  } = useStarredSongs()
 
   const greeting = tx('greeting.hello', {
     greeting: tx(timeGreetingKey()),
@@ -74,7 +75,37 @@ export default function HomeScreen() {
     }, []),
   )
   const continueSong = getRecentlyOpened()[0] ?? null
-  const { lastSet } = useLastSet()
+  const { lastSet, error: lastSetError, retry: retryLastSet } = useLastSet()
+
+  // Inline failure line for a dashboard card: the localized reason plus a text
+  // Retry. Deliberately NOT the full-screen EmptyState — these live inside a
+  // card, and the happy-path card layout must stay untouched. `messageKey` is an
+  // i18n key supplied by the hook (see errors.ts); raw error text is never shown.
+  function cardError(messageKey: string, onRetry: () => void) {
+    return (
+      <View style={{ marginTop: t.spacing.md, alignItems: 'flex-start' }}>
+        <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+          {tx(messageKey)}
+        </Text>
+        <Pressable
+          onPress={onRetry}
+          accessibilityRole="button"
+          hitSlop={8}
+          style={({ pressed }) => ({ paddingVertical: 6, opacity: pressed ? 0.6 : 1 })}
+        >
+          <Text
+            style={{
+              fontSize: t.typography.rowSubtitle.fontSize,
+              fontWeight: '600',
+              color: t.colors.textAccent,
+            }}
+          >
+            {tx('common:retry')}
+          </Text>
+        </Pressable>
+      </View>
+    )
+  }
 
   function onAvatar() {
     router.push('/settings')
@@ -170,6 +201,27 @@ export default function HomeScreen() {
         </Pressable>
       </View>
     </View>
+  ) : lastSetError ? (
+    // Before 1.0.1 this branch did not exist: HomeScreen discarded useLastSet's
+    // `error`, so a failed read rendered NOTHING — visually identical to "no
+    // setlists yet" and to still-loading, with no retry and no pull-to-refresh on
+    // Home. A request deadline would otherwise have turned a hang into exactly
+    // that blank space. Loading and genuinely-empty still render nothing, as
+    // before.
+    <View style={cardStyle(t)}>
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '700',
+          letterSpacing: 0.7,
+          textTransform: 'uppercase',
+          color: t.colors.textAccent,
+        }}
+      >
+        {tx('lastSet.label')}
+      </Text>
+      {cardError(lastSetError, retryLastSet)}
+    </View>
   ) : null
 
   const starredCard = (
@@ -192,9 +244,7 @@ export default function HomeScreen() {
       {starredLoading ? (
         <ActivityIndicator color={t.colors.accent} style={{ marginTop: t.spacing.md }} />
       ) : starredError ? (
-        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
-          {starredError}
-        </Text>
+        cardError(starredError, reloadStarred)
       ) : starred.length === 0 ? (
         <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
           {tx('starredCard.empty')}

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -84,7 +84,7 @@ export default function HomeScreen() {
   function cardError(messageKey: string, onRetry: () => void) {
     return (
       <View style={{ marginTop: t.spacing.md, alignItems: 'flex-start' }}>
-        <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+        <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
           {tx(messageKey)}
         </Text>
         <Pressable
@@ -246,7 +246,7 @@ export default function HomeScreen() {
       ) : starredError ? (
         cardError(starredError, reloadStarred)
       ) : starred.length === 0 ? (
-        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+        <Text style={{ marginTop: t.spacing.md, fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
           {tx('starredCard.empty')}
         </Text>
       ) : (
@@ -302,7 +302,7 @@ export default function HomeScreen() {
                     </Text>
                   ) : null}
                   {s.time_signature ? (
-                    <Text style={{ marginTop: 2, fontSize: t.typography.rowMeta.fontSize, color: t.colors.muted }}>
+                    <Text style={{ marginTop: 2, fontSize: t.typography.rowMeta.fontSize, color: t.colors.sec }}>
                       {s.time_signature}
                     </Text>
                   ) : null}
@@ -445,7 +445,7 @@ export default function HomeScreen() {
                       </Text>
                     ) : null}
                     {songMeta(continueSong, tx) ? (
-                      <Text numberOfLines={1} style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 3 }}>
+                      <Text numberOfLines={1} style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 3 }}>
                         {songMeta(continueSong, tx)}
                       </Text>
                     ) : null}

--- a/apps/mobile/src/screens/MetronomeScreen.tsx
+++ b/apps/mobile/src/screens/MetronomeScreen.tsx
@@ -182,7 +182,7 @@ export default function MetronomeScreen({ embedded }: { embedded?: boolean }) {
                 fontSize: t.typography.overline.fontSize,
                 fontWeight: t.typography.overline.fontWeight,
                 letterSpacing: t.typography.overline.letterSpacing,
-                color: t.colors.muted,
+                color: t.colors.sec,
               }}
             >
               {tx('metronome.bpm')}
@@ -295,7 +295,7 @@ export default function MetronomeScreen({ embedded }: { embedded?: boolean }) {
             style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
           >
             <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('nav:utilities')}</Text>
           </Pressable>
         )}
         <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('metronome.title')}</Text>

--- a/apps/mobile/src/screens/OfflineDownloadsScreen.tsx
+++ b/apps/mobile/src/screens/OfflineDownloadsScreen.tsx
@@ -114,7 +114,7 @@ export default function OfflineDownloadsScreen() {
         fontWeight: '600',
         letterSpacing: 0.6,
         textTransform: 'uppercase',
-        color: t.colors.muted,
+        color: t.colors.sec,
         paddingHorizontal: t.spacing.lg,
         paddingBottom: 7,
         marginTop: t.spacing.xl,
@@ -166,7 +166,7 @@ export default function OfflineDownloadsScreen() {
           >
             <View style={{ height: '100%', width: `${usagePct}%`, backgroundColor: t.colors.accent, borderRadius: t.radii.pill }} />
           </View>
-          <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 9 }}>
+          <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 9 }}>
             {tx('downloadedCount', { count: downloadedList.length, total: translations.length })}
           </Text>
         </Card>
@@ -190,7 +190,7 @@ export default function OfflineDownloadsScreen() {
                       >
                         <View style={{ height: '100%', width: `${pct}%`, backgroundColor: t.colors.accent, borderRadius: t.radii.pill }} />
                       </View>
-                      <Text style={{ fontSize: 12, color: t.colors.muted, marginTop: 6 }}>{tx('percent', { value: pct })}</Text>
+                      <Text style={{ fontSize: 12, color: t.colors.sec, marginTop: 6 }}>{tx('percent', { value: pct })}</Text>
                     </View>
                     <Pressable
                       onPress={() => handleCancel(tr.id)}
@@ -229,7 +229,7 @@ export default function OfflineDownloadsScreen() {
                       <Text numberOfLines={1} style={{ fontSize: 16, fontWeight: '500', color: t.colors.ink }}>
                         {r.name}
                       </Text>
-                      <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 1 }}>
+                      <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 1 }}>
                         {stale
                           ? tx('translationMetaStale', { language: r.language, size: formatMB(r.sizeBytes, tx) })
                           : tx('translationMeta', { language: r.language, size: formatMB(r.sizeBytes, tx) })}
@@ -279,7 +279,7 @@ export default function OfflineDownloadsScreen() {
                     <Text numberOfLines={1} style={{ fontSize: 16, fontWeight: '500', color: t.colors.ink }}>
                       {tr.name}
                     </Text>
-                    <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 1 }}>{tr.language}</Text>
+                    <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 1 }}>{tr.language}</Text>
                   </View>
                   <SymbolIcon name="arrow.down.circle" size={23} color={t.colors.accent} />
                 </Pressable>
@@ -305,7 +305,7 @@ export default function OfflineDownloadsScreen() {
             />
           </View>
         </Card>
-        <Text style={{ fontSize: 12.5, lineHeight: 19, color: t.colors.muted, paddingHorizontal: t.spacing.lg, paddingTop: 8 }}>
+        <Text style={{ fontSize: 12.5, lineHeight: 19, color: t.colors.sec, paddingHorizontal: t.spacing.lg, paddingTop: 8 }}>
           {tx('footer')}
         </Text>
       </ScrollView>
@@ -335,7 +335,7 @@ export default function OfflineDownloadsScreen() {
           style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
         >
           <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('back')}</Text>
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('back')}</Text>
         </Pressable>
       </GlassSurface>
     </Screen>

--- a/apps/mobile/src/screens/PitchPipeScreen.tsx
+++ b/apps/mobile/src/screens/PitchPipeScreen.tsx
@@ -183,7 +183,7 @@ export default function PitchPipeScreen({ embedded }: { embedded?: boolean }) {
                 fontSize: 52,
                 fontWeight: '700',
                 letterSpacing: -1,
-                color: activeNote ? t.colors.accent : t.colors.muted,
+                color: activeNote ? t.colors.accent : t.colors.sec,
                 fontVariant: ['tabular-nums'],
               }}
             >
@@ -240,7 +240,7 @@ export default function PitchPipeScreen({ embedded }: { embedded?: boolean }) {
                 fontSize: t.typography.overline.fontSize,
                 fontWeight: t.typography.overline.fontWeight,
                 letterSpacing: t.typography.overline.letterSpacing,
-                color: t.colors.muted,
+                color: t.colors.sec,
               }}
             >
               {tx('pitchPipe.octave')}
@@ -314,7 +314,7 @@ export default function PitchPipeScreen({ embedded }: { embedded?: boolean }) {
             style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
           >
             <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('nav:utilities')}</Text>
           </Pressable>
         )}
         <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('pitchPipe.title')}</Text>

--- a/apps/mobile/src/screens/ReflectionComposeScreen.tsx
+++ b/apps/mobile/src/screens/ReflectionComposeScreen.tsx
@@ -172,7 +172,7 @@ export default function ReflectionComposeScreen() {
           hitSlop={8}
           style={{ flex: 1 }}
         >
-          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>
             {tx('reflection.cancel')}
           </Text>
         </Pressable>
@@ -186,7 +186,7 @@ export default function ReflectionComposeScreen() {
                 style={{
                   fontSize: 16,
                   fontWeight: '700',
-                  color: canAct ? t.colors.accent : t.colors.muted,
+                  color: canAct ? t.colors.textAccent : t.colors.muted,
                 }}
               >
                 {actionLabel}
@@ -210,14 +210,14 @@ export default function ReflectionComposeScreen() {
         >
           <Text style={{ fontSize: 13, fontWeight: '600', color: t.colors.sec }}>{dateLabel}</Text>
           {passages ? (
-            <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 2 }}>{passages}</Text>
+            <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 2 }}>{passages}</Text>
           ) : null}
 
           <TextInput
             value={body}
             onChangeText={setBody}
             placeholder={tx('reflection.placeholder')}
-            placeholderTextColor={t.colors.muted}
+            placeholderTextColor={t.colors.sec}
             multiline
             autoFocus
             textAlignVertical="top"
@@ -232,7 +232,7 @@ export default function ReflectionComposeScreen() {
             }}
           />
 
-          <Text style={{ marginTop: t.spacing.sm, fontSize: 12, color: t.colors.muted, textAlign: 'right' }}>
+          <Text style={{ marginTop: t.spacing.sm, fontSize: 12, color: t.colors.sec, textAlign: 'right' }}>
             {tx('reflection.charCount', { count: body.length, max: MAX_BODY })}
           </Text>
         </ScrollView>

--- a/apps/mobile/src/screens/ReflectionComposeScreen.tsx
+++ b/apps/mobile/src/screens/ReflectionComposeScreen.tsx
@@ -22,7 +22,7 @@ import {
   reflectionDateKey,
   useTodayReflection,
 } from '../lib/useReflections'
-import { errMessage } from '../lib/errors'
+import { actionFailureMessage } from '../lib/errors'
 
 // The reflection composer. A full pushed screen (not a formSheet) to give the
 // up-to-2000-char editor room and a comfortable keyboard. It covers two flows
@@ -121,7 +121,7 @@ export default function ReflectionComposeScreen() {
       router.back()
     } catch (err: unknown) {
       setSaving(false)
-      Alert.alert(tx('reflection.editErrorTitle'), errMessage(err))
+      Alert.alert(tx('reflection.editErrorTitle'), actionFailureMessage('ReflectionCompose.edit', err, tx))
     }
   }
 
@@ -144,7 +144,7 @@ export default function ReflectionComposeScreen() {
         ])
         return
       }
-      Alert.alert(tx('reflection.saveErrorTitle'), errMessage(err))
+      Alert.alert(tx('reflection.saveErrorTitle'), actionFailureMessage('ReflectionCompose.save', err, tx))
     }
   }
 

--- a/apps/mobile/src/screens/ReflectionJournalScreen.tsx
+++ b/apps/mobile/src/screens/ReflectionJournalScreen.tsx
@@ -26,7 +26,7 @@ function dateFromKey(key: string): Date {
 export default function ReflectionJournalScreen() {
   const t = useTheme()
   const router = useRouter()
-  const { t: tx, i18n } = useTranslation('reader')
+  const { t: tx, i18n } = useTranslation(['reader', 'common', 'errors'])
   const insets = useSafeAreaInsets()
   const { reflections, loading, error, refresh, remove } = useReflectionList()
   const [expanded, setExpanded] = useState<string | null>(null)
@@ -92,11 +92,15 @@ export default function ReflectionJournalScreen() {
           <ActivityIndicator color={t.colors.accent} />
         </View>
       ) : error ? (
+        // `error` is an i18n key from the hook. This branch used to borrow the
+        // READER's copy — "Can't load today's reading", with a subtitle about
+        // downloading a Bible translation for offline use — on a screen that
+        // lists reflections. Neither sentence was true here.
         <EmptyState
           icon="wifi.slash"
-          title={tx('error.title')}
-          subtitle={tx('error.subtitle')}
-          actionLabel={tx('error.retry')}
+          title={tx(error)}
+          subtitle={tx('errors:load.hint')}
+          actionLabel={tx('common:retry')}
           onAction={() => void refresh()}
         />
       ) : reflections.length === 0 ? (

--- a/apps/mobile/src/screens/ReflectionJournalScreen.tsx
+++ b/apps/mobile/src/screens/ReflectionJournalScreen.tsx
@@ -77,7 +77,7 @@ export default function ReflectionJournalScreen() {
           style={{ flexDirection: 'row', alignItems: 'center', gap: 2, flex: 1 }}
         >
           <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>
             {tx('landingTitle')}
           </Text>
         </Pressable>
@@ -155,13 +155,13 @@ export default function ReflectionJournalScreen() {
                           paddingVertical: 2,
                         }}
                       >
-                        <Text style={{ fontSize: 10.5, fontWeight: '700', color: t.colors.muted }}>
+                        <Text style={{ fontSize: 10.5, fontWeight: '700', color: t.colors.sec }}>
                           {tx('journal.privateLabel')}
                         </Text>
                       </View>
                     </View>
                     {passages ? (
-                      <Text style={{ fontSize: 12.5, color: t.colors.muted, marginTop: 2 }} numberOfLines={1}>
+                      <Text style={{ fontSize: 12.5, color: t.colors.sec, marginTop: 2 }} numberOfLines={1}>
                         {passages}
                       </Text>
                     ) : null}
@@ -174,7 +174,7 @@ export default function ReflectionJournalScreen() {
                   <SymbolIcon
                     name={isOpen ? 'chevron.up' : 'chevron.down'}
                     size={13}
-                    color={t.colors.muted}
+                    color={t.colors.sec}
                   />
                 </Pressable>
 
@@ -212,7 +212,7 @@ export default function ReflectionJournalScreen() {
                         style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
                       >
                         <SymbolIcon name="square.and.pencil" size={14} color={t.colors.accent} />
-                        <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.accent }}>
+                        <Text style={{ fontSize: 14, fontWeight: '600', color: t.colors.textAccent }}>
                           {tx('reflection.edit')}
                         </Text>
                       </Pressable>

--- a/apps/mobile/src/screens/SessionFollowerScreen.tsx
+++ b/apps/mobile/src/screens/SessionFollowerScreen.tsx
@@ -206,7 +206,7 @@ export default function SessionFollowerScreen({ code }: { code: string }) {
       <Screen edges={['top', 'left', 'right', 'bottom']}>
         <View style={styles.center}>
           <ActivityIndicator color={t.colors.accent} />
-          <Text style={{ marginTop: t.spacing.md, color: t.colors.muted }}>
+          <Text style={{ marginTop: t.spacing.md, color: t.colors.sec }}>
             {tx('setlist:sessionFollower.joining')}
           </Text>
         </View>
@@ -221,7 +221,7 @@ export default function SessionFollowerScreen({ code }: { code: string }) {
           <Text style={{ fontSize: 20, fontWeight: '700', color: t.colors.ink, marginBottom: 8 }}>
             {tx('setlist:sessionFollower.notFoundTitle')}
           </Text>
-          <Text style={{ color: t.colors.muted, textAlign: 'center', marginBottom: 18 }}>
+          <Text style={{ color: t.colors.sec, textAlign: 'center', marginBottom: 18 }}>
             {tx('setlist:sessionFollower.notFoundBody')}
           </Text>
           <Pressable onPress={goHome} style={pillStyle(t)}>
@@ -241,7 +241,7 @@ export default function SessionFollowerScreen({ code }: { code: string }) {
           <Text style={{ fontSize: 22, fontWeight: '700', color: t.colors.ink, marginBottom: 10, textAlign: 'center' }}>
             {tx('setlist:sessionFollower.endedTitle')}
           </Text>
-          <Text style={{ color: t.colors.muted, marginBottom: 18 }}>
+          <Text style={{ color: t.colors.sec, marginBottom: 18 }}>
             {tx('setlist:sessionFollower.endedBody')}
           </Text>
           <Pressable onPress={goHome} style={pillStyle(t)}>
@@ -271,6 +271,26 @@ export default function SessionFollowerScreen({ code }: { code: string }) {
         <Pressable onPress={goHome} hitSlop={8} accessibilityRole="button" accessibilityLabel={tx('setlist:sessionFollower.home')}>
           <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
         </Pressable>
+        {/* The one deliberately hardcoded colour in the app, kept as an explained
+            exception rather than forced into the palette:
+
+            • It is theme-INVARIANT on purpose — a "live" indicator that reads the
+              same in light and dark. Every token in ThemeColors is a light/dark
+              pair, so a token whose two values were identical would assert a theme
+              relationship that does not exist here.
+            • It is not `danger`. That token means destructive (delete, error) and
+              is used as such across a dozen surfaces; "broadcasting" is not
+              "destructive", and the palette has no rose family to borrow from.
+            • One call site. Adding a token would mean editing packages/tokens —
+              shared with apps/web — and regenerating the committed Swift mirror
+              for apps/studio (npm run tokens:swift, guarded by :check in CI), for
+              an 8pt dot neither app would use.
+
+            Decorative: the localized "LIVE" text beside it carries the meaning, so
+            VoiceOver correctly skips this bare View and WCAG 1.4.11 does not apply.
+            Note apps/web draws the same dot at 9px (SessionViewerPage.jsx) — the
+            hand-copied literal has already drifted, which is the argument for a
+            real token if this ever gains a second use here. */}
         <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: '#e0245e' }} />
         <Text style={{ fontWeight: '800', letterSpacing: 0.4, color: t.colors.ink }}>
           {tx('setlist:sessionFollower.live')}
@@ -303,14 +323,14 @@ export default function SessionFollowerScreen({ code }: { code: string }) {
             <Text style={{ fontSize: 18, fontWeight: '600', color: t.colors.ink, marginBottom: 6 }}>
               {displayedItem.title || ''}
             </Text>
-            <Text style={{ color: t.colors.muted }}>{tx('setlist:sessionFollower.unavailable')}</Text>
+            <Text style={{ color: t.colors.sec }}>{tx('setlist:sessionFollower.unavailable')}</Text>
           </View>
         ) : doc ? (
           <ChordChart doc={doc} steps={steps} preferFlat={preferFlat} showChords={showChords} />
         ) : (
           <View style={styles.center}>
             <ActivityIndicator color={t.colors.accent} />
-            <Text style={{ marginTop: t.spacing.md, color: t.colors.muted }}>
+            <Text style={{ marginTop: t.spacing.md, color: t.colors.sec }}>
               {tx('setlist:sessionFollower.loadingSong')}
             </Text>
           </View>

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -40,7 +40,7 @@ import { exportSetlist } from '../lib/exportSong'
 import { pushSetToTelegram, TELEGRAM_BOT_URL } from '../lib/telegramPush'
 import { timeAgo } from '../lib/relativeTime'
 import { uuidv4 } from '../lib/uuid'
-import { errMessage } from '../lib/errors'
+import { actionFailureMessage } from '../lib/errors'
 
 const TOAST_MS = 1900
 
@@ -51,7 +51,7 @@ const TOAST_MS = 1900
 // setlist key via the existing initialKey param.
 export default function SetlistBuilderScreen({ setlistId }: { setlistId: string }) {
   const t = useTheme()
-  const { t: tx, i18n } = useTranslation(['setlist', 'common', 'export'])
+  const { t: tx, i18n } = useTranslation(['setlist', 'common', 'export', 'errors'])
   const router = useRouter()
   const isTablet = useIsTabletWidth()
   const {
@@ -168,7 +168,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
             await deleteSet()
             router.back()
           } catch (err: unknown) {
-            Alert.alert(tx('alerts.couldNotDelete'), errMessage(err))
+            Alert.alert(tx('alerts.couldNotDelete'), actionFailureMessage('SetlistBuilder.delete', err, tx))
           }
         },
       },
@@ -181,7 +181,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
     const id = uuidv4()
     router.replace(`/setlist/${id}`)
     createSetlist(supabase, { id }).catch((err: unknown) => {
-      Alert.alert(tx('alerts.couldNotCreate'), errMessage(err))
+      Alert.alert(tx('alerts.couldNotCreate'), actionFailureMessage('SetlistBuilder.create', err, tx))
     })
   }
 
@@ -194,7 +194,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
       await Clipboard.setStringAsync(buildSetlistShareUrl(items))
       showToast(tx('toasts.setLinkCopied'))
     } catch (err: unknown) {
-      Alert.alert(tx('alerts.couldNotCopyLink'), errMessage(err))
+      Alert.alert(tx('alerts.couldNotCopyLink'), actionFailureMessage('SetlistBuilder.copyLink', err, tx))
     }
   }
 
@@ -211,7 +211,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
       )
       await Sharing.shareAsync(uri)
     } catch (err: unknown) {
-      Alert.alert(tx('export:alerts.exportFailedTitle'), errMessage(err))
+      Alert.alert(tx('export:alerts.exportFailedTitle'), actionFailureMessage('SetlistBuilder.export', err, tx))
     }
   }
 
@@ -230,7 +230,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
       }
       showToast(tx('toasts.sentToTelegram'))
     } catch (err: unknown) {
-      Alert.alert(tx('alerts.couldNotSendSet'), errMessage(err))
+      Alert.alert(tx('alerts.couldNotSendSet'), actionFailureMessage('SetlistBuilder.sendTelegram', err, tx))
     }
   }
 
@@ -409,7 +409,9 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
                 color: t.colors.danger,
               }}
             >
-              {error}
+              {/* An i18n key from useSetlistBuilder — a save failure and a load
+                  failure say different things — never raw error text. */}
+              {tx(error)}
             </Text>
           ) : null}
           {items.length === 0 ? (

--- a/apps/mobile/src/screens/SetlistBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SetlistBuilderScreen.tsx
@@ -265,7 +265,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
     return (
       <Screen edges={['top', 'left', 'right', 'bottom']}>
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
-          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec }}>
             {tx('builder.notFound')}
           </Text>
         </View>
@@ -330,7 +330,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
                     fontWeight: t.typography.overline.fontWeight,
                     letterSpacing: t.typography.overline.letterSpacing,
                     textTransform: 'uppercase',
-                    color: t.colors.muted,
+                    color: t.colors.sec,
                   }}
                 >
                   {tx('builder.setName')}
@@ -367,7 +367,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
                     accessibilityLabel={tx('builder.clearSetName')}
                     hitSlop={8}
                   >
-                    <SymbolIcon name="xmark.circle.fill" size={18} color={t.colors.muted} />
+                    <SymbolIcon name="xmark.circle.fill" size={18} color={t.colors.sec} />
                   </Pressable>
                 </View>
                 <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -386,13 +386,13 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
                   >
                     {name}
                   </Text>
-                  <SymbolIcon name="pencil" size={15} color={t.colors.muted} />
+                  <SymbolIcon name="pencil" size={15} color={t.colors.sec} />
                 </View>
                 <Text style={{ marginTop: 6, fontSize: t.typography.rowMeta.fontSize, color: t.colors.sec }}>
                   {metaLine}
                 </Text>
                 {edited ? (
-                  <Text style={{ marginTop: 2, fontSize: t.typography.rowMeta.fontSize, color: t.colors.muted }}>
+                  <Text style={{ marginTop: 2, fontSize: t.typography.rowMeta.fontSize, color: t.colors.sec }}>
                     {tx('builder.lastEdited', { time: edited })}
                   </Text>
                 ) : null}
@@ -419,7 +419,7 @@ export default function SetlistBuilderScreen({ setlistId }: { setlistId: string 
               <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.ink }}>
                 {tx('builder.noSongs')}
               </Text>
-              <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.muted }}>
+              <Text style={{ fontSize: t.typography.rowSubtitle.fontSize, color: t.colors.sec }}>
                 {isTablet ? tx('builder.addHintTablet') : tx('builder.addHintPhone')}
               </Text>
             </View>

--- a/apps/mobile/src/screens/SetlistImportScreen.tsx
+++ b/apps/mobile/src/screens/SetlistImportScreen.tsx
@@ -19,7 +19,7 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useSongList } from '../lib/useSongList'
 import { supabase } from '../lib/supabase'
 import { uuidv4 } from '../lib/uuid'
-import { errMessage } from '../lib/errors'
+import { actionFailureMessage } from '../lib/errors'
 import {
   buildMissingWarning,
   buildSavePayload,
@@ -92,7 +92,7 @@ export default function SetlistImportScreen({
       router.replace(`/setlist/${id}`)
     } catch (err: unknown) {
       setSaving(false)
-      Alert.alert(tx('import.couldNotImportAlert'), errMessage(err))
+      Alert.alert(tx('import.couldNotImportAlert'), actionFailureMessage('SetlistImport.import', err, tx))
     }
   }
 

--- a/apps/mobile/src/screens/SetlistsScreen.tsx
+++ b/apps/mobile/src/screens/SetlistsScreen.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '../theme/ThemeProvider'
 import { useSetlists, type SetlistRow } from '../lib/useSetlists'
 import { timeAgo } from '../lib/relativeTime'
 import { uuidv4 } from '../lib/uuid'
-import { errMessage } from '../lib/errors'
+import { actionFailureMessage, errMessage } from '../lib/errors'
 
 // The Setlists tab: every personal setlist (newest-edited first), a New set
 // action, and tap-to-open into the builder.
@@ -67,7 +67,7 @@ export default function SetlistsScreen() {
         await refresh()
         setPruneOpen(true)
       } else {
-        Alert.alert(tx('alerts.couldNotCreate'), errMessage(err))
+        Alert.alert(tx('alerts.couldNotCreate'), actionFailureMessage('Setlists.create', err, tx))
       }
     } finally {
       setCreating(false)
@@ -78,7 +78,7 @@ export default function SetlistsScreen() {
     try {
       await remove(item.id)
     } catch (err: unknown) {
-      Alert.alert(tx('alerts.couldNotDelete'), errMessage(err))
+      Alert.alert(tx('alerts.couldNotDelete'), actionFailureMessage('Setlists.delete', err, tx))
       refresh()
     }
   }

--- a/apps/mobile/src/screens/SetlistsScreen.tsx
+++ b/apps/mobile/src/screens/SetlistsScreen.tsx
@@ -20,7 +20,7 @@ import { errMessage } from '../lib/errors'
 // action, and tap-to-open into the builder.
 export default function SetlistsScreen() {
   const t = useTheme()
-  const { t: tx, i18n } = useTranslation(['setlist', 'common'])
+  const { t: tx, i18n } = useTranslation(['setlist', 'common', 'errors'])
   const router = useRouter()
   const { setlists, loading, error, refresh, create, remove, removeMany, limit, atLimit } =
     useSetlists()
@@ -94,13 +94,18 @@ export default function SetlistsScreen() {
     if (loading) {
       return <LoadingSkeleton label={tx('syncing')} />
     }
+    // `error` is an i18n key, not raw error text (see useSetlists / errors.ts).
+    // The RefreshControl below only exists on the populated list, so before 1.0.1
+    // this branch had no way forward at all even though `refresh` was in scope.
     if (error) {
       return (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
-          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted, textAlign: 'center' }}>
-            {error}
-          </Text>
-        </View>
+        <EmptyState
+          icon="wifi.slash"
+          title={tx(error)}
+          subtitle={tx('errors:load.hint')}
+          actionLabel={tx('common:retry')}
+          onAction={() => void refresh()}
+        />
       )
     }
     if (setlists.length === 0) {

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -14,7 +14,7 @@ import { useFormSheet } from '../lib/formSheetHost'
 import { useTheme } from '../theme/ThemeProvider'
 import type { Tokens } from '@gracechords/tokens/native'
 import { supabase } from '../lib/supabase'
-import { useCurrentUser } from '../lib/greetings'
+import { useCurrentUser } from '../lib/currentUser'
 import { useProfileSprite } from '../lib/useProfileSprite'
 import {
   setDefaultChordStyle,

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -327,7 +327,7 @@ export default function SettingsScreen() {
                 </Text>
               ) : null}
             </View>
-            <SymbolIcon name="chevron.right" size={14} color={t.colors.muted} />
+            <SymbolIcon name="chevron.right" size={14} color={t.colors.sec} />
           </Pressable>
         </Card>
 
@@ -482,7 +482,7 @@ export default function SettingsScreen() {
           style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
         >
           <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:home')}</Text>
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('nav:home')}</Text>
         </Pressable>
       </GlassSurface>
 

--- a/apps/mobile/src/screens/SongEditorScreen.tsx
+++ b/apps/mobile/src/screens/SongEditorScreen.tsx
@@ -117,7 +117,7 @@ export default function SongEditorScreen() {
         }}
       >
         <Pressable onPress={() => router.back()} accessibilityRole="button" hitSlop={8}>
-          <Text style={{ fontSize: 16, color: t.colors.accent }}>Cancel</Text>
+          <Text style={{ fontSize: 16, color: t.colors.textAccent }}>Cancel</Text>
         </Pressable>
         <Text style={{ fontSize: 16, fontWeight: '700', color: t.colors.ink }}>
           {form.title || 'New Song'}
@@ -127,7 +127,7 @@ export default function SongEditorScreen() {
           accessibilityRole="button"
           hitSlop={8}
         >
-          <Text style={{ fontSize: 16, color: t.colors.accent }}>
+          <Text style={{ fontSize: 16, color: t.colors.textAccent }}>
             {mode === 'edit' ? 'Preview' : 'Edit'}
           </Text>
         </Pressable>
@@ -138,7 +138,7 @@ export default function SongEditorScreen() {
           {previewDoc ? (
             <ChordChart doc={previewDoc} steps={0} preferFlat={false} />
           ) : (
-            <Text style={{ color: t.colors.muted }}>Nothing to preview yet.</Text>
+            <Text style={{ color: t.colors.sec }}>Nothing to preview yet.</Text>
           )}
         </ScrollView>
       ) : (
@@ -255,7 +255,7 @@ export default function SongEditorScreen() {
                 </View>
               </ScrollView>
             ) : (
-              <Text style={{ fontSize: 12.5, color: t.colors.muted, marginBottom: 8 }}>
+              <Text style={{ fontSize: 12.5, color: t.colors.sec, marginBottom: 8 }}>
                 Set a key to enable quick chords.
               </Text>
             )}
@@ -267,7 +267,7 @@ export default function SongEditorScreen() {
               selection={selection}
               multiline
               placeholder={'{start_of_verse: Verse 1}\n[G]Amazing [D]grace\n{end_of_verse}'}
-              placeholderTextColor={t.colors.muted}
+              placeholderTextColor={t.colors.sec}
               autoCapitalize="none"
               autoCorrect={false}
               style={{
@@ -321,7 +321,7 @@ function PlainInput(props: React.ComponentProps<typeof TextInput>) {
   const t = useTheme()
   return (
     <TextInput
-      placeholderTextColor={t.colors.muted}
+      placeholderTextColor={t.colors.sec}
       {...props}
       style={{
         height: 48,

--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -357,14 +357,14 @@ export default function SongLibraryScreen() {
               height: 44,
             }}
           >
-            <SymbolIcon name="magnifyingglass" size={18} color={t.colors.muted} />
+            <SymbolIcon name="magnifyingglass" size={18} color={t.colors.sec} />
             <TextInput
               ref={inputRef}
               value={query}
               onChangeText={setQuery}
               onFocus={() => setSearchActive(true)}
               placeholder={tx('library.searchPlaceholder')}
-              placeholderTextColor={t.colors.muted}
+              placeholderTextColor={t.colors.sec}
               returnKeyType="search"
               autoCorrect={false}
               style={{ flex: 1, fontSize: 16, color: t.colors.ink, padding: 0 }}
@@ -415,7 +415,7 @@ export default function SongLibraryScreen() {
   function centeredMessage(message: string) {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: t.spacing.xl }}>
-        <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted, textAlign: 'center' }}>
+        <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec, textAlign: 'center' }}>
           {message}
         </Text>
       </View>
@@ -465,7 +465,7 @@ export default function SongLibraryScreen() {
                   fontWeight: t.typography.overline.fontWeight,
                   letterSpacing: t.typography.overline.letterSpacing,
                   textTransform: 'uppercase',
-                  color: t.colors.muted,
+                  color: t.colors.sec,
                 }}
               >
                 {tx('library.results', { count: results.length })}

--- a/apps/mobile/src/screens/SongLibraryScreen.tsx
+++ b/apps/mobile/src/screens/SongLibraryScreen.tsx
@@ -17,6 +17,7 @@ import Screen from '../components/Screen'
 import ListRow from '../components/ListRow'
 import SectionHeader from '../components/SectionHeader'
 import SymbolIcon from '../components/SymbolIcon'
+import EmptyState from '../components/EmptyState'
 import AlphaScrubber from '../components/AlphaScrubber'
 import FilterSortSheet, { type SortDir, type SortKey } from '../components/FilterSortSheet'
 import { songBadge } from '../components/PersonalChip'
@@ -107,9 +108,9 @@ function buildSections(songs: Song[], sortKey: SortKey, sortDir: SortDir, tx: Tr
 
 export default function SongLibraryScreen() {
   const t = useTheme()
-  const { t: tx } = useTranslation(['song', 'common'])
+  const { t: tx } = useTranslation(['song', 'common', 'errors'])
   const router = useRouter()
-  const { songs, loading, error } = useSongList()
+  const { songs, loading, error, reload } = useSongList()
   const insets = useSafeAreaInsets()
   const isTablet = useIsTabletWidth()
   const { width, height } = useWindowDimensions()
@@ -429,7 +430,20 @@ export default function SongLibraryScreen() {
         </View>
       )
     }
-    if (error) return centeredMessage(error)
+    // `error` is an i18n key, not raw error text — the hook picks it and logs the
+    // real failure (see useSongList / errors.ts). `reload` already existed here
+    // and had no caller; the Retry is what it was written for.
+    if (error) {
+      return (
+        <EmptyState
+          icon="wifi.slash"
+          title={tx(error)}
+          subtitle={tx('errors:load.hint')}
+          actionLabel={tx('common:retry')}
+          onAction={reload}
+        />
+      )
+    }
     if (songs.length === 0) return centeredMessage(tx('library.empty'))
 
     if (searchActive) {

--- a/apps/mobile/src/screens/SongbookBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SongbookBuilderScreen.tsx
@@ -16,7 +16,7 @@ import SongbookOptionsSheet from '../components/songbook/SongbookOptionsSheet'
 import { useTheme } from '../theme/ThemeProvider'
 import { useSongList, type Song } from '../lib/useSongList'
 import { exportSongbook } from '../lib/exportSong'
-import { errMessage } from '../lib/errors'
+import { actionFailureMessage } from '../lib/errors'
 
 // Utilities tool: build a songbook PDF. Pick songs (reusing the setlist
 // AddSongsModal), optionally name it / add a cover image / toggle a numbered
@@ -87,7 +87,7 @@ export default function SongbookBuilderScreen({ embedded }: { embedded?: boolean
       setCoverImageDataUrl(dataUrl)
       setCoverName(asset.fileName || tx('songbook.coverLabel'))
     } catch (err: unknown) {
-      Alert.alert(tx('songbook.pickCoverErrorTitle'), errMessage(err))
+      Alert.alert(tx('songbook.pickCoverErrorTitle'), actionFailureMessage('SongbookBuilder.pickCover', err, tx))
     }
   }, [tx])
 
@@ -108,7 +108,7 @@ export default function SongbookBuilderScreen({ embedded }: { embedded?: boolean
       })
       await Sharing.shareAsync(uri)
     } catch (err: unknown) {
-      Alert.alert(tx('export:alerts.exportFailedTitle'), errMessage(err))
+      Alert.alert(tx('export:alerts.exportFailedTitle'), actionFailureMessage('SongbookBuilder.export', err, tx))
     }
   }, [selectedSongs, title, subtitle, includeTOC, coverImageDataUrl, tx])
 

--- a/apps/mobile/src/screens/SongbookBuilderScreen.tsx
+++ b/apps/mobile/src/screens/SongbookBuilderScreen.tsx
@@ -131,7 +131,7 @@ export default function SongbookBuilderScreen({ embedded }: { embedded?: boolean
         <SectionHeader label={tx('songbook.selectedCount', { count: selectedSongs.length })} />
 
         {selectedSongs.length === 0 ? (
-          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted, paddingHorizontal: t.spacing.xs }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec, paddingHorizontal: t.spacing.xs }}>
             {tx('songbook.noneSelected')}
           </Text>
         ) : (
@@ -235,7 +235,7 @@ export default function SongbookBuilderScreen({ embedded }: { embedded?: boolean
             style={{ flexDirection: 'row', alignItems: 'center', gap: 2, width: 90 }}
           >
             <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('nav:utilities')}</Text>
           </Pressable>
         )}
         <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('songbook.title')}</Text>
@@ -244,7 +244,7 @@ export default function SongbookBuilderScreen({ embedded }: { embedded?: boolean
 
       {loading && songs.length === 0 ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+          <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec }}>
             {tx('common:loading')}
           </Text>
         </View>

--- a/apps/mobile/src/screens/SpritePickerScreen.tsx
+++ b/apps/mobile/src/screens/SpritePickerScreen.tsx
@@ -197,7 +197,7 @@ export default function SpritePickerScreen() {
             hitSlop={4}
             style={{ height: 40, alignItems: 'center', justifyContent: 'center' }}
           >
-            <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.muted }}>
+            <Text style={{ fontSize: 14.5, fontWeight: '600', color: t.colors.sec }}>
               {tx('spritePicker.skipForNow')}
             </Text>
           </Pressable>

--- a/apps/mobile/src/screens/TunerScreen.tsx
+++ b/apps/mobile/src/screens/TunerScreen.tsx
@@ -62,7 +62,7 @@ function MeterTicks({ radius, t }: { radius: number; t: Tokens }) {
 }
 
 function holdColor(reading: TunerReading | null, t: Tokens): string {
-  if (!reading) return t.colors.muted
+  if (!reading) return t.colors.sec
   if (reading.hold === 'inTune') return t.colors.success
   if (reading.hold === 'settling') return t.colors.accent
   return t.colors.ink
@@ -243,7 +243,7 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
                     left: 0,
                     bottom: 0,
                     fontSize: 20,
-                    color: t.colors.muted,
+                    color: t.colors.sec,
                   }}
                 >
                   ♭
@@ -254,7 +254,7 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
                     right: 0,
                     bottom: 0,
                     fontSize: 20,
-                    color: t.colors.muted,
+                    color: t.colors.sec,
                   }}
                 >
                   ♯
@@ -276,7 +276,7 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
                 >
                   {reading ? reading.string.label : '–'}
                 </Text>
-                <Text style={{ fontSize: 28, fontWeight: '600', color: t.colors.muted }}>
+                <Text style={{ fontSize: 28, fontWeight: '600', color: t.colors.sec }}>
                   {reading ? reading.string.name.slice(-1) : ''}
                 </Text>
               </View>
@@ -337,7 +337,7 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
                 marginTop: t.spacing.md,
                 textAlign: 'center',
                 fontSize: t.typography.rowMeta.fontSize,
-                color: t.colors.muted,
+                color: t.colors.sec,
               }}
             >
               {lockedString ? tx('tuner.autoModeOff') : tx('tuner.autoModeOn')}
@@ -376,7 +376,7 @@ export default function TunerScreen({ embedded }: { embedded?: boolean }) {
             style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
           >
             <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
-            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.accent }}>{tx('nav:utilities')}</Text>
+            <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>{tx('nav:utilities')}</Text>
           </Pressable>
         )}
         <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.ink }}>{tx('tuner.title')}</Text>

--- a/apps/mobile/src/screens/UtilitiesScreen.tsx
+++ b/apps/mobile/src/screens/UtilitiesScreen.tsx
@@ -152,7 +152,7 @@ export default function UtilitiesScreen() {
               }}
             >
               <SymbolIcon name="wrench.and.screwdriver" size={34} color={t.colors.muted} />
-              <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.muted }}>
+              <Text style={{ fontSize: t.typography.body.fontSize, color: t.colors.sec }}>
                 {tx('pickTool')}
               </Text>
             </View>

--- a/packages/core/src/supabase/client.js
+++ b/packages/core/src/supabase/client.js
@@ -5,7 +5,13 @@ import { createClient } from '@supabase/supabase-js'
 // core never touches import.meta.env or browser globals — and nothing is
 // constructed at import time. This is the seam that lets the query layer run
 // unchanged on web and React Native.
-export function createGcSupabase({ url, anonKey, storage, auth } = {}) {
+// `global` is passed straight through to createClient when supplied, which is how
+// a platform injects its own fetch. supabase-js hands global.fetch to GoTrue,
+// PostgREST, storage and functions alike, so one wrapper bounds every request the
+// client makes — see apps/mobile/src/lib/supabase.ts, which uses it to put a
+// timeout on requests that would otherwise run to the ~60 s platform default.
+// Omitted (as the web does) it is not forwarded at all, so nothing changes.
+export function createGcSupabase({ url, anonKey, storage, auth, global } = {}) {
   return createClient(url, anonKey, {
     auth: {
       storage,
@@ -14,5 +20,6 @@ export function createGcSupabase({ url, anonKey, storage, auth } = {}) {
       detectSessionInUrl: true,
       ...auth,
     },
+    ...(global ? { global } : {}),
   })
 }


### PR DESCRIPTION
## Summary

This PR introduces a network timeout policy across the app, adds a new centralized current user store, optimizes launch storage reads, and improves error messaging with i18n support.

## Key Changes

**Network Request Budgets** (`requestBudget.ts`)
- Implements three timeout budgets: `GATE_MS` (2500ms for boot), `FOREGROUND_MS` (14000ms for user-visible requests), and `BACKGROUND_MS` (7000ms for speculative work)
- Provides `withRequestBudget()` wrapper to enforce deadlines on fetch operations
- Introduces `RequestTimeoutError` to distinguish app-imposed timeouts from network errors
- Ensures no request runs indefinitely on the platform default (~60s on iOS)

**Current User Store** (`currentUser.ts`)
- Replaces per-component `useCurrentUser()` hooks that each called `supabase.auth.getUser()` and opened separate subscriptions
- Centralizes identity state in a single module-level store using `useSyncExternalStore`
- Eliminates duplicate network calls and subscriptions (Home was calling twice)
- Uses session snapshot from root layout instead of server-side validation, enabling offline support

**Launch Storage Optimization** (`launchStorage.ts`)
- Batches 12 device-local storage reads into a single `multiGet()` call during splash gate
- Provides a KVStorage facade that serves primed values on first access, then delegates to real store
- Maintains equivalence with existing hydration logic—no parsing or fallback changes
- Reduces launch I/O from 12 sequential reads to 1 batch operation

**Error Handling Improvements** (`errors.ts`)
- Adds `reportFailure()` to distinguish real failures from deliberate cancellations
- Introduces `failureDetailKey()` and `actionFailureMessage()` for i18n-driven error messages
- Recognizes `RequestTimeoutError` and logs it distinctly from query errors
- Adds `UserFacingError` for explicit error wrapping

**Contrast Validation** (`contrast.test.ts`)
- Pins WCAG contrast ratios for color tokens to prevent silent regressions
- Validates that `sec` color meets 4.5:1 normal-text contrast on all backgrounds (load-bearing assertion from 1.0.1 accessibility batch)

**Error Copy Testing** (`errorCopy.test.ts`)
- Validates that every i18n error key referenced in source exists in all locales
- Catches typos that would render literal key segments to users

## Implementation Details

- Request budgets are applied at the Supabase client level and to explicit fetch calls (R2 chapter reads, API requests)
- Current user state is published by root layout after session resolution; screens subscribe via `useCurrentUser()` hook
- Launch storage facade gracefully falls back to real store if `multiGet()` fails, preserving per-module error isolation
- All new modules are RN-free and unit-test headless under vitest
- Color contrast and error copy tests are pure arithmetic/string validation with no platform dependencies
- Version bumped to 1.0.1

## Breaking Changes

None. The changes are additive and maintain backward compatibility with existing storage and error handling patterns.

https://claude.ai/code/session_01NTgd3sMmSChzNJdLdwRJX5