### PR TITLE
fix(mobile): stop the Daily Word reflection card spinning on every focus

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -28,6 +28,7 @@ import { hydrateDownloads } from '../src/lib/downloads/manifest'
 import { hydrateDrafts } from '../src/lib/drafts/draftsStore'
 import { hydrateRecents } from '../src/lib/recents'
 import { hydrateReadingStreak } from '../src/lib/readingStreak'
+import { clearReflectionDays, hydrateTodayReflection } from '../src/lib/reflectionDayStore'
 import { hydrateReaderReminder } from '../src/lib/readerReminder'
 import { syncDevotionals } from '../src/lib/devotionals/sync'
 import {
@@ -211,7 +212,7 @@ export default function RootLayout() {
     // session read were nested behind it the two would serialise and cold launch
     // would regress — the whole point of batching is to be no slower.
     const sessionRead = resolveInitialSession(supabase.auth)
-    // One AsyncStorage round trip for all 12 launch keys instead of 12 separate
+    // One AsyncStorage round trip for all 13 launch keys instead of 13 separate
     // getItem calls. The stores themselves are untouched: they receive a
     // KVStorage that answers from the batch, so every missing/null/malformed
     // fallback is byte-for-byte what it was. See launchStorage.ts.
@@ -225,6 +226,11 @@ export default function RootLayout() {
         hydrateReaderReminder(store),
         hydrateViewerPrefs(store),
         hydrateBibleTranslationPref(store),
+        // Today's cached reflection, so the Daily Word landing paints the card
+        // it already knows about instead of spinning. Does NOT need to be
+        // ordered against sessionRead: the stored entry names its own owner and
+        // is only found by a lookup for that same user (reflectionDayStore.ts).
+        hydrateTodayReflection(store),
       ]),
     )
     Promise.all([
@@ -284,6 +290,11 @@ export default function RootLayout() {
       if (event === 'SIGNED_IN' && next?.user) {
         void flushPendingSprite(supabase, AsyncStorage, next.user.id)
       }
+      // A reflection is private journal text, and caching it to disk is only
+      // defensible if signing out takes it back off again. The in-memory copy is
+      // keyed by user id and so could never be shown to the next account, but
+      // the persisted one should not outlive the session that wrote it.
+      if (event === 'SIGNED_OUT') clearReflectionDays()
     })
     return () => {
       sub.subscription.unsubscribe()

--- a/apps/mobile/src/lib/__tests__/launchStorage.test.ts
+++ b/apps/mobile/src/lib/__tests__/launchStorage.test.ts
@@ -6,11 +6,20 @@ import { hydrateRecents, getRecentlyOpened } from '../recents'
 import { hydrateReadingStreak, getReadingStreak, DEFAULT_READING_STREAK } from '../readingStreak'
 import { hydrateReaderReminder, getReaderReminder, DEFAULT_READER_REMINDER } from '../readerReminder'
 import { hydrateViewerPrefs, getColumnMode } from '../viewerPrefs'
+import {
+  __resetReflectionDayStoreForTest,
+  getReflectionDay,
+  hydrateTodayReflection,
+  reflectionCacheKey,
+} from '../reflectionDayStore'
 
-// The whole point of the facade is that the eight hydrate modules are unchanged,
+// The whole point of the facade is that the nine hydrate modules are unchanged,
 // so these tests assert the OUTCOME each module produces when fed through a
 // batch — not the facade in isolation. A silent change to any fallback here
 // would reset a real user's preference on upgrade.
+
+/** Fixed "now" so the reflection cases don't depend on the day they run. */
+const REFLECTION_NOW = new Date('2026-08-07T12:00:00')
 
 function makeStore(seed: Record<string, string> = {}) {
   const data = new Map(Object.entries(seed))
@@ -36,9 +45,9 @@ function makeStore(seed: Record<string, string> = {}) {
 }
 
 describe('LAUNCH_STORAGE_KEYS', () => {
-  it('covers the 12 keys the splash gate reads', () => {
-    expect(LAUNCH_STORAGE_KEYS).toHaveLength(12)
-    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(12)
+  it('covers the 13 keys the splash gate reads', () => {
+    expect(LAUNCH_STORAGE_KEYS).toHaveLength(13)
+    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(13)
   })
 })
 
@@ -60,8 +69,8 @@ describe('primeLaunchStorage', () => {
 
   it('falls back to the real store when multiGet rejects', async () => {
     // Today each module does its own getItem behind its own try/catch, so one
-    // failing read can only affect one module. A batch that reset all 12
-    // preferences to defaults at once would be a far worse failure.
+    // failing read can only affect one module. A batch that reset all 13
+    // keys to defaults at once would be a far worse failure.
     const { store } = makeStore({ 'gc.defaults.theme': 'dark' })
     store.multiGet = () => Promise.reject(new Error('storage unavailable'))
     const primed = await primeLaunchStorage(store)
@@ -185,6 +194,46 @@ describe('fallbacks are unchanged, batched vs unbatched', () => {
       run: async (s) => {
         await hydrateViewerPrefs(s)
         return getColumnMode('anything')
+      },
+    },
+    {
+      name: 'today’s reflection: cached entry',
+      seed: {
+        'gc.reflection.today.v1': JSON.stringify({
+          userId: 'user-1',
+          date: '2026-08-07',
+          reflection: {
+            id: 'r1',
+            user_id: 'user-1',
+            reflection_date: '2026-08-07',
+            content_key: null,
+            visibility: 'private',
+            body: 'cached',
+            created_at: '2026-08-07T09:00:00Z',
+          },
+        }),
+      },
+      run: async (s) => {
+        // Module-level store, and `run` is called twice (direct then batched) —
+        // reset so the second pass genuinely re-reads rather than seeing the first.
+        __resetReflectionDayStoreForTest()
+        await hydrateTodayReflection(s, REFLECTION_NOW)
+        return getReflectionDay(reflectionCacheKey('user-1', '2026-08-07')) ?? null
+      },
+    },
+    {
+      name: 'today’s reflection: entry from an earlier day is dropped',
+      seed: {
+        'gc.reflection.today.v1': JSON.stringify({
+          userId: 'user-1',
+          date: '2026-08-06',
+          reflection: null,
+        }),
+      },
+      run: async (s) => {
+        __resetReflectionDayStoreForTest()
+        await hydrateTodayReflection(s, REFLECTION_NOW)
+        return getReflectionDay(reflectionCacheKey('user-1', '2026-08-06')) ?? null
       },
     },
     {

--- a/apps/mobile/src/lib/__tests__/reflectionDayStore.test.ts
+++ b/apps/mobile/src/lib/__tests__/reflectionDayStore.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Reflection } from '@gracechords/core'
+import {
+  __resetReflectionDayStoreForTest,
+  applyReflectionRowChange,
+  clearReflectionDays,
+  getReflectionDay,
+  hydrateTodayReflection,
+  reflectionCacheKey,
+  reflectionDateKey,
+  setReflectionDay,
+  subscribeReflectionDays,
+} from '../reflectionDayStore'
+import type { KVStorage } from '../defaults'
+
+// The day cache behind the Daily Word landing. What these tests pin down is the
+// difference between "read, and there is none" and "never read" (the landing
+// shows a spinner only for the latter), and the user keying that stops one
+// account's private reflection reaching the next account on the device.
+
+const STORAGE_KEY = 'gc.reflection.today.v1'
+
+function memoryStorage(
+  initial: Record<string, string> = {},
+): KVStorage & { store: Map<string, string> } {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    getItem: async (k) => store.get(k) ?? null,
+    setItem: async (k, v) => void store.set(k, v),
+    removeItem: async (k) => void store.delete(k),
+  }
+}
+
+const d = (iso: string) => new Date(`${iso}T12:00:00`)
+
+function reflection(over: Partial<Reflection> = {}): Reflection {
+  return {
+    id: 'r1',
+    user_id: 'user-1',
+    reflection_date: '2026-08-07',
+    content_key: null,
+    visibility: 'private',
+    body: 'He restores my soul.',
+    created_at: '2026-08-07T09:00:00Z',
+    ...over,
+  }
+}
+
+/** A persisted blob as the store writes it. */
+function stored(userId: string, date: string, row: Reflection | null) {
+  return JSON.stringify({ userId, date, reflection: row })
+}
+
+describe('reflectionDayStore', () => {
+  beforeEach(() => __resetReflectionDayStoreForTest())
+
+  it('an unread day is undefined, and a read-but-empty day is a real answer', async () => {
+    await hydrateTodayReflection(memoryStorage(), d('2026-08-07'))
+    const key = reflectionCacheKey('user-1', '2026-08-07')
+    expect(getReflectionDay(key)).toBeUndefined()
+
+    setReflectionDay('user-1', '2026-08-07', null, d('2026-08-07'))
+    // Present entry, null reflection — the landing may now show the compose CTA.
+    expect(getReflectionDay(key)).toEqual({
+      userId: 'user-1',
+      date: '2026-08-07',
+      reflection: null,
+    })
+  })
+
+  it('hydrates today’s persisted entry so a cold launch has an answer', async () => {
+    const row = reflection()
+    const store = memoryStorage({ [STORAGE_KEY]: stored('user-1', '2026-08-07', row) })
+    await hydrateTodayReflection(store, d('2026-08-07'))
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))?.reflection).toEqual(row)
+  })
+
+  it('drops a persisted entry from an earlier day rather than answering today with it', async () => {
+    const store = memoryStorage({
+      [STORAGE_KEY]: stored('user-1', '2026-08-06', reflection({ reflection_date: '2026-08-06' })),
+    })
+    await hydrateTodayReflection(store, d('2026-08-07'))
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))).toBeUndefined()
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-06'))).toBeUndefined()
+  })
+
+  it('never serves one user’s cached reflection to another', async () => {
+    const store = memoryStorage({
+      [STORAGE_KEY]: stored('user-1', '2026-08-07', reflection({ body: 'private to user-1' })),
+    })
+    await hydrateTodayReflection(store, d('2026-08-07'))
+    // The query itself has no user_id filter (RLS scopes it), so the key is the
+    // only thing standing between two accounts on one device.
+    expect(getReflectionDay(reflectionCacheKey('user-2', '2026-08-07'))).toBeUndefined()
+  })
+
+  it('ignores a malformed or absent persisted entry instead of throwing', async () => {
+    await hydrateTodayReflection(memoryStorage({ [STORAGE_KEY]: 'not json' }), d('2026-08-07'))
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))).toBeUndefined()
+
+    __resetReflectionDayStoreForTest()
+    await hydrateTodayReflection(
+      memoryStorage({ [STORAGE_KEY]: JSON.stringify({ userId: 5, date: null }) }),
+      d('2026-08-07'),
+    )
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))).toBeUndefined()
+  })
+
+  it('persists today, and only today', async () => {
+    const store = memoryStorage()
+    await hydrateTodayReflection(store, d('2026-08-07'))
+
+    setReflectionDay('user-1', '2026-08-07', reflection(), d('2026-08-07'))
+    expect(store.store.get(STORAGE_KEY)).toContain('He restores my soul.')
+
+    // Editing an older day from the journal must not evict today's entry.
+    setReflectionDay('user-1', '2026-08-01', reflection({ id: 'old', body: 'older' }), d('2026-08-07'))
+    expect(store.store.get(STORAGE_KEY)).toContain('He restores my soul.')
+    expect(store.store.get(STORAGE_KEY)).not.toContain('older')
+    // …but it is still cached in memory for the session.
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-01'))?.reflection?.id).toBe('old')
+  })
+
+  it('does not persist a signed-out read', async () => {
+    const store = memoryStorage()
+    await hydrateTodayReflection(store, d('2026-08-07'))
+    setReflectionDay(null, '2026-08-07', null, d('2026-08-07'))
+    expect(store.store.has(STORAGE_KEY)).toBe(false)
+  })
+
+  it('applies a journal delete to the cached day so the landing stops showing it', async () => {
+    const store = memoryStorage()
+    await hydrateTodayReflection(store, d('2026-08-07'))
+    setReflectionDay('user-1', '2026-08-07', reflection(), d('2026-08-07'))
+
+    applyReflectionRowChange('r1', null, d('2026-08-07'))
+    const day = getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))
+    // Still a known answer — just an empty one.
+    expect(day).toEqual({ userId: 'user-1', date: '2026-08-07', reflection: null })
+    expect(store.store.get(STORAGE_KEY)).toBe(stored('user-1', '2026-08-07', null))
+  })
+
+  it('applies a journal edit to the cached day and leaves other rows alone', async () => {
+    await hydrateTodayReflection(memoryStorage(), d('2026-08-07'))
+    setReflectionDay('user-1', '2026-08-07', reflection(), d('2026-08-07'))
+    setReflectionDay('user-1', '2026-08-01', reflection({ id: 'other' }), d('2026-08-07'))
+
+    applyReflectionRowChange('r1', reflection({ body: 'edited' }), d('2026-08-07'))
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))?.reflection?.body).toBe(
+      'edited',
+    )
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-01'))?.reflection?.body).toBe(
+      'He restores my soul.',
+    )
+  })
+
+  it('sign-out clears memory and the persisted copy', async () => {
+    const store = memoryStorage()
+    await hydrateTodayReflection(store, d('2026-08-07'))
+    setReflectionDay('user-1', '2026-08-07', reflection(), d('2026-08-07'))
+
+    clearReflectionDays()
+    expect(getReflectionDay(reflectionCacheKey('user-1', '2026-08-07'))).toBeUndefined()
+    expect(store.store.has(STORAGE_KEY)).toBe(false)
+  })
+
+  it('notifies subscribers on write, and stops after unsubscribe', async () => {
+    await hydrateTodayReflection(memoryStorage(), d('2026-08-07'))
+    let calls = 0
+    const unsubscribe = subscribeReflectionDays(() => {
+      calls += 1
+    })
+    setReflectionDay('user-1', '2026-08-07', reflection(), d('2026-08-07'))
+    expect(calls).toBe(1)
+
+    // A row change that matches nothing must not wake React for no reason.
+    applyReflectionRowChange('does-not-exist', null, d('2026-08-07'))
+    expect(calls).toBe(1)
+
+    unsubscribe()
+    setReflectionDay('user-1', '2026-08-07', null, d('2026-08-07'))
+    expect(calls).toBe(1)
+  })
+
+  it('returns a reference-stable snapshot between writes (useSyncExternalStore)', async () => {
+    await hydrateTodayReflection(memoryStorage(), d('2026-08-07'))
+    setReflectionDay('user-1', '2026-08-07', reflection(), d('2026-08-07'))
+    const key = reflectionCacheKey('user-1', '2026-08-07')
+    expect(getReflectionDay(key)).toBe(getReflectionDay(key))
+  })
+
+  it('reflectionDateKey uses the local calendar day, not UTC', () => {
+    // 23:30 local on the 7th is the 8th in UTC; the reflection belongs to the 7th.
+    expect(reflectionDateKey(new Date('2026-08-07T23:30:00'))).toBe('2026-08-07')
+    expect(reflectionDateKey(new Date('2026-01-05T00:15:00'))).toBe('2026-01-05')
+  })
+})

--- a/apps/mobile/src/lib/launchStorage.ts
+++ b/apps/mobile/src/lib/launchStorage.ts
@@ -1,15 +1,15 @@
 // One AsyncStorage round trip for the whole splash gate.
 //
-// The launch path hydrates eight device-local stores before first paint, and
-// between them they read 12 keys with 12 separate getItem calls (five in
-// defaults.ts alone). This module reads all 12 in a single multiGet and hands
+// The launch path hydrates nine device-local stores before first paint, and
+// between them they read 13 keys with 13 separate getItem calls (five in
+// defaults.ts alone). This module reads all 13 in a single multiGet and hands
 // back a KVStorage-shaped facade served from the result.
 //
 // The point of the facade — rather than teaching each store to accept a
 // pre-read value — is that NOT ONE LINE of parsing, validation or fallback logic
-// in those stores changes. Every key backs a user preference, and a silent
-// behaviour change here would reset people's settings on upgrade. Equivalence is
-// established by construction instead of by review.
+// in those stores changes. Nearly every key backs a user preference, and a
+// silent behaviour change here would reset people's settings on upgrade.
+// Equivalence is established by construction instead of by review.
 //
 // RN-free (storage is injected, like defaults.ts) so it unit-tests headless.
 
@@ -49,21 +49,22 @@ export const LAUNCH_STORAGE_KEYS = [
   'gc.readerReminder.v1', // readerReminder.ts       → DEFAULT_READER_REMINDER
   'gc.viewer.columnMode.v1', // viewerPrefs.ts       → EMPTY (default 'single')
   'gc.bible.translation.v1', // bibleTranslationPref.ts → '' (no prior choice)
+  'gc.reflection.today.v1', // reflectionDayStore.ts   → null (nothing cached)
 ] as const
 
 /**
  * Read `keys` in one batch and return a KVStorage that serves those reads from
  * memory.
  *
- * Behaviour that is deliberately identical to 12 separate getItem calls:
+ * Behaviour that is deliberately identical to 13 separate getItem calls:
  *
  * - A key absent from storage yields null, which is what every store's
  *   missing-value branch already handles. multiGet reports an absent key as
  *   [key, null], and a pair missing from the response falls to null too.
  * - A REJECTING multiGet returns the raw store untouched, so each module does
  *   its own getItem behind its own try/catch just as it does today. Without
- *   this, one failed batch would reset all 12 preferences to defaults at once —
- *   a far worse failure than the per-module degradation we have now.
+ *   this, one failed batch would reset all 13 keys to defaults at once — a far
+ *   worse failure than the per-module degradation we have now.
  *
  * The facade is a correct KVStorage for the app's whole lifetime, not just for
  * the launch read: the stores keep whatever storage they were handed for

--- a/apps/mobile/src/lib/reflectionDayStore.ts
+++ b/apps/mobile/src/lib/reflectionDayStore.ts
@@ -1,0 +1,192 @@
+import type { Reflection } from '@gracechords/core'
+import type { KVStorage } from './defaults'
+
+// The signed-in user's reflection for a single day, cached so the Daily Word
+// landing does not re-answer a question it has already answered.
+//
+// Before this store, the landing showed a spinner on every focus: its
+// useFocusEffect called a refresh that unconditionally set loading=true, so a
+// known answer was discarded and refetched several times a day. Here the answer
+// is kept, and a refetch happens behind the rendered card.
+//
+// Follows the defaults.ts / readingStreak.ts pattern: module-level cache,
+// subscriber set for useSyncExternalStore, INJECTED storage so the module is
+// RN-free and unit-tests headless. The network read is NOT here — it stays in
+// useReflections.ts, which is what keeps this file free of the supabase client
+// (and therefore of react-native).
+//
+// KEYED BY USER, which is load-bearing. fetchReflectionForDate has no user_id
+// filter: it relies on RLS to scope rows to the caller. A cache keyed by date
+// alone would therefore hand one account's private reflection to the next
+// account signed in on the same device.
+
+/**
+ * A resolved day. `reflection: null` means "we read, and there is none" — which
+ * is a real answer and distinct from an absent entry ("never read"). The landing
+ * depends on that distinction: it may only show the compose CTA when it knows
+ * the day is empty, because prompting a second same-day write is rejected by the
+ * one-per-day unique index.
+ */
+export type ReflectionDay = {
+  userId: string | null
+  date: string
+  reflection: Reflection | null
+}
+
+type PersistedDay = { userId: string; date: string; reflection: Reflection | null }
+
+const STORAGE_KEY = 'gc.reflection.today.v1'
+
+const memory = new Map<string, ReflectionDay>()
+const listeners = new Set<() => void>()
+let storage: KVStorage | null = null
+
+/** Signed-out reads still cache (RLS returns nothing) but never persist. */
+const ANON = 'anon'
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+/** Local-time day key (YYYY-MM-DD) — reflections follow the user's calendar day. */
+export function reflectionDateKey(d: Date): string {
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${mm}-${dd}`
+}
+
+export function reflectionCacheKey(userId: string | null, date: string): string {
+  return `${userId ?? ANON}|${date}`
+}
+
+function isReflection(v: unknown): v is Reflection {
+  if (!v || typeof v !== 'object') return false
+  const r = v as Record<string, unknown>
+  return (
+    typeof r.id === 'string' &&
+    typeof r.body === 'string' &&
+    typeof r.reflection_date === 'string'
+  )
+}
+
+function isPersistedDay(v: unknown): v is PersistedDay {
+  if (!v || typeof v !== 'object') return false
+  const d = v as Record<string, unknown>
+  return (
+    typeof d.userId === 'string' &&
+    typeof d.date === 'string' &&
+    (d.reflection === null || isReflection(d.reflection))
+  )
+}
+
+/**
+ * Persist the day so a cold launch paints it on the first frame.
+ *
+ * ONLY TODAY IS WRITTEN, and to a single key. The landing can only ever open on
+ * today, so one entry is all a cold launch can use — and storing one means a new
+ * day overwrites the old one instead of accumulating entries that would then
+ * need pruning. An older day (the journal editing a past entry) stays in memory
+ * for the session and is simply not written.
+ */
+function persist(day: ReflectionDay, now: Date): void {
+  if (!day.userId) return
+  if (day.date !== reflectionDateKey(now)) return
+  const payload: PersistedDay = { userId: day.userId, date: day.date, reflection: day.reflection }
+  storage?.setItem(STORAGE_KEY, JSON.stringify(payload)).catch(() => {})
+}
+
+/**
+ * Load the persisted day into memory. Called once from the splash join.
+ *
+ * Ordering against the session read does not matter: the stored blob names its
+ * own owner, so it lands under that user's key and is only ever found by a
+ * lookup for that same user. A blob from an earlier day is dropped rather than
+ * seeded — it would only be a stale answer to today's question.
+ */
+export async function hydrateTodayReflection(
+  store: KVStorage,
+  now: Date = new Date(),
+): Promise<void> {
+  storage = store
+  try {
+    const parsed = JSON.parse((await store.getItem(STORAGE_KEY)) ?? 'null') as unknown
+    if (!isPersistedDay(parsed)) return
+    if (parsed.date !== reflectionDateKey(now)) return
+    memory.set(reflectionCacheKey(parsed.userId, parsed.date), {
+      userId: parsed.userId,
+      date: parsed.date,
+      reflection: parsed.reflection,
+    })
+    emit()
+  } catch {
+    // Best-effort: a bad read just means the first open fetches, as it used to.
+  }
+}
+
+/**
+ * The cached day, or undefined if it has never been read.
+ *
+ * Reference-stable between writes, which useSyncExternalStore requires of
+ * getSnapshot — the entry object is replaced, never mutated.
+ */
+export function getReflectionDay(key: string): ReflectionDay | undefined {
+  return memory.get(key)
+}
+
+/** Record a resolved day and notify subscribers. */
+export function setReflectionDay(
+  userId: string | null,
+  date: string,
+  reflection: Reflection | null,
+  now: Date = new Date(),
+): void {
+  const day: ReflectionDay = { userId, date, reflection }
+  memory.set(reflectionCacheKey(userId, date), day)
+  emit()
+  persist(day, now)
+}
+
+/**
+ * Apply a journal edit or delete to whichever cached day holds that row.
+ *
+ * The journal (useReflectionList) owns its own copy of the rows, so without this
+ * a delete there would leave the landing painting the deleted entry from cache
+ * until its background refetch landed. Passing `null` records the day as empty,
+ * which is a known answer — so the landing correctly shows the compose CTA.
+ */
+export function applyReflectionRowChange(id: string, next: Reflection | null, now: Date = new Date()): void {
+  let changed = false
+  for (const [key, day] of memory) {
+    if (day.reflection?.id !== id) continue
+    const updated: ReflectionDay = { ...day, reflection: next }
+    memory.set(key, updated)
+    persist(updated, now)
+    changed = true
+  }
+  if (changed) emit()
+}
+
+/**
+ * Drop everything, including the persisted copy. Called on sign-out: a
+ * reflection is private journal text, and caching it to disk is only defensible
+ * if signing out takes it back off again.
+ */
+export function clearReflectionDays(): void {
+  memory.clear()
+  emit()
+  storage?.removeItem(STORAGE_KEY).catch(() => {})
+}
+
+export function subscribeReflectionDays(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Test-only reset so each test starts from a clean module state. */
+export function __resetReflectionDayStoreForTest(): void {
+  memory.clear()
+  listeners.clear()
+  storage = null
+}

--- a/apps/mobile/src/lib/useReflections.ts
+++ b/apps/mobile/src/lib/useReflections.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
 import {
   createReflection,
   deleteReflection,
@@ -9,21 +9,29 @@ import {
   type Reflection,
 } from '@gracechords/core'
 import { supabase } from './supabase'
+import { useCurrentUserState } from './currentUser'
 import { reportFailure } from './errors'
+import {
+  applyReflectionRowChange,
+  getReflectionDay,
+  reflectionCacheKey,
+  reflectionDateKey,
+  setReflectionDay,
+  subscribeReflectionDays,
+} from './reflectionDayStore'
 
 // i18n key for the user-facing failure — never the raw error. See errors.ts.
 const LOAD_ERROR_KEY = 'errors:load.reflection'
 
-// Private per-user reflections for the Daily Word landing + journal. Same plain
-// loading/error/data pattern as useSetlists — no React Query. All reads/writes
-// are RLS-scoped to the signed-in user; Phase 1 only ever writes 'private'.
+// Private per-user reflections for the Daily Word landing + journal. No React
+// Query — the day read is backed by reflectionDayStore.ts (the same
+// module-level-cache pattern as defaults.ts and eight other stores in src/lib),
+// and the journal list stays plain loading/error/data like useSetlists. All
+// reads/writes are RLS-scoped to the signed-in user; Phase 1 only ever writes
+// 'private'.
 
-/** Local-time day key (YYYY-MM-DD) — reflections follow the user's calendar day. */
-export function reflectionDateKey(d: Date): string {
-  const mm = String(d.getMonth() + 1).padStart(2, '0')
-  const dd = String(d.getDate()).padStart(2, '0')
-  return `${d.getFullYear()}-${mm}-${dd}`
-}
+// Re-exported so callers keep importing it from here (the compose screen does).
+export { reflectionDateKey }
 
 /** Thrown by createToday when the day already has a reflection (23505). */
 export class DuplicateReflectionError extends Error {
@@ -33,29 +41,70 @@ export class DuplicateReflectionError extends Error {
   }
 }
 
+// One in-flight read per (user, day), shared by every hook instance.
+//
+// The landing mounts this hook and ALSO calls refresh() from useFocusEffect,
+// which fires on initial focus too — so opening the tab used to issue two
+// identical reads. useSetlists avoids that by having no mount fetch, but the
+// compose screen has no focus effect and needs one, so the two are coalesced
+// here instead. Resolves to an i18n error key on failure rather than throwing,
+// because whether a failure is worth showing depends on what the caller already
+// has cached.
+const inFlight = new Map<string, Promise<string | null>>()
+
+function loadDay(key: string, userId: string | null, dateKey: string): Promise<string | null> {
+  const existing = inFlight.get(key)
+  if (existing) return existing
+  const run = fetchReflectionForDate(supabase, dateKey)
+    .then((row) => {
+      setReflectionDay(userId, dateKey, (row as Reflection | null) ?? null)
+      return null
+    })
+    .catch((err: unknown) => (reportFailure('useTodayReflection', err) ? LOAD_ERROR_KEY : null))
+    .finally(() => {
+      inFlight.delete(key)
+    })
+  inFlight.set(key, run)
+  return run
+}
+
 /**
- * The signed-in user's reflection for a single day (defaults to today), plus a
- * create action. Used by the landing's "Your reflection" area and the compose
- * screen. `create` rejects with DuplicateReflectionError on a second same-day
- * write so callers can show a graceful message.
+ * The signed-in user's reflection for a single day (defaults to today), plus
+ * create/update/delete actions. Used by the landing's "Your reflection" area and
+ * the compose screen. `create` rejects with DuplicateReflectionError on a second
+ * same-day write so callers can show a graceful message.
+ *
+ * CACHE-FIRST. A day already read — this session or, for today, a previous
+ * launch — is returned synchronously and revalidated in the background, so
+ * `loading` is true only when the answer is genuinely unknown. That is what
+ * stops the landing spinning on every tab focus, and what lets it render
+ * offline.
  */
 export function useTodayReflection(dateKey: string = reflectionDateKey(new Date())) {
-  const [reflection, setReflection] = useState<Reflection | null>(null)
-  const [loading, setLoading] = useState(true)
+  const { user, resolved } = useCurrentUserState()
+  const userId = user?.id ?? null
+  const key = reflectionCacheKey(userId, dateKey)
+
+  const getSnapshot = useCallback(() => getReflectionDay(key), [key])
+  const day = useSyncExternalStore(subscribeReflectionDays, getSnapshot, getSnapshot)
+
   const [error, setError] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
-    setLoading(true)
-    try {
-      const row = (await fetchReflectionForDate(supabase, dateKey)) as Reflection | null
-      setReflection(row)
-      setError(null)
-    } catch (err: unknown) {
-      if (reportFailure('useTodayReflection', err)) setError(LOAD_ERROR_KEY)
-    } finally {
-      setLoading(false)
-    }
-  }, [dateKey])
+    // Reading before the root has published identity would both waste a request
+    // and cache the result under the wrong key. The root resolves the session
+    // before the splash lifts, so in practice this only guards a screen mounted
+    // outside that gate.
+    if (!resolved) return
+    setError(null)
+    const failure = await loadDay(key, userId, dateKey)
+    // A failed revalidation with a cached answer in hand is logged but never
+    // surfaced — the card keeps showing what we know, which is what makes this
+    // work in airplane mode. Only a failure with nothing cached becomes the
+    // error card, which the landing needs: falling through to the compose CTA
+    // on an unknown answer invites a rejected duplicate same-day write.
+    if (failure && !getReflectionDay(key)) setError(failure)
+  }, [resolved, key, userId, dateKey])
 
   useEffect(() => {
     void refresh()
@@ -68,30 +117,45 @@ export function useTodayReflection(dateKey: string = reflectionDateKey(new Date(
           reflectionDate: dateKey,
           body,
         })) as Reflection
-        setReflection(row)
+        setReflectionDay(userId, dateKey, row)
         return row
       } catch (err: unknown) {
         if (isDuplicateReflectionError(err)) throw new DuplicateReflectionError()
         throw err
       }
     },
-    [dateKey],
+    [userId, dateKey],
   )
 
   // Edit an existing PRIVATE reflection in place (public posts are immutable).
+  // Applied by row id rather than to this hook's own day: the compose screen can
+  // be opened on a past entry from the journal, in which case the row being
+  // edited belongs to a different cached day than the one this instance is for.
   const update = useCallback(async (id: string, body: string) => {
     const row = (await updateReflection(supabase, id, body)) as Reflection
-    setReflection((prev) => (prev && prev.id === id ? row : prev))
+    applyReflectionRowChange(id, row)
     return row
   }, [])
 
   const remove = useCallback(async () => {
-    if (!reflection) return
-    await deleteReflection(supabase, reflection.id)
-    setReflection(null)
-  }, [reflection])
+    const current = getReflectionDay(key)?.reflection
+    if (!current) return
+    await deleteReflection(supabase, current.id)
+    setReflectionDay(userId, dateKey, null)
+  }, [key, userId, dateKey])
 
-  return { reflection, loading, error, refresh, create, update, remove }
+  return {
+    reflection: day?.reflection ?? null,
+    // Unknown answer and no error to explain why — the only state that earns a
+    // spinner. An absent entry means never read; `reflection: null` inside a
+    // present entry means read-and-empty.
+    loading: day === undefined && error === null,
+    error,
+    refresh,
+    create,
+    update,
+    remove,
+  }
 }
 
 /**
@@ -123,12 +187,15 @@ export function useReflectionList() {
   const update = useCallback(async (id: string, body: string) => {
     const row = (await updateReflection(supabase, id, body)) as Reflection
     setReflections((prev) => prev.map((r) => (r.id === id ? row : r)))
+    // The landing may be holding this same row from cache.
+    applyReflectionRowChange(id, row)
     return row
   }, [])
 
   const remove = useCallback(async (id: string) => {
     await deleteReflection(supabase, id)
     setReflections((prev) => prev.filter((r) => r.id !== id))
+    applyReflectionRowChange(id, null)
   }, [])
 
   return { reflections, loading, error, refresh, update, remove }


### PR DESCRIPTION
## The bug

The "Write your reflection" card on the Daily Word landing showed a spinner on **every** tab focus, even when the answer hadn't changed.

## Root cause

`DailyWordLandingScreen`'s `useFocusEffect` calls `refresh()` on every focus, and `refresh()` started with an unconditional `setLoading(true)` — so a known answer was thrown away and refetched behind a spinner several times a day. There was no cache at any layer, in memory or persisted.

The screen staying mounted under `NativeTabs` did **not** help: the focus effect reset the state regardless. (No `unmountOnBlur` / `freezeOnBlur` / `lazy` anywhere in `apps/mobile`.)

The proof is one directory over: `useSetlists` uses the identical focus-refresh pattern but has no `loading` flip, which is why the Setlists tab revalidates silently. This hook had drifted from the house pattern.

## The fix

A new day store backs the read, following the module-level cache + `useSyncExternalStore` + injected-`KVStorage` pattern already used by `defaults.ts`, `readingStreak.ts` and seven other stores in `src/lib`. A day already read — this session, or for today a previous launch — is returned synchronously and revalidated in the background, so `loading` is true only when the answer is genuinely unknown.

No new dependency and no second caching layer: this is AsyncStorage via the existing splash-batched facade. The repo had already made this call twice, for `useProfileSprite` (avatar) and `useDevotionalDay` (devotional content) — the latter with a comment explicitly rejecting spinners over cached content.

Details worth review:

- **Keyed by user id**, which is load-bearing. `fetchReflectionForDate` has no `user_id` filter and relies on RLS, so a date-only cache would hand one account's private reflection to the next account on the device.
- **An absent entry ("never read") stays distinct from an entry holding `null` ("read, and empty").** The landing depends on this: it may only show the compose CTA when it *knows* the day is empty, since prompting a second same-day write is rejected by the one-per-day unique index. This preserves the safety property documented at `DailyWordLandingScreen.tsx:255`.
- **A failed revalidation with a cached answer in hand is logged, not shown** — this is what makes airplane mode work. Only a failure with nothing cached becomes the error card.
- **Concurrent reads for the same day are coalesced**, which also collapses a pre-existing double fetch on the landing (the hook's mount effect *plus* `useFocusEffect`'s initial-focus fire).
- **Only today is persisted, to a single key**, so a new day overwrites the old one instead of accumulating entries needing pruning.
- **Journal edits/deletes are applied to the cached day by row id**, so the landing doesn't paint a row the journal just removed.
- **Sign-out drops the persisted copy.** Caching private journal text to disk is only defensible if signing out takes it back off again. This one goes slightly beyond the reported bug — happy to drop it if you'd rather keep the diff tight.

## Files

| File | Change |
|---|---|
| `src/lib/reflectionDayStore.ts` | **new** — RN-free day cache (injected storage, so it unit-tests headless) |
| `src/lib/useReflections.ts` | cache-first `useTodayReflection`; journal writes kept coherent |
| `src/lib/launchStorage.ts` | +1 key in the splash batch |
| `app/_layout.tsx` | hydrate at splash; purge on `SIGNED_OUT` |
| `src/lib/__tests__/reflectionDayStore.test.ts` | **new** — 13 tests |
| `src/lib/__tests__/launchStorage.test.ts` | key-count drift test + 2 facade cases |

The store had to be its own file rather than living inside the hook: `useReflections.ts` imports `./supabase`, which pulls in react-native, and the vitest harness is node-env. Every comparable store in `src/lib` is split the same way for the same reason.

`DailyWordLandingScreen.tsx` needed no changes — its four render branches work as-is under the new `loading` semantics.

**Not touched:** the reflection editor, the save flow, `packages/core`, Supabase tables/RLS/migrations, and the web app (which doesn't fetch this data — its only "reflection" reference is account-deletion copy).

## Verification

`npx tsc --noEmit` and `npm test` (in `apps/mobile`) are both **exactly at their pre-existing baseline**, confirmed by stashing the changes and re-running:

- **tsc** — 1 error, `launchStorage.test.ts(8,30)`: `getColumnMode` was renamed to `getColumns` by `c786928`. Identical before and after this change.
- **vitest** — 502 tests, 2 failing: the same `getColumnMode` pair, plus a file-level failure in `devotionalSource.test.ts`. Baseline was 487 / 2 failing; the 15 new tests all pass.

Neither pre-existing failure is fixed here — both are outside this change, and the `getColumns` one needs a judgment call about the intended assertion (the default is now `1`, not `'single'`). Can clean them up separately if wanted.

**Lint:** there is no ESLint config for `apps/mobile` (only `apps/web/eslint.config.js`); `apps/mobile/AGENTS.md` lists `npm run typecheck` and `npm run test` as its checks. PR Checks CI is web-only and warn-only, so it won't exercise any of this.

## Manual test checklist

- [ ] Cold launch → Daily Word: card paints with no spinner if opened earlier that day (one spinner on a fresh install is correct)
- [ ] Tab away and back ×3: no spinner — **the reported bug**
- [ ] Reflection exists: entry card stable across focus changes
- [ ] No reflection: compose CTA immediate, never a spinner, never a CTA-then-entry flash
- [ ] Airplane mode + cached: card renders, no error card
- [ ] Airplane mode + fresh install: error card with Retry, **not** the compose CTA
- [ ] Write a reflection, navigate away, return: new text shows
- [ ] Edit from the landing, save, back: updated text, no spinner
- [ ] Delete from the landing: CTA appears and stays gone across focus
- [ ] Delete today's entry from the Journal, then open the landing: CTA, no flash of deleted text
- [ ] Sign out, sign in as a different account: their own reflection, never the previous account's
- [ ] Cross midnight backgrounded, reopen: one spinner for the new day is correct

The airplane-mode-fresh-install, account-switch, and midnight cases are the ones worth prioritizing — unit tests can only approximate them.

## Migration impact

None. No schema, RLS, or migration changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhPjuWB55LpYH21xfYTCNC)_