### PR TITLE
Add stale chunk recovery for lazy-loaded routes

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,32 +1,33 @@
 import React from 'react'
 import { Routes, Route, Link, Outlet } from 'react-router-dom'
+import lazyRoute from './utils/app/lazyRoute'
 import HomeDashboard from './pages/HomeDashboardPage'
 import Songs from './pages/SongsPage'
 import SongView from './pages/SongViewPage'
-const Setlist = React.lazy(() => import('./pages/SetlistPage'))
-const ReadingsPage = React.lazy(() => import('./pages/ReadingsPage'))
+const Setlist = lazyRoute(() => import('./pages/SetlistPage'))
+const ReadingsPage = lazyRoute(() => import('./pages/ReadingsPage'))
 import Bundle from './pages/BundlePage'
-const Songbook = React.lazy(() => import('./pages/SongbookPage'))
-const About = React.lazy(() => import('./pages/AboutPage'))
-const PrivacyPage = React.lazy(() => import('./pages/PrivacyPage'))
-const TermsPage = React.lazy(() => import('./pages/TermsPage'))
-const LicensesPage = React.lazy(() => import('./pages/LicensesPage'))
-const DeleteAccountPage = React.lazy(() => import('./pages/DeleteAccountPage'))
-const LoginPage = React.lazy(() => import('./pages/LoginPage'))
-const SignupPage = React.lazy(() => import('./pages/SignupPage'))
-const ProfilePage = React.lazy(() => import('./pages/ProfilePage'))
-const AuthCallbackPage = React.lazy(() => import('./pages/AuthCallbackPage'))
-const ResetPasswordPage = React.lazy(() => import('./pages/ResetPasswordPage'))
-const ForgotPasswordPage = React.lazy(() => import('./pages/ForgotPasswordPage'))
-const AdminPage = React.lazy(() => import('./pages/AdminPage'))
-const EditorPage = React.lazy(() => import('./pages/EditorPage'))
-const PortalEditorPage = React.lazy(() => import('./pages/portal/EditorPage'))
-const AuditLogPage = React.lazy(() => import('./components/editor/AuditLogPanel'))
-const PostsPage = React.lazy(() => import('./pages/PostsPage'))
-const PostDetailPage = React.lazy(() => import('./pages/PostDetailPage'))
-const SessionViewer = React.lazy(() => import('./pages/SessionViewerPage'))
-const ManagePostsPage = React.lazy(() => import('./pages/portal/ManagePostsPage'))
-const EditPostPage = React.lazy(() => import('./pages/portal/EditPostPage'))
+const Songbook = lazyRoute(() => import('./pages/SongbookPage'))
+const About = lazyRoute(() => import('./pages/AboutPage'))
+const PrivacyPage = lazyRoute(() => import('./pages/PrivacyPage'))
+const TermsPage = lazyRoute(() => import('./pages/TermsPage'))
+const LicensesPage = lazyRoute(() => import('./pages/LicensesPage'))
+const DeleteAccountPage = lazyRoute(() => import('./pages/DeleteAccountPage'))
+const LoginPage = lazyRoute(() => import('./pages/LoginPage'))
+const SignupPage = lazyRoute(() => import('./pages/SignupPage'))
+const ProfilePage = lazyRoute(() => import('./pages/ProfilePage'))
+const AuthCallbackPage = lazyRoute(() => import('./pages/AuthCallbackPage'))
+const ResetPasswordPage = lazyRoute(() => import('./pages/ResetPasswordPage'))
+const ForgotPasswordPage = lazyRoute(() => import('./pages/ForgotPasswordPage'))
+const AdminPage = lazyRoute(() => import('./pages/AdminPage'))
+const EditorPage = lazyRoute(() => import('./pages/EditorPage'))
+const PortalEditorPage = lazyRoute(() => import('./pages/portal/EditorPage'))
+const AuditLogPage = lazyRoute(() => import('./components/editor/AuditLogPanel'))
+const PostsPage = lazyRoute(() => import('./pages/PostsPage'))
+const PostDetailPage = lazyRoute(() => import('./pages/PostDetailPage'))
+const SessionViewer = lazyRoute(() => import('./pages/SessionViewerPage'))
+const ManagePostsPage = lazyRoute(() => import('./pages/portal/ManagePostsPage'))
+const EditPostPage = lazyRoute(() => import('./pages/portal/EditPostPage'))
 import NavBar from './components/ui/Navbar'
 import RoleGuard from './components/auth/RoleGuard'
 import WorshipMode from './pages/WorshipModePage'

--- a/apps/web/src/__tests__/lazyRoute.test.jsx
+++ b/apps/web/src/__tests__/lazyRoute.test.jsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+// lazyRoute keeps a module-level "reload in flight" flag, so each test needs a
+// fresh copy of the module.
+async function loadLazyRoute(){
+  vi.resetModules()
+  return import('../utils/app/lazyRoute')
+}
+
+function Boundary({ children }){
+  return (
+    <ErrorCatcher>
+      <React.Suspense fallback={<div>suspense-fallback</div>}>{children}</React.Suspense>
+    </ErrorCatcher>
+  )
+}
+
+class ErrorCatcher extends React.Component {
+  constructor(props){ super(props); this.state = { error: null } }
+  static getDerivedStateFromError(error){ return { error } }
+  render(){
+    if (this.state.error) return <div>caught: {this.state.error.message}</div>
+    return this.props.children
+  }
+}
+
+let reload
+
+beforeEach(() => {
+  reload = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, reload },
+  })
+  window.sessionStorage.clear()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('lazyRoute', () => {
+  it('renders the route when the chunk loads', async () => {
+    const { default: lazyRoute } = await loadLazyRoute()
+    const Route = lazyRoute(async () => ({ default: () => <div>route-content</div> }))
+
+    render(<Boundary><Route /></Boundary>)
+
+    expect(await screen.findByText('route-content')).toBeInTheDocument()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  // The reported /admin crash: Vite's __vitePreload swallows a stale-chunk
+  // failure into a resolved `undefined`, and React.lazy then dies reading
+  // `_result.default` with a TypeError that names nothing useful.
+  it('recovers instead of crashing when the chunk resolves without a module', async () => {
+    const { default: lazyRoute } = await loadLazyRoute()
+    const Route = lazyRoute(async () => undefined)
+
+    render(<Boundary><Route /></Boundary>)
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText(/caught:/)).not.toBeInTheDocument()
+  })
+
+  it('recovers when the chunk import rejects', async () => {
+    const { default: lazyRoute } = await loadLazyRoute()
+    const Route = lazyRoute(async () => {
+      throw new Error('Failed to fetch dynamically imported module')
+    })
+
+    render(<Boundary><Route /></Boundary>)
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText(/caught:/)).not.toBeInTheDocument()
+  })
+
+  it('reloads only once even when several routes fail together', async () => {
+    const { default: lazyRoute } = await loadLazyRoute()
+    const First = lazyRoute(async () => undefined)
+    const Second = lazyRoute(async () => undefined)
+
+    render(<Boundary><First /><Second /></Boundary>)
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+  })
+
+  // A reload that already happened and didn't help must stop looping and let
+  // the error reach the boundary, where it is at least legible.
+  it('surfaces the failure when a recent reload already failed to fix it', async () => {
+    window.sessionStorage.setItem('gc:chunkReloadAt', String(Date.now()))
+    const { default: lazyRoute } = await loadLazyRoute()
+    const Route = lazyRoute(async () => undefined)
+
+    render(<Boundary><Route /></Boundary>)
+
+    expect(await screen.findByText(/caught: Route chunk loaded without a module/)).toBeInTheDocument()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('reloads again once the cooldown has passed', async () => {
+    window.sessionStorage.setItem('gc:chunkReloadAt', String(Date.now() - 20000))
+    const { default: lazyRoute } = await loadLazyRoute()
+    const Route = lazyRoute(async () => undefined)
+
+    render(<Boundary><Route /></Boundary>)
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1))
+  })
+})

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -7,6 +7,7 @@ import { AuthProvider } from './hooks/useAuth'
 import { LocaleProvider } from './hooks/useLocale'
 import { SettingsProvider } from './hooks/useSettings'
 import { initTheme } from './utils/app/theme'
+import { reloadOnceForStaleChunk } from './utils/app/lazyRoute'
 import './i18n'
 
 function bootstrapRouteFromQuery(){
@@ -113,33 +114,26 @@ function recoverFromMissingStylesheets(){
 // with "Something went wrong". The service worker self-heals only the entry
 // asset, not per-route chunks — so recover here by reloading once, which pulls
 // fresh HTML + the current chunk hashes (navigations are network-first in
-// sw.js). A sessionStorage timestamp guards against reload loops if a reload
-// can't fix it (e.g. genuinely offline).
+// sw.js). reloadOnceForStaleChunk() carries the loop guard, shared with
+// lazyRoute() so both recovery paths agree on whether a reload is under way.
 function recoverFromStaleChunks(){
   if (typeof window === 'undefined') return
-  const RELOAD_KEY = 'gc:chunkReloadAt'
   const CHUNK_ERROR_RE = /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|Unable to preload (?:CSS|module)/i
-
-  function reloadOnce(){
-    let last = 0
-    try { last = Number(window.sessionStorage.getItem(RELOAD_KEY) || 0) } catch {}
-    if (Date.now() - last < 15000) return
-    try { window.sessionStorage.setItem(RELOAD_KEY, String(Date.now())) } catch {}
-    window.location.reload()
-  }
 
   // Vite dispatches this when __vitePreload can't load a dynamically imported
   // chunk — the canonical stale-deploy signal. preventDefault stops Vite from
-  // rethrowing (we're reloading anyway).
+  // rethrowing (we're reloading anyway); the cost is that __vitePreload then
+  // resolves with `undefined` instead, which is why lazyRoute() has to check
+  // for a module that arrived without a default export.
   window.addEventListener('vite:preloadError', (event) => {
     if (typeof event?.preventDefault === 'function') event.preventDefault()
-    reloadOnce()
+    reloadOnceForStaleChunk()
   })
 
   // Backstop for failures that surface as an unhandled promise rejection.
   window.addEventListener('unhandledrejection', (event) => {
     const message = event?.reason?.message ?? event?.reason ?? ''
-    if (CHUNK_ERROR_RE.test(String(message))) reloadOnce()
+    if (CHUNK_ERROR_RE.test(String(message))) reloadOnceForStaleChunk()
   })
 }
 

--- a/apps/web/src/utils/app/lazyRoute.js
+++ b/apps/web/src/utils/app/lazyRoute.js
@@ -1,0 +1,71 @@
+import React from 'react'
+
+// Recovery for route chunks a newer deploy has replaced. A client running an
+// older entry bundle asks for chunk hashes the deploy no longer serves, so the
+// dynamic import fails and the route dies. Reloading pulls fresh HTML plus the
+// current chunk hashes (navigations are network-first in sw.js).
+const RELOAD_KEY = 'gc:chunkReloadAt'
+const RELOAD_COOLDOWN_MS = 15000
+
+// A reload we started in this page's lifetime. Later callers must be told the
+// recovery is already under way rather than being sent down the cooldown path,
+// which would surface an error screen while the page is navigating away.
+let reloadInFlight = false
+
+/**
+ * Reload once to pick up the current deploy's chunk hashes.
+ *
+ * Returns true when a reload is under way (just started, or started earlier in
+ * this page's lifetime) and false when the cooldown says the previous reload
+ * already failed to fix things — callers should surface the error instead of
+ * looping. The sessionStorage stamp is what carries the cooldown across the
+ * reload, so a chunk that is still broken on the second try reports honestly.
+ */
+export function reloadOnceForStaleChunk(){
+  if (typeof window === 'undefined') return false
+  if (reloadInFlight) return true
+  let last = 0
+  try { last = Number(window.sessionStorage.getItem(RELOAD_KEY) || 0) } catch {}
+  if (Date.now() - last < RELOAD_COOLDOWN_MS) return false
+  try { window.sessionStorage.setItem(RELOAD_KEY, String(Date.now())) } catch {}
+  reloadInFlight = true
+  window.location.reload()
+  return true
+}
+
+// Stands in for the route only while the recovery reload is in flight, so a
+// stale chunk shows the usual loading state instead of flashing ErrorBoundary.
+function ReloadingRoute(){
+  return React.createElement(
+    'div',
+    { className: 'container' },
+    React.createElement('h3', null, 'Loading...'),
+  )
+}
+
+function recoverOrRethrow(error){
+  if (reloadOnceForStaleChunk()) return { default: ReloadingRoute }
+  throw error
+}
+
+/**
+ * React.lazy for route chunks, hardened against stale-deploy loads.
+ *
+ * Vite's __vitePreload reports a failed chunk through a cancelable
+ * `vite:preloadError` event, and when a listener calls preventDefault() — ours
+ * does, in main.jsx, so it can reload instead — it swallows the rejection and
+ * the import RESOLVES WITH `undefined`. React.lazy stores that as its result
+ * and then dies inside its own initializer reading `_result.default`
+ * ("undefined is not an object"), an error that names nothing the reader can
+ * act on. So treat a module that arrived without a default export exactly like
+ * a rejected import: recover if a reload can still help, otherwise fail with an
+ * error that says what actually happened.
+ */
+export default function lazyRoute(load){
+  return React.lazy(() => Promise.resolve().then(load).then(
+    (mod) => (mod && mod.default
+      ? mod
+      : recoverOrRethrow(new Error('Route chunk loaded without a module — its deploy is no longer being served.'))),
+    (error) => recoverOrRethrow(error),
+  ))
+}


### PR DESCRIPTION
## Summary

Adds a hardened lazy-loading utility for route chunks that recovers gracefully when a deploy replaces chunks that older entry bundles still reference. This prevents crashes and infinite reload loops by coordinating recovery across both dynamic imports and error boundaries.

## Changes

- **New `lazyRoute()` utility** (`apps/web/src/utils/app/lazyRoute.js`):
  - Drop-in replacement for `React.lazy()` that handles stale chunk failures
  - Detects when Vite's `__vitePreload` swallows a failed chunk load and resolves with `undefined` instead of rejecting
  - Converts both rejection and missing-module cases into recoverable errors
  - Implements a 15-second cooldown via `sessionStorage` to prevent reload loops when a reload can't fix the issue
  - Tracks in-flight reloads at module level so multiple failing routes don't trigger multiple reloads

- **Updated route definitions** (`apps/web/src/App.jsx`):
  - Replaced all `React.lazy()` calls with `lazyRoute()` for consistency and protection across all lazy-loaded routes

- **Refactored recovery logic** (`apps/web/src/main.jsx`):
  - Extracted `reloadOnceForStaleChunk()` function from inline code into `lazyRoute.js` for reuse
  - Both `vite:preloadError` and `unhandledrejection` handlers now call the shared recovery function
  - Ensures both recovery paths agree on reload state and cooldown timing

- **Comprehensive test suite** (`apps/web/src/__tests__/lazyRoute.test.jsx`):
  - Tests successful chunk loading
  - Tests recovery from missing modules and rejected imports
  - Tests deduplication when multiple routes fail simultaneously
  - Tests cooldown enforcement and loop prevention
  - Tests cooldown expiration allowing retry

## Implementation Details

The solution addresses a specific Vite behavior: when `__vitePreload` fails to load a chunk, it dispatches a `vite:preloadError` event. If a listener calls `preventDefault()`, Vite resolves the import with `undefined` instead of rejecting. React.lazy then crashes trying to read `.default` on `undefined` with an unhelpful error message. `lazyRoute()` detects this case and treats it identically to a rejected import, enabling coordinated recovery.

The module-level `reloadInFlight` flag ensures that when multiple routes fail during the same page load, only one reload is triggered. The `sessionStorage` cooldown persists across the reload, so if the chunk is still broken after reloading, the error surfaces to the error boundary instead of looping infinitely.

https://claude.ai/code/session_01HJHRuRWQAGRKFoR1W821Ci