### PR TITLE
feat: Account screen + native Telegram account linking

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -369,6 +369,8 @@ export default function RootLayout() {
             <Stack.Screen name="perform/[id]" />
             <Stack.Screen name="session/[code]" />
             <Stack.Screen name="settings" />
+            <Stack.Screen name="account/index" />
+            <Stack.Screen name="account/password" />
             <Stack.Screen name="about" />
             <Stack.Screen name="offline" />
             <Stack.Screen name="tuner" />

--- a/apps/mobile/app/account/index.tsx
+++ b/apps/mobile/app/account/index.tsx
@@ -1,0 +1,8 @@
+import AccountScreen from '../../src/screens/AccountScreen'
+
+// Account — pushed from the Profile & Settings header card. A folder route
+// rather than a flat file because this area owns a sub-route (password), the
+// same shape as app/daily/ and app/setlist/.
+export default function Account() {
+  return <AccountScreen />
+}

--- a/apps/mobile/app/account/password.tsx
+++ b/apps/mobile/app/account/password.tsx
@@ -1,0 +1,7 @@
+import ChangePasswordScreen from '../../src/screens/ChangePasswordScreen'
+
+// Account → Change password. Only reachable when the account carries an `email`
+// identity; AccountScreen hides the row otherwise.
+export default function ChangePassword() {
+  return <ChangePasswordScreen />
+}

--- a/apps/mobile/src/components/DangerCard.tsx
+++ b/apps/mobile/src/components/DangerCard.tsx
@@ -1,0 +1,43 @@
+import { Pressable, Text } from 'react-native'
+import Card from './Card'
+import { useTheme } from '../theme/ThemeProvider'
+
+// A standalone destructive action card (Log out / Delete account), styled as a
+// full-width centered row inside its own Card. Lives on the Account screen.
+//
+// React Native exposes no "destructive" accessibility trait, so the red text is
+// invisible to a screen reader. `hint` carries that meaning instead — pass
+// localized copy saying what the action does.
+
+export default function DangerCard({
+  label,
+  onPress,
+  accessibilityLabel,
+  hint,
+}: {
+  label: string
+  onPress: () => void
+  accessibilityLabel?: string
+  hint?: string
+}) {
+  const t = useTheme()
+  return (
+    <Card style={{ marginTop: t.spacing.lg }}>
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? label}
+        accessibilityHint={hint}
+        style={({ pressed }) => ({
+          paddingVertical: 13,
+          alignItems: 'center',
+          backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
+        })}
+      >
+        <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.danger }}>
+          {label}
+        </Text>
+      </Pressable>
+    </Card>
+  )
+}

--- a/apps/mobile/src/components/RowIcon.tsx
+++ b/apps/mobile/src/components/RowIcon.tsx
@@ -1,0 +1,24 @@
+import { View } from 'react-native'
+import { useTheme } from '../theme/ThemeProvider'
+import SymbolIcon, { type SymbolIconProps } from './SymbolIcon'
+
+// The rounded leading icon chip on grouped settings rows. Shared by the
+// Profile & Settings and Account screens.
+
+export default function RowIcon({ name }: { name: SymbolIconProps['name'] }) {
+  const t = useTheme()
+  return (
+    <View
+      style={{
+        width: 29,
+        height: 29,
+        borderRadius: 7,
+        backgroundColor: t.colors.accentSoft,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <SymbolIcon name={name} size={16} color={t.colors.accent} />
+    </View>
+  )
+}

--- a/apps/mobile/src/i18n/locales/en/auth.json
+++ b/apps/mobile/src/i18n/locales/en/auth.json
@@ -39,7 +39,14 @@
     "googlePlayUnavailable": "Google Play Services is unavailable on this device.",
     "googleFailed": "Google sign-in failed. Please try again.",
     "googleConfigError": "Google sign-in isn't set up correctly for this app. Please use another sign-in method or contact support.",
-    "googleNoCredential": "Google did not return a credential."
+    "googleNoCredential": "Google did not return a credential.",
+    "currentPasswordRequired": "Enter your current password.",
+    "wrongCurrentPassword": "That current password isn't right.",
+    "passwordMismatch": "The new passwords don't match.",
+    "passwordSameAsCurrent": "Your new password must be different from your current one.",
+    "passwordNeedsMix": "Password must include an uppercase and a lowercase letter, a number and a symbol.",
+    "rateLimitedSignIn": "Too many attempts. Sign-in for this account is temporarily limited — this affects signing in anywhere, not just here. Wait a few minutes and try again.",
+    "network": "No connection. Check your network and try again."
   },
   "spritePicker": {
     "changeYourIcon": "Change your icon",
@@ -51,5 +58,16 @@
       "title": "Check your email",
       "message": "Confirm your account, then sign in."
     }
+  },
+  "changePassword": {
+    "title": "Change password",
+    "current": "Current password",
+    "new": "New password",
+    "confirm": "Confirm new password",
+    "requirements": "At least {{min}} characters, with an uppercase and a lowercase letter, a number and a symbol.",
+    "submit": "Change password",
+    "successTitle": "Password changed",
+    "successMessage": "You're still signed in on this device. Any other devices have been signed out.",
+    "otherDevicesNote": "Changing your password signs you out everywhere else. This device stays signed in."
   }
 }

--- a/apps/mobile/src/i18n/locales/en/common.json
+++ b/apps/mobile/src/i18n/locales/en/common.json
@@ -3,6 +3,7 @@
   "appName": "GraceChords",
   "save": "Save",
   "cancel": "Cancel",
+  "ok": "OK",
   "delete": "Delete",
   "done": "Done",
   "back": "Back",

--- a/apps/mobile/src/i18n/locales/en/profile.json
+++ b/apps/mobile/src/i18n/locales/en/profile.json
@@ -1,0 +1,42 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "" },
+  "title": "Account",
+  "sections": {
+    "profile": "PROFILE",
+    "security": "SECURITY",
+    "connections": "CONNECTIONS"
+  },
+  "appIcon": "App icon",
+  "name": "Name",
+  "email": "Email",
+  "changePassword": "Change password",
+  "nameSheet": {
+    "title": "Your name",
+    "placeholder": "Alex Brown",
+    "hint": "This is the name shown on your profile and in greetings.",
+    "save": "Save",
+    "saving": "Saving…",
+    "saveFailedTitle": "Couldn't save your name",
+    "saveFailedMessage": "Please check your connection and try again."
+  },
+  "telegram": {
+    "title": "Telegram",
+    "status": "Status",
+    "link": "Link Telegram",
+    "linked": "Linked",
+    "linkedOn": "Linked · {{date}}",
+    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "unlink": "Unlink Telegram",
+    "unlinking": "Unlinking…",
+    "unlinkAlert": {
+      "title": "Unlink Telegram?",
+      "message": "The bot will stop sending you charts until you link again.",
+      "confirm": "Unlink"
+    },
+    "unlinkFailedTitle": "Couldn't unlink Telegram"
+  },
+  "logOut": "Log out",
+  "logOutHint": "Signs you out of GraceChords on this device.",
+  "deleteAccount": "Delete account",
+  "deleteAccountHint": "Permanently deletes your account and all of your data."
+}

--- a/apps/mobile/src/i18n/locales/en/profile.json
+++ b/apps/mobile/src/i18n/locales/en/profile.json
@@ -23,9 +23,10 @@
     "title": "Telegram",
     "status": "Status",
     "link": "Link Telegram",
+    "linking": "Opening Telegram…",
     "linked": "Linked",
     "linkedOn": "Linked · {{date}}",
-    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "linkHint": "Opens Telegram so you can tap Start in @gracechords_bot. Once linked, send the bot a song title and it sends the chord chart back.",
     "unlink": "Unlink Telegram",
     "unlinking": "Unlinking…",
     "unlinkAlert": {
@@ -33,7 +34,8 @@
       "message": "The bot will stop sending you charts until you link again.",
       "confirm": "Unlink"
     },
-    "unlinkFailedTitle": "Couldn't unlink Telegram"
+    "unlinkFailedTitle": "Couldn't unlink Telegram",
+    "linkFailedTitle": "Couldn't start linking"
   },
   "logOut": "Log out",
   "logOutHint": "Signs you out of GraceChords on this device.",

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -3,6 +3,7 @@
   "title": "Profile & Settings",
   "yourAccount": "Your account",
   "changeYourIcon": "Change your icon",
+  "openAccount": "Account",
   "sections": {
     "settings": "SETTINGS",
     "reader": "READER",

--- a/apps/mobile/src/i18n/locales/es/auth.json
+++ b/apps/mobile/src/i18n/locales/es/auth.json
@@ -39,7 +39,14 @@
     "googlePlayUnavailable": "Los servicios de Google Play no están disponibles en este dispositivo.",
     "googleFailed": "El inicio de sesión con Google falló. Inténtalo de nuevo.",
     "googleConfigError": "El inicio de sesión con Google no está configurado correctamente para esta app. Usa otro método de inicio de sesión o contacta con soporte.",
-    "googleNoCredential": "Google no devolvió una credencial."
+    "googleNoCredential": "Google no devolvió una credencial.",
+    "currentPasswordRequired": "Enter your current password.",
+    "wrongCurrentPassword": "That current password isn't right.",
+    "passwordMismatch": "The new passwords don't match.",
+    "passwordSameAsCurrent": "Your new password must be different from your current one.",
+    "passwordNeedsMix": "Password must include an uppercase and a lowercase letter, a number and a symbol.",
+    "rateLimitedSignIn": "Too many attempts. Sign-in for this account is temporarily limited — this affects signing in anywhere, not just here. Wait a few minutes and try again.",
+    "network": "No connection. Check your network and try again."
   },
   "spritePicker": {
     "changeYourIcon": "Cambia tu icono",
@@ -51,5 +58,16 @@
       "title": "Revisa tu correo electrónico",
       "message": "Confirma tu cuenta y luego inicia sesión."
     }
+  },
+  "changePassword": {
+    "title": "Change password",
+    "current": "Current password",
+    "new": "New password",
+    "confirm": "Confirm new password",
+    "requirements": "At least {{min}} characters, with an uppercase and a lowercase letter, a number and a symbol.",
+    "submit": "Change password",
+    "successTitle": "Password changed",
+    "successMessage": "You're still signed in on this device. Any other devices have been signed out.",
+    "otherDevicesNote": "Changing your password signs you out everywhere else. This device stays signed in."
   }
 }

--- a/apps/mobile/src/i18n/locales/es/common.json
+++ b/apps/mobile/src/i18n/locales/es/common.json
@@ -3,6 +3,7 @@
   "appName": "GraceChords",
   "save": "Guardar",
   "cancel": "Cancelar",
+  "ok": "OK",
   "delete": "Eliminar",
   "done": "Listo",
   "back": "Atrás",

--- a/apps/mobile/src/i18n/locales/es/profile.json
+++ b/apps/mobile/src/i18n/locales/es/profile.json
@@ -1,0 +1,42 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
+  "title": "Account",
+  "sections": {
+    "profile": "PROFILE",
+    "security": "SECURITY",
+    "connections": "CONNECTIONS"
+  },
+  "appIcon": "App icon",
+  "name": "Name",
+  "email": "Email",
+  "changePassword": "Change password",
+  "nameSheet": {
+    "title": "Your name",
+    "placeholder": "Alex Brown",
+    "hint": "This is the name shown on your profile and in greetings.",
+    "save": "Save",
+    "saving": "Saving…",
+    "saveFailedTitle": "Couldn't save your name",
+    "saveFailedMessage": "Please check your connection and try again."
+  },
+  "telegram": {
+    "title": "Telegram",
+    "status": "Status",
+    "link": "Link Telegram",
+    "linked": "Linked",
+    "linkedOn": "Linked · {{date}}",
+    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "unlink": "Unlink Telegram",
+    "unlinking": "Unlinking…",
+    "unlinkAlert": {
+      "title": "Unlink Telegram?",
+      "message": "The bot will stop sending you charts until you link again.",
+      "confirm": "Unlink"
+    },
+    "unlinkFailedTitle": "Couldn't unlink Telegram"
+  },
+  "logOut": "Log out",
+  "logOutHint": "Signs you out of GraceChords on this device.",
+  "deleteAccount": "Delete account",
+  "deleteAccountHint": "Permanently deletes your account and all of your data."
+}

--- a/apps/mobile/src/i18n/locales/es/profile.json
+++ b/apps/mobile/src/i18n/locales/es/profile.json
@@ -23,9 +23,10 @@
     "title": "Telegram",
     "status": "Status",
     "link": "Link Telegram",
+    "linking": "Opening Telegram…",
     "linked": "Linked",
     "linkedOn": "Linked · {{date}}",
-    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "linkHint": "Opens Telegram so you can tap Start in @gracechords_bot. Once linked, send the bot a song title and it sends the chord chart back.",
     "unlink": "Unlink Telegram",
     "unlinking": "Unlinking…",
     "unlinkAlert": {
@@ -33,7 +34,8 @@
       "message": "The bot will stop sending you charts until you link again.",
       "confirm": "Unlink"
     },
-    "unlinkFailedTitle": "Couldn't unlink Telegram"
+    "unlinkFailedTitle": "Couldn't unlink Telegram",
+    "linkFailedTitle": "Couldn't start linking"
   },
   "logOut": "Log out",
   "logOutHint": "Signs you out of GraceChords on this device.",

--- a/apps/mobile/src/i18n/locales/es/settings.json
+++ b/apps/mobile/src/i18n/locales/es/settings.json
@@ -3,6 +3,7 @@
   "title": "Perfil y ajustes",
   "yourAccount": "Tu cuenta",
   "changeYourIcon": "Cambia tu icono",
+  "openAccount": "Account",
   "sections": {
     "settings": "AJUSTES",
     "reader": "LECTOR",

--- a/apps/mobile/src/i18n/locales/ko/auth.json
+++ b/apps/mobile/src/i18n/locales/ko/auth.json
@@ -39,7 +39,14 @@
     "googlePlayUnavailable": "이 기기에서 Google Play 서비스를 사용할 수 없습니다.",
     "googleFailed": "Google 로그인에 실패했습니다. 다시 시도해 주세요.",
     "googleConfigError": "이 앱에서 Google 로그인이 올바르게 설정되지 않았습니다. 다른 로그인 방법을 사용하거나 지원팀에 문의하세요.",
-    "googleNoCredential": "Google에서 자격 증명을 반환하지 않았습니다."
+    "googleNoCredential": "Google에서 자격 증명을 반환하지 않았습니다.",
+    "currentPasswordRequired": "Enter your current password.",
+    "wrongCurrentPassword": "That current password isn't right.",
+    "passwordMismatch": "The new passwords don't match.",
+    "passwordSameAsCurrent": "Your new password must be different from your current one.",
+    "passwordNeedsMix": "Password must include an uppercase and a lowercase letter, a number and a symbol.",
+    "rateLimitedSignIn": "Too many attempts. Sign-in for this account is temporarily limited — this affects signing in anywhere, not just here. Wait a few minutes and try again.",
+    "network": "No connection. Check your network and try again."
   },
   "spritePicker": {
     "changeYourIcon": "아이콘 변경",
@@ -51,5 +58,16 @@
       "title": "이메일을 확인해 주세요",
       "message": "계정을 인증한 후 로그인하세요."
     }
+  },
+  "changePassword": {
+    "title": "Change password",
+    "current": "Current password",
+    "new": "New password",
+    "confirm": "Confirm new password",
+    "requirements": "At least {{min}} characters, with an uppercase and a lowercase letter, a number and a symbol.",
+    "submit": "Change password",
+    "successTitle": "Password changed",
+    "successMessage": "You're still signed in on this device. Any other devices have been signed out.",
+    "otherDevicesNote": "Changing your password signs you out everywhere else. This device stays signed in."
   }
 }

--- a/apps/mobile/src/i18n/locales/ko/common.json
+++ b/apps/mobile/src/i18n/locales/ko/common.json
@@ -3,6 +3,7 @@
   "appName": "GraceChords",
   "save": "저장",
   "cancel": "취소",
+  "ok": "OK",
   "delete": "삭제",
   "done": "완료",
   "back": "뒤로",

--- a/apps/mobile/src/i18n/locales/ko/profile.json
+++ b/apps/mobile/src/i18n/locales/ko/profile.json
@@ -1,0 +1,42 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
+  "title": "Account",
+  "sections": {
+    "profile": "PROFILE",
+    "security": "SECURITY",
+    "connections": "CONNECTIONS"
+  },
+  "appIcon": "App icon",
+  "name": "Name",
+  "email": "Email",
+  "changePassword": "Change password",
+  "nameSheet": {
+    "title": "Your name",
+    "placeholder": "Alex Brown",
+    "hint": "This is the name shown on your profile and in greetings.",
+    "save": "Save",
+    "saving": "Saving…",
+    "saveFailedTitle": "Couldn't save your name",
+    "saveFailedMessage": "Please check your connection and try again."
+  },
+  "telegram": {
+    "title": "Telegram",
+    "status": "Status",
+    "link": "Link Telegram",
+    "linked": "Linked",
+    "linkedOn": "Linked · {{date}}",
+    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "unlink": "Unlink Telegram",
+    "unlinking": "Unlinking…",
+    "unlinkAlert": {
+      "title": "Unlink Telegram?",
+      "message": "The bot will stop sending you charts until you link again.",
+      "confirm": "Unlink"
+    },
+    "unlinkFailedTitle": "Couldn't unlink Telegram"
+  },
+  "logOut": "Log out",
+  "logOutHint": "Signs you out of GraceChords on this device.",
+  "deleteAccount": "Delete account",
+  "deleteAccountHint": "Permanently deletes your account and all of your data."
+}

--- a/apps/mobile/src/i18n/locales/ko/profile.json
+++ b/apps/mobile/src/i18n/locales/ko/profile.json
@@ -23,9 +23,10 @@
     "title": "Telegram",
     "status": "Status",
     "link": "Link Telegram",
+    "linking": "Opening Telegram…",
     "linked": "Linked",
     "linkedOn": "Linked · {{date}}",
-    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "linkHint": "Opens Telegram so you can tap Start in @gracechords_bot. Once linked, send the bot a song title and it sends the chord chart back.",
     "unlink": "Unlink Telegram",
     "unlinking": "Unlinking…",
     "unlinkAlert": {
@@ -33,7 +34,8 @@
       "message": "The bot will stop sending you charts until you link again.",
       "confirm": "Unlink"
     },
-    "unlinkFailedTitle": "Couldn't unlink Telegram"
+    "unlinkFailedTitle": "Couldn't unlink Telegram",
+    "linkFailedTitle": "Couldn't start linking"
   },
   "logOut": "Log out",
   "logOutHint": "Signs you out of GraceChords on this device.",

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -3,6 +3,7 @@
   "title": "프로필 및 설정",
   "yourAccount": "내 계정",
   "changeYourIcon": "아이콘 변경",
+  "openAccount": "Account",
   "sections": {
     "settings": "설정",
     "reader": "읽기",

--- a/apps/mobile/src/i18n/locales/tr/auth.json
+++ b/apps/mobile/src/i18n/locales/tr/auth.json
@@ -39,7 +39,14 @@
     "googlePlayUnavailable": "Bu cihazda Google Play Hizmetleri kullanılamıyor.",
     "googleFailed": "Google ile giriş başarısız oldu. Lütfen tekrar deneyin.",
     "googleConfigError": "Google ile giriş bu uygulama için doğru şekilde yapılandırılmamış. Lütfen başka bir giriş yöntemi kullanın veya destek ekibiyle iletişime geçin.",
-    "googleNoCredential": "Google bir kimlik bilgisi döndürmedi."
+    "googleNoCredential": "Google bir kimlik bilgisi döndürmedi.",
+    "currentPasswordRequired": "Enter your current password.",
+    "wrongCurrentPassword": "That current password isn't right.",
+    "passwordMismatch": "The new passwords don't match.",
+    "passwordSameAsCurrent": "Your new password must be different from your current one.",
+    "passwordNeedsMix": "Password must include an uppercase and a lowercase letter, a number and a symbol.",
+    "rateLimitedSignIn": "Too many attempts. Sign-in for this account is temporarily limited — this affects signing in anywhere, not just here. Wait a few minutes and try again.",
+    "network": "No connection. Check your network and try again."
   },
   "spritePicker": {
     "changeYourIcon": "Simgenizi değiştirin",
@@ -51,5 +58,16 @@
       "title": "E-postanızı kontrol edin",
       "message": "Hesabınızı doğrulayın, ardından giriş yapın."
     }
+  },
+  "changePassword": {
+    "title": "Change password",
+    "current": "Current password",
+    "new": "New password",
+    "confirm": "Confirm new password",
+    "requirements": "At least {{min}} characters, with an uppercase and a lowercase letter, a number and a symbol.",
+    "submit": "Change password",
+    "successTitle": "Password changed",
+    "successMessage": "You're still signed in on this device. Any other devices have been signed out.",
+    "otherDevicesNote": "Changing your password signs you out everywhere else. This device stays signed in."
   }
 }

--- a/apps/mobile/src/i18n/locales/tr/common.json
+++ b/apps/mobile/src/i18n/locales/tr/common.json
@@ -3,6 +3,7 @@
   "appName": "GraceChords",
   "save": "Kaydet",
   "cancel": "İptal",
+  "ok": "OK",
   "delete": "Sil",
   "done": "Bitti",
   "back": "Geri",

--- a/apps/mobile/src/i18n/locales/tr/profile.json
+++ b/apps/mobile/src/i18n/locales/tr/profile.json
@@ -1,0 +1,42 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
+  "title": "Account",
+  "sections": {
+    "profile": "PROFILE",
+    "security": "SECURITY",
+    "connections": "CONNECTIONS"
+  },
+  "appIcon": "App icon",
+  "name": "Name",
+  "email": "Email",
+  "changePassword": "Change password",
+  "nameSheet": {
+    "title": "Your name",
+    "placeholder": "Alex Brown",
+    "hint": "This is the name shown on your profile and in greetings.",
+    "save": "Save",
+    "saving": "Saving…",
+    "saveFailedTitle": "Couldn't save your name",
+    "saveFailedMessage": "Please check your connection and try again."
+  },
+  "telegram": {
+    "title": "Telegram",
+    "status": "Status",
+    "link": "Link Telegram",
+    "linked": "Linked",
+    "linkedOn": "Linked · {{date}}",
+    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "unlink": "Unlink Telegram",
+    "unlinking": "Unlinking…",
+    "unlinkAlert": {
+      "title": "Unlink Telegram?",
+      "message": "The bot will stop sending you charts until you link again.",
+      "confirm": "Unlink"
+    },
+    "unlinkFailedTitle": "Couldn't unlink Telegram"
+  },
+  "logOut": "Log out",
+  "logOutHint": "Signs you out of GraceChords on this device.",
+  "deleteAccount": "Delete account",
+  "deleteAccountHint": "Permanently deletes your account and all of your data."
+}

--- a/apps/mobile/src/i18n/locales/tr/profile.json
+++ b/apps/mobile/src/i18n/locales/tr/profile.json
@@ -23,9 +23,10 @@
     "title": "Telegram",
     "status": "Status",
     "link": "Link Telegram",
+    "linking": "Opening Telegram…",
     "linked": "Linked",
     "linkedOn": "Linked · {{date}}",
-    "linkHint": "Linking is done on the web for now. We'll open your profile in the browser, where you can connect Telegram in one tap.",
+    "linkHint": "Opens Telegram so you can tap Start in @gracechords_bot. Once linked, send the bot a song title and it sends the chord chart back.",
     "unlink": "Unlink Telegram",
     "unlinking": "Unlinking…",
     "unlinkAlert": {
@@ -33,7 +34,8 @@
       "message": "The bot will stop sending you charts until you link again.",
       "confirm": "Unlink"
     },
-    "unlinkFailedTitle": "Couldn't unlink Telegram"
+    "unlinkFailedTitle": "Couldn't unlink Telegram",
+    "linkFailedTitle": "Couldn't start linking"
   },
   "logOut": "Log out",
   "logOutHint": "Signs you out of GraceChords on this device.",

--- a/apps/mobile/src/i18n/locales/tr/settings.json
+++ b/apps/mobile/src/i18n/locales/tr/settings.json
@@ -3,6 +3,7 @@
   "title": "Profil ve Ayarlar",
   "yourAccount": "Hesabınız",
   "changeYourIcon": "Simgenizi değiştirin",
+  "openAccount": "Account",
   "sections": {
     "settings": "AYARLAR",
     "reader": "OKUYUCU",

--- a/apps/mobile/src/lib/__tests__/passwordChange.test.ts
+++ b/apps/mobile/src/lib/__tests__/passwordChange.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+import { changePassword } from '../passwordChange'
+import { validatePasswordStrength } from '../authValidation'
+
+type Auth = Parameters<typeof changePassword>[0]
+
+const GOOD = 'NewPassw0rd!'
+
+function fakeSupabase(overrides: Record<string, unknown> = {}): Auth {
+  return {
+    auth: {
+      signInWithPassword: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      updateUser: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+      ...overrides,
+    },
+  } as unknown as Auth
+}
+
+function input(overrides: Partial<Parameters<typeof changePassword>[1]> = {}) {
+  return {
+    email: 'user@example.com',
+    currentPassword: 'OldPassw0rd!',
+    newPassword: GOOD,
+    confirmPassword: GOOD,
+    ...overrides,
+  }
+}
+
+describe('validatePasswordStrength', () => {
+  it('accepts a password meeting the configured policy', () => {
+    expect(validatePasswordStrength(GOOD)).toBeNull()
+  })
+
+  it('rejects anything under the minimum length', () => {
+    expect(validatePasswordStrength('Ab1!')).toBe('errors.passwordTooShort')
+  })
+
+  it.each([
+    ['no lowercase', 'NEWPASSW0RD!'],
+    ['no uppercase', 'newpassw0rd!'],
+    ['no digit', 'NewPassword!'],
+    ['no symbol', 'NewPassw0rd'],
+  ])('rejects a long password with %s', (_label, password) => {
+    expect(validatePasswordStrength(password)).toBe('errors.passwordNeedsMix')
+  })
+})
+
+describe('changePassword', () => {
+  it('verifies, updates, then drops other sessions — in that order', async () => {
+    const supabase = fakeSupabase()
+    const result = await changePassword(supabase, input())
+
+    expect(result).toEqual({ ok: true, othersSignedOut: true })
+    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'OldPassw0rd!',
+    })
+    expect(supabase.auth.updateUser).toHaveBeenCalledWith({ password: GOOD })
+    expect(supabase.auth.signOut).toHaveBeenCalledWith({ scope: 'others' })
+  })
+
+  it('does NOT sign the user out when the current password is wrong', async () => {
+    const supabase = fakeSupabase({
+      signInWithPassword: vi
+        .fn()
+        .mockResolvedValue({ data: {}, error: { code: 'invalid_credentials', status: 400 } }),
+    })
+    const result = await changePassword(supabase, input())
+
+    expect(result).toEqual({ ok: false, error: 'errors.wrongCurrentPassword' })
+    expect(supabase.auth.signOut).not.toHaveBeenCalled()
+    expect(supabase.auth.updateUser).not.toHaveBeenCalled()
+  })
+
+  it('reports rate limiting distinctly from a wrong password', async () => {
+    const supabase = fakeSupabase({
+      signInWithPassword: vi.fn().mockResolvedValue({ data: {}, error: { status: 429 } }),
+    })
+    expect(await changePassword(supabase, input())).toEqual({
+      ok: false,
+      error: 'errors.rateLimitedSignIn',
+    })
+  })
+
+  it('reports a network failure distinctly', async () => {
+    const supabase = fakeSupabase({
+      signInWithPassword: vi
+        .fn()
+        .mockResolvedValue({ data: {}, error: { message: 'Network request failed' } }),
+    })
+    expect(await changePassword(supabase, input())).toEqual({ ok: false, error: 'errors.network' })
+  })
+
+  it('rejects a mismatched confirmation before touching the network', async () => {
+    const supabase = fakeSupabase()
+    const result = await changePassword(supabase, input({ confirmPassword: 'Different1!' }))
+
+    expect(result).toEqual({ ok: false, error: 'errors.passwordMismatch' })
+    expect(supabase.auth.signInWithPassword).not.toHaveBeenCalled()
+  })
+
+  it('rejects a new password identical to the current one', async () => {
+    const supabase = fakeSupabase()
+    const result = await changePassword(
+      supabase,
+      input({ currentPassword: GOOD, newPassword: GOOD, confirmPassword: GOOD }),
+    )
+
+    expect(result).toEqual({ ok: false, error: 'errors.passwordSameAsCurrent' })
+    expect(supabase.auth.signInWithPassword).not.toHaveBeenCalled()
+  })
+
+  it('rejects a policy-failing new password client-side', async () => {
+    const supabase = fakeSupabase()
+    const result = await changePassword(
+      supabase,
+      input({ newPassword: 'alllowercase1', confirmPassword: 'alllowercase1' }),
+    )
+
+    expect(result).toEqual({ ok: false, error: 'errors.passwordNeedsMix' })
+    expect(supabase.auth.signInWithPassword).not.toHaveBeenCalled()
+  })
+
+  it('maps the server-side weak_password rejection to the same message', async () => {
+    const supabase = fakeSupabase({
+      updateUser: vi.fn().mockResolvedValue({ data: {}, error: { code: 'weak_password', status: 422 } }),
+    })
+    expect(await changePassword(supabase, input())).toEqual({
+      ok: false,
+      error: 'errors.passwordNeedsMix',
+    })
+  })
+
+  it('still reports success when only the other-session sign-out fails', async () => {
+    const supabase = fakeSupabase({
+      signOut: vi.fn().mockResolvedValue({ error: { message: 'boom' } }),
+    })
+    expect(await changePassword(supabase, input())).toEqual({ ok: true, othersSignedOut: false })
+  })
+
+  it('requires a current password', async () => {
+    const supabase = fakeSupabase()
+    expect(await changePassword(supabase, input({ currentPassword: '' }))).toEqual({
+      ok: false,
+      error: 'errors.currentPasswordRequired',
+    })
+  })
+})

--- a/apps/mobile/src/lib/__tests__/profile.test.ts
+++ b/apps/mobile/src/lib/__tests__/profile.test.ts
@@ -3,6 +3,8 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import {
   PENDING_SPRITE_KEY,
   flushPendingSprite,
+  resolveDisplayName,
+  saveDisplayName,
   saveSpritePreference,
   stashPendingSprite,
   type KVStorage,
@@ -134,5 +136,54 @@ describe('stash / flush pending sprite', () => {
       removeItem: async () => {},
     }
     await expect(flushPendingSprite(db.client, storage, 'user-1')).resolves.toBeUndefined()
+  })
+})
+
+describe('resolveDisplayName', () => {
+  const user = {
+    email: 'ryan@example.com',
+    user_metadata: { full_name: 'Ryan Moore (mooer112233)', name: 'Ryan M' },
+  }
+
+  it('prefers the edited column over the provider profile', () => {
+    // The whole point of storing the name in public.users: an OAuth sign-in
+    // repopulates user_metadata, so the column has to win.
+    expect(resolveDisplayName('Ryan Moore', user)).toBe('Ryan Moore')
+  })
+
+  it('falls back to full_name when nothing has been edited', () => {
+    expect(resolveDisplayName(null, user)).toBe('Ryan Moore (mooer112233)')
+  })
+
+  it('falls back to name when full_name is absent', () => {
+    expect(resolveDisplayName(null, { email: 'a@b.co', user_metadata: { name: 'Just Name' } })).toBe(
+      'Just Name',
+    )
+  })
+
+  it('falls back to the email local part when no metadata name exists', () => {
+    expect(resolveDisplayName(null, { email: 'ryan@example.com', user_metadata: {} })).toBe('ryan')
+  })
+
+  it('returns null when nothing is usable, so callers localize the fallback', () => {
+    expect(resolveDisplayName(null, null)).toBeNull()
+    expect(resolveDisplayName('   ', { email: null, user_metadata: {} })).toBeNull()
+  })
+})
+
+describe('saveDisplayName', () => {
+  it('writes the trimmed name to display_name', async () => {
+    const db = fakeDb({ updatedRows: [{ id: 'user-1' }] })
+    const result = await saveDisplayName(db.client, 'user-1', '  Ryan Moore  ')
+
+    expect(result).toEqual({ error: null })
+    expect(db.update).toHaveBeenCalledWith({ display_name: 'Ryan Moore' })
+  })
+
+  it('reports an RLS-denied write rather than reporting success', async () => {
+    const db = fakeDb({ updatedRows: [] })
+    const result = await saveDisplayName(db.client, 'user-1', 'Ryan')
+
+    expect(result.error).toBeTruthy()
   })
 })

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -22,17 +22,31 @@ export function apiBase(): string {
   return base.replace(/\/$/, '')
 }
 
+async function authHeader(): Promise<{ Authorization: string }> {
+  const { data } = await supabase.auth.getSession()
+  const session = data?.session
+  if (!session) throw new Error('not_signed_in')
+  return { Authorization: `Bearer ${session.access_token}` }
+}
+
+/**
+ * GET or DELETE with the caller's Supabase bearer token.
+ *
+ * No 405-redirect retry, unlike apiPost: that retry exists because a redirect
+ * rewrites POST to GET, which cannot happen to a method that is already safe or
+ * idempotent (307/308 preserve the method, 301/302 on a GET are transparent).
+ */
+export async function apiRequest(method: 'GET' | 'DELETE', path: string): Promise<Response> {
+  return budgetedFetch(`${apiBase()}${path}`, { method, headers: await authHeader() })
+}
+
 // POST JSON with the caller's Supabase bearer token. If the configured base
 // URL redirects (e.g. apex → www), fetch follows the redirect but converts
 // the POST to a GET per spec, and the API answers 405 — so on a redirected
 // 405 we retry the POST once against the redirect's final origin.
 export async function apiPost(path: string, body: unknown): Promise<Response> {
-  const { data } = await supabase.auth.getSession()
-  const session = data?.session
-  if (!session) throw new Error('not_signed_in')
-
   const headers = {
-    Authorization: `Bearer ${session.access_token}`,
+    ...(await authHeader()),
     'Content-Type': 'application/json',
   }
   const payload = JSON.stringify(body)

--- a/apps/mobile/src/lib/authValidation.ts
+++ b/apps/mobile/src/lib/authValidation.ts
@@ -7,6 +7,46 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export const MIN_PASSWORD_LENGTH = 8
 
+// The project's password policy lives in the Supabase dashboard (Authentication
+// → Providers → Email) and is NOT machine-readable from this repo — there is no
+// supabase/config.toml. As of 2026-08-07 it reads:
+//
+//   Minimum password length ... 8
+//   Password requirements ..... lowercase, uppercase letters, digits and symbols
+//
+// Mirrored below so the change-password form can reject a bad password before a
+// round trip. If the dashboard setting changes, change this with it. The server's
+// own weak_password rejection is surfaced inline regardless, so drift degrades to
+// a slower error rather than a wrong one.
+//
+// GoTrue's default symbol set for that policy. Matched by membership rather than
+// a character class so none of these need regex escaping.
+const PASSWORD_SYMBOLS = "!@#$%^&*()_+-=[]{};'\\:\"|<>?,./"
+
+function hasSymbol(password: string): boolean {
+  for (const ch of password) {
+    if (PASSWORD_SYMBOLS.includes(ch)) return true
+  }
+  return false
+}
+
+/**
+ * Check a NEW password against the configured policy. Returns an auth-namespace
+ * i18n key, or null when it passes.
+ *
+ * Deliberately not wired into validateSignUp — that path only checks length
+ * today, so signup can still fail server-side against this policy. Left as-is on
+ * purpose; see the PR description.
+ */
+export function validatePasswordStrength(password: string): string | null {
+  if (password.length < MIN_PASSWORD_LENGTH) return 'errors.passwordTooShort'
+  if (!/[a-z]/.test(password)) return 'errors.passwordNeedsMix'
+  if (!/[A-Z]/.test(password)) return 'errors.passwordNeedsMix'
+  if (!/[0-9]/.test(password)) return 'errors.passwordNeedsMix'
+  if (!hasSymbol(password)) return 'errors.passwordNeedsMix'
+  return null
+}
+
 export function isValidEmail(email: string): boolean {
   return EMAIL_RE.test(email.trim())
 }

--- a/apps/mobile/src/lib/passwordChange.ts
+++ b/apps/mobile/src/lib/passwordChange.ts
@@ -1,0 +1,134 @@
+// Change-password orchestration for Account → Change password. Pure and
+// dependency-injected (only the supabase auth surface, type-only) so the vitest
+// harness exercises it headless, matching authFlows.ts.
+//
+// The current-password prompt is a UX guard against an accidental or unattended
+// change — nothing more. This project has "Secure password change" and "Require
+// current password when updating" both OFF in the Supabase dashboard, so
+// updateUser() succeeds on the session alone; verifying the old password is our
+// own front-door check, not a security control, and it should not be described
+// as one.
+//
+// Chosen over Supabase's reauthenticate() nonce flow deliberately: that path
+// needs an email round trip, which fails in the low-connectivity settings this
+// app is used in.
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { validatePasswordStrength } from './authValidation'
+
+type SupabaseAuth = Pick<SupabaseClient, 'auth'>
+
+export type PasswordChangeResult = {
+  ok: boolean
+  /**
+   * An auth-namespace i18n key (errors.*) for our own failures, or a raw
+   * passthrough message from Supabase. The screen renders it through
+   * t(error, { defaultValue: error }) so both forms display.
+   */
+  error?: string
+  /**
+   * False when the password changed but signing other devices out failed. The
+   * change itself succeeded, so the screen still reports success — this exists
+   * so the caller can log the difference.
+   */
+  othersSignedOut?: boolean
+}
+
+// Supabase auth errors are plain objects: { message, status, code, name }.
+type AuthErrorish = { message?: string; status?: number; code?: string } | null | undefined
+
+function code(e: AuthErrorish): string {
+  return String(e?.code ?? '')
+}
+
+/**
+ * Supabase throttles by IP and account, and the limit it applies here is the
+ * general sign-in limit — not a change-password-specific one. So repeated wrong
+ * guesses lock the user out of signing in anywhere, which the copy must say.
+ */
+function isRateLimited(e: AuthErrorish): boolean {
+  return e?.status === 429 || code(e).includes('rate_limit')
+}
+
+function isWrongPassword(e: AuthErrorish): boolean {
+  return code(e) === 'invalid_credentials' || code(e) === 'invalid_grant'
+}
+
+function isWeakPassword(e: AuthErrorish): boolean {
+  return code(e) === 'weak_password'
+}
+
+function isSamePassword(e: AuthErrorish): boolean {
+  return code(e) === 'same_password'
+}
+
+// React Native's fetch rejects with a bare TypeError on an unreachable host —
+// no code, no cause. Same string match as errors.ts, inlined to keep this
+// module free of that module's RN-adjacent imports.
+function isNetworkFailure(e: AuthErrorish): boolean {
+  const message = String(e?.message ?? '').toLowerCase()
+  return (
+    message.includes('network request failed') ||
+    message.includes('failed to fetch') ||
+    message.includes('network error')
+  )
+}
+
+export type ChangePasswordInput = {
+  email: string
+  currentPassword: string
+  newPassword: string
+  confirmPassword: string
+}
+
+export async function changePassword(
+  supabase: SupabaseAuth,
+  input: ChangePasswordInput,
+): Promise<PasswordChangeResult> {
+  const { email, currentPassword, newPassword, confirmPassword } = input
+
+  if (!currentPassword) return { ok: false, error: 'errors.currentPasswordRequired' }
+  if (newPassword !== confirmPassword) return { ok: false, error: 'errors.passwordMismatch' }
+  if (newPassword === currentPassword) return { ok: false, error: 'errors.passwordSameAsCurrent' }
+
+  const weak = validatePasswordStrength(newPassword)
+  if (weak) return { ok: false, error: weak }
+
+  // 1. Verify the current password.
+  //
+  // A FAILURE HERE MUST NOT SIGN THE USER OUT. supabase-js leaves the stored
+  // session untouched when signInWithPassword rejects, so returning early is
+  // enough — do not add a signOut() on this path.
+  //
+  // On success a fresh session for the SAME user replaces the stored one. The
+  // root layout's onAuthStateChange fires, but currentUser.ts compares identity
+  // rather than object reference, so nothing re-renders and nothing flashes.
+  const verify = await supabase.auth.signInWithPassword({
+    email: email.trim(),
+    password: currentPassword,
+  })
+  if (verify.error) {
+    const e = verify.error as AuthErrorish
+    if (isRateLimited(e)) return { ok: false, error: 'errors.rateLimitedSignIn' }
+    if (isWrongPassword(e)) return { ok: false, error: 'errors.wrongCurrentPassword' }
+    if (isNetworkFailure(e)) return { ok: false, error: 'errors.network' }
+    return { ok: false, error: e?.message || 'errors.generic' }
+  }
+
+  // 2. Set the new password.
+  const update = await supabase.auth.updateUser({ password: newPassword })
+  if (update.error) {
+    const e = update.error as AuthErrorish
+    if (isRateLimited(e)) return { ok: false, error: 'errors.rateLimitedSignIn' }
+    if (isSamePassword(e)) return { ok: false, error: 'errors.passwordSameAsCurrent' }
+    if (isWeakPassword(e)) return { ok: false, error: 'errors.passwordNeedsMix' }
+    if (isNetworkFailure(e)) return { ok: false, error: 'errors.network' }
+    return { ok: false, error: e?.message || 'errors.generic' }
+  }
+
+  // 3. Drop every OTHER session, keeping this device signed in. The password is
+  // already changed at this point, so a failure here is reported, not raised —
+  // telling the user the change failed would be untrue and would invite a retry
+  // that then trips the same-password check.
+  const signOut = await supabase.auth.signOut({ scope: 'others' })
+  return { ok: true, othersSignedOut: !signOut.error }
+}

--- a/apps/mobile/src/lib/profile.ts
+++ b/apps/mobile/src/lib/profile.ts
@@ -58,6 +58,78 @@ export async function fetchSpritePreference(
   return typeof sprite === 'string' ? sprite : null
 }
 
+// ---------------------------------------------------------------------------
+// Display name
+//
+// The editable name is stored on public.users.display_name, NOT in
+// auth.users.user_metadata. Two reasons, both load-bearing:
+//
+//   1. OAuth providers repopulate user_metadata on sign-in, so a name edited
+//      there is silently overwritten by the next Google or Apple sign-in.
+//   2. display_name already exists, is already what the web Profile page writes,
+//      and is one of only two columns `authenticated` may UPDATE
+//      (20260806000500_users_grant_hardening.sql). No schema change is needed.
+//
+// handle_new_user() seeds it from raw_user_meta_data->>'full_name' at signup and
+// never runs again, so a user who has never edited their name still has the
+// provider-supplied value in this column rather than a blank.
+// ---------------------------------------------------------------------------
+
+/** Read public.users.display_name. Null when unset or the read is denied. */
+export async function fetchDisplayName(
+  client: SupabaseClient,
+  userId: string,
+): Promise<string | null> {
+  const { data, error } = await client
+    .from('users')
+    .select('display_name')
+    .eq('id', userId)
+    .maybeSingle()
+  if (error || !data) return null
+  const name = (data as { display_name?: unknown }).display_name
+  return typeof name === 'string' && name.trim() ? name.trim() : null
+}
+
+export async function saveDisplayName(
+  client: SupabaseClient,
+  userId: string,
+  displayName: string,
+): Promise<{ error: string | null }> {
+  const { data: updated, error } = await client
+    .from('users')
+    .update({ display_name: displayName.trim() })
+    .eq('id', userId)
+    .select('id')
+  if (error) return { error: error.message }
+  if (!updated || updated.length === 0) {
+    // RLS denied the write or the users row doesn't exist yet (trigger race).
+    return { error: 'Profile row not found or not writable.' }
+  }
+  return { error: null }
+}
+
+type NameMetadataSource = {
+  email?: string | null
+  user_metadata?: Record<string, unknown> | null
+} | null
+
+/**
+ * The name to show, in precedence order: the edited column, then the provider
+ * profile, then the email local part. Returns null when nothing is usable —
+ * callers supply their own localized fallback.
+ *
+ * Pure, so the precedence is unit-tested rather than inferred from a screen.
+ */
+export function resolveDisplayName(stored: string | null, user: NameMetadataSource): string | null {
+  if (stored && stored.trim()) return stored.trim()
+  const meta = (user?.user_metadata ?? {}) as Record<string, unknown>
+  const full = (meta.full_name ?? meta.name) as string | undefined
+  if (full && full.trim()) return full.trim()
+  const email = user?.email
+  if (email) return email.split('@')[0]
+  return null
+}
+
 export async function stashPendingSprite(storage: KVStorage, sprite: string): Promise<void> {
   await storage.setItem(PENDING_SPRITE_KEY, sprite)
 }

--- a/apps/mobile/src/lib/telegramLink.ts
+++ b/apps/mobile/src/lib/telegramLink.ts
@@ -1,18 +1,21 @@
-import { apiBase, apiError, apiRequest } from './api'
+import { apiError, apiPost, apiRequest } from './api'
 
-// Telegram account-link STATUS and UNLINK, against the web app's existing
-// Pages Function (apps/web/functions/api/telegram/link.js). Both verbs are
-// reused verbatim — nothing here forks the backend:
+// Telegram account linking, against the web app's Pages Functions:
 //
-//   GET    /api/telegram/link → { linked, telegram_user_id, telegram_linked_at }
-//   DELETE /api/telegram/link → clears both columns
+//   GET    /api/telegram/link       → { linked, telegram_user_id, telegram_linked_at }
+//   DELETE /api/telegram/link       → clears both columns
+//   POST   /api/telegram/link-token → { url, expires_in } — the native handoff
 //
-// LINKING is not implemented natively yet. The only mechanism the backend
-// supports today is the Telegram Login Widget, which is browser-only: it injects
-// a script that calls back with an HMAC-signed payload, and there is no native
-// equivalent. So the unlinked row hands off to the web profile, where that widget
-// lives. The native bot `?start=<token>` flow that replaces this handoff ships
-// separately (PR 2) because it changes the bot webhook, which is in daily use.
+// The link URL is a `t.me` deep link carrying a short-lived, single-use token.
+// Opening it launches Telegram on the bot; the user taps START; the bot redeems
+// the token and writes the association. `t.me` is a Telegram universal link, so
+// it opens the installed app directly and falls back to the web client
+// otherwise — there is no `tg://` probe and so no LSApplicationQueriesSchemes
+// entry or native rebuild.
+//
+// The app cannot observe the outcome: the association happens inside Telegram
+// and is written server-side. Callers refetch status on focus and on the
+// foreground transition instead.
 //
 // No handle is available: the schema stores telegram_user_id (bigint) and
 // telegram_linked_at only — there is no username column anywhere.
@@ -24,15 +27,19 @@ export type TelegramLinkState = {
 
 export const UNLINKED: TelegramLinkState = { linked: false, linkedAt: null }
 
-/** The web profile's Telegram section, where the Login Widget is rendered. */
-export function telegramProfileUrl(): string {
-  try {
-    return `${apiBase()}/profile#telegram`
-  } catch {
-    // apiBase() throws when EXPO_PUBLIC_API_BASE_URL is unset. Opening a help
-    // link should never be the thing that crashes a settings screen.
-    return 'https://www.gracechords.com/profile#telegram'
-  }
+/**
+ * Mint a link token and return the Telegram URL that carries it.
+ *
+ * Minted per tap rather than cached: the token lives ten minutes and is burned
+ * on first use, so a stale one would fail silently inside Telegram where we
+ * cannot see it or explain it.
+ */
+export async function startTelegramLink(): Promise<string> {
+  const res = await apiPost('/api/telegram/link-token', {})
+  if (!res.ok) throw await apiError(res, 'telegram_link_token_failed')
+  const body = (await res.json()) as { url?: string }
+  if (!body?.url) throw new Error('telegram_link_token_failed')
+  return body.url
 }
 
 export async function fetchTelegramLink(): Promise<TelegramLinkState> {

--- a/apps/mobile/src/lib/telegramLink.ts
+++ b/apps/mobile/src/lib/telegramLink.ts
@@ -1,0 +1,54 @@
+import { apiBase, apiError, apiRequest } from './api'
+
+// Telegram account-link STATUS and UNLINK, against the web app's existing
+// Pages Function (apps/web/functions/api/telegram/link.js). Both verbs are
+// reused verbatim — nothing here forks the backend:
+//
+//   GET    /api/telegram/link → { linked, telegram_user_id, telegram_linked_at }
+//   DELETE /api/telegram/link → clears both columns
+//
+// LINKING is not implemented natively yet. The only mechanism the backend
+// supports today is the Telegram Login Widget, which is browser-only: it injects
+// a script that calls back with an HMAC-signed payload, and there is no native
+// equivalent. So the unlinked row hands off to the web profile, where that widget
+// lives. The native bot `?start=<token>` flow that replaces this handoff ships
+// separately (PR 2) because it changes the bot webhook, which is in daily use.
+//
+// No handle is available: the schema stores telegram_user_id (bigint) and
+// telegram_linked_at only — there is no username column anywhere.
+
+export type TelegramLinkState = {
+  linked: boolean
+  linkedAt: string | null
+}
+
+export const UNLINKED: TelegramLinkState = { linked: false, linkedAt: null }
+
+/** The web profile's Telegram section, where the Login Widget is rendered. */
+export function telegramProfileUrl(): string {
+  try {
+    return `${apiBase()}/profile#telegram`
+  } catch {
+    // apiBase() throws when EXPO_PUBLIC_API_BASE_URL is unset. Opening a help
+    // link should never be the thing that crashes a settings screen.
+    return 'https://www.gracechords.com/profile#telegram'
+  }
+}
+
+export async function fetchTelegramLink(): Promise<TelegramLinkState> {
+  const res = await apiRequest('GET', '/api/telegram/link')
+  if (!res.ok) throw await apiError(res, 'telegram_status_failed')
+  const body = (await res.json()) as {
+    linked?: boolean
+    telegram_linked_at?: string | null
+  }
+  return {
+    linked: Boolean(body?.linked),
+    linkedAt: body?.telegram_linked_at ?? null,
+  }
+}
+
+export async function unlinkTelegram(): Promise<void> {
+  const res = await apiRequest('DELETE', '/api/telegram/link')
+  if (!res.ok) throw await apiError(res, 'telegram_unlink_failed')
+}

--- a/apps/mobile/src/lib/useDisplayName.ts
+++ b/apps/mobile/src/lib/useDisplayName.ts
@@ -1,0 +1,83 @@
+import { useEffect, useSyncExternalStore } from 'react'
+import { supabase } from './supabase'
+import { useCurrentUserState } from './currentUser'
+import { fetchDisplayName, resolveDisplayName } from './profile'
+
+// The current user's editable display name, resolved against the provider
+// profile. Same shape as useProfileSprite: a module-level store so a save
+// updates every consumer at once (the Account row, the Settings header card and
+// Home's greeting all read it), plus a shared in-flight read so mounting three
+// consumers costs one request.
+//
+// Reads public.users.display_name; falls back to user_metadata and then the
+// email local part via resolveDisplayName. Returns null only when nothing is
+// usable, so callers supply their own localized fallback.
+
+let cachedUserId: string | null = null
+let cachedName: string | null = null
+const listeners = new Set<() => void>()
+
+let fetchedUserId: string | null = null
+let inFlight: Promise<void> | null = null
+
+function emit() {
+  for (const l of listeners) l()
+}
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+function getSnapshot(): string | null {
+  return cachedName
+}
+
+/** Update the cached name everywhere (call after a successful save). */
+export function setLocalDisplayName(name: string | null): void {
+  const next = name && name.trim() ? name.trim() : null
+  if (cachedName === next) return
+  cachedName = next
+  emit()
+}
+
+export function useDisplayName(): string | null {
+  const { user, resolved } = useCurrentUserState()
+  const stored = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  useEffect(() => {
+    // Don't touch the cache before auth is known: a null user here means "not
+    // resolved yet", not "signed out", and clearing on it would drop a good
+    // name and then re-fetch it.
+    if (!resolved) return
+    const uid = user?.id ?? null
+    if (uid !== cachedUserId) {
+      cachedUserId = uid
+      fetchedUserId = null
+      inFlight = null
+      setLocalDisplayName(null)
+    }
+    if (!uid) return
+    if (fetchedUserId === uid) return
+    if (!inFlight) {
+      inFlight = fetchDisplayName(supabase, uid)
+        .then((name) => {
+          // Ignore a late result for an account we have since switched away from.
+          if (cachedUserId !== uid) return
+          fetchedUserId = uid
+          if (name) setLocalDisplayName(name)
+        })
+        .catch(() => {
+          // A failed read is indistinguishable from "never set" — the caller
+          // falls back to the provider profile, which is the same value the
+          // column was seeded with. Not marked fetched, so the next mount
+          // retries.
+        })
+        .finally(() => {
+          inFlight = null
+        })
+    }
+  }, [user?.id, resolved])
+
+  return resolveDisplayName(stored, user)
+}

--- a/apps/mobile/src/screens/AccountScreen.tsx
+++ b/apps/mobile/src/screens/AccountScreen.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { Alert, AppState, Image, Linking, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { useTranslation } from 'react-i18next'
-import * as WebBrowser from 'expo-web-browser'
 import { useFocusEffect, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Screen from '../components/Screen'
@@ -23,7 +22,7 @@ import { saveDisplayName } from '../lib/profile'
 import { actionFailureMessage } from '../lib/errors'
 import {
   fetchTelegramLink,
-  telegramProfileUrl,
+  startTelegramLink,
   unlinkTelegram,
   UNLINKED,
   type TelegramLinkState,
@@ -128,6 +127,24 @@ export default function AccountScreen() {
     }
   }
 
+  // Mint a token and hand off to Telegram. We never learn whether the user
+  // actually tapped START, so there is nothing to await — the focus and
+  // foreground refetches above are what update the row when they come back.
+  async function onLinkTelegram() {
+    if (telegramBusy) return
+    setTelegramBusy(true)
+    try {
+      await Linking.openURL(await startTelegramLink())
+    } catch (err) {
+      Alert.alert(
+        tx('telegram.linkFailedTitle'),
+        actionFailureMessage('AccountScreen.startTelegramLink', err, tx),
+      )
+    } finally {
+      setTelegramBusy(false)
+    }
+  }
+
   function onUnlinkTelegram() {
     Alert.alert(tx('telegram.unlinkAlert.title'), tx('telegram.unlinkAlert.message'), [
       { text: tx('common:cancel'), style: 'cancel' },
@@ -193,7 +210,9 @@ export default function AccountScreen() {
     ? linkedDate
       ? tx('telegram.linkedOn', { date: linkedDate })
       : tx('telegram.linked')
-    : tx('telegram.link')
+    : telegramBusy
+      ? tx('telegram.linking')
+      : tx('telegram.link')
 
   return (
     <Screen edges={['left', 'right']}>
@@ -292,14 +311,8 @@ export default function AccountScreen() {
             chevron
             isLast
             onPress={() => {
-              if (telegram.linked) {
-                setSheet('telegram')
-                return
-              }
-              // In-app browser, so dismissing it returns here rather than
-              // leaving the app. Refetch on dismissal: the link may have just
-              // completed, and this is the tightest signal we get.
-              void WebBrowser.openBrowserAsync(telegramProfileUrl()).then(() => loadTelegram())
+              if (telegram.linked) setSheet('telegram')
+              else void onLinkTelegram()
             }}
           />
         </Card>

--- a/apps/mobile/src/screens/AccountScreen.tsx
+++ b/apps/mobile/src/screens/AccountScreen.tsx
@@ -1,0 +1,467 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import * as WebBrowser from 'expo-web-browser'
+import { useFocusEffect, useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Screen from '../components/Screen'
+import Card from '../components/Card'
+import ListRow from '../components/ListRow'
+import SectionHeader from '../components/SectionHeader'
+import SymbolIcon from '../components/SymbolIcon'
+import RowIcon from '../components/RowIcon'
+import DangerCard from '../components/DangerCard'
+import GlassSurface from '../components/GlassSurface'
+import FormSheetShell from '../components/FormSheetShell'
+import { useFormSheet } from '../lib/formSheetHost'
+import { useTheme } from '../theme/ThemeProvider'
+import { supabase } from '../lib/supabase'
+import { useCurrentUser } from '../lib/currentUser'
+import { useProfileSprite } from '../lib/useProfileSprite'
+import { useDisplayName, setLocalDisplayName } from '../lib/useDisplayName'
+import { saveDisplayName } from '../lib/profile'
+import { actionFailureMessage } from '../lib/errors'
+import {
+  fetchTelegramLink,
+  telegramProfileUrl,
+  unlinkTelegram,
+  UNLINKED,
+  type TelegramLinkState,
+} from '../lib/telegramLink'
+
+// Account — one level under Profile & Settings. Holds the identity, security and
+// connection actions that used to be scattered across the settings screen, plus
+// Log out and Delete account, which MOVED here rather than being duplicated:
+// two copies of a destructive action double both the mis-tap surface and the
+// confirm-dialog maintenance. App Store Guideline 5.1.1(v) wants account
+// deletion discoverable in-app, not top-level, so one level down matches how
+// Apple's own Settings treats Apple ID sign-out.
+
+/** Formats the link date in the app locale; the day is all the row needs. */
+function formatLinkedDate(iso: string | null, language: string): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return new Intl.DateTimeFormat(language, { dateStyle: 'medium' }).format(d)
+}
+
+export default function AccountScreen() {
+  const t = useTheme()
+  const { t: tx, i18n } = useTranslation(['profile', 'settings', 'common'])
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const user = useCurrentUser()
+  const { source: spriteSource } = useProfileSprite()
+  const displayName = useDisplayName()
+
+  const [sheet, setSheet] = useState<null | 'name' | 'telegram'>(null)
+  const [nameDraft, setNameDraft] = useState('')
+  const [savingName, setSavingName] = useState(false)
+  const [telegram, setTelegram] = useState<TelegramLinkState>(UNLINKED)
+  const [telegramBusy, setTelegramBusy] = useState(false)
+  const [barH, setBarH] = useState(0)
+
+  const email = user?.email ?? ''
+  const shownName = displayName ?? tx('settings:yourAccount')
+
+  // Render Change password if and only if this account carries an `email`
+  // identity. Deliberately NOT inferred from the absence of Google/Apple:
+  // identity linking means one user can hold an email identity AND OAuth
+  // identities at once, and inferring from OAuth would wrongly hide the row for
+  // exactly those accounts.
+  const hasEmailIdentity = (user?.identities ?? []).some((i) => i.provider === 'email')
+
+  const loadTelegram = useCallback(async () => {
+    try {
+      setTelegram(await fetchTelegramLink())
+    } catch (err) {
+      // Status is decoration on a settings row, not content. Leaving the row on
+      // its last known value beats replacing the screen with an error.
+      console.error('[AccountScreen] telegram status failed:', err)
+    }
+  }, [])
+
+  // The app cannot observe a link happening elsewhere — it completes in a
+  // browser (and, after PR 2, in Telegram). Refetch on focus AND on the
+  // foreground transition: returning from another app fires only the latter,
+  // because this screen never lost focus while the user was away.
+  const focused = useRef(false)
+  useFocusEffect(
+    useCallback(() => {
+      focused.current = true
+      void loadTelegram()
+      return () => {
+        focused.current = false
+      }
+    }, [loadTelegram]),
+  )
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active' && focused.current) void loadTelegram()
+    })
+    return () => sub.remove()
+  }, [loadTelegram])
+
+  function openNameSheet() {
+    setNameDraft(displayName ?? '')
+    setSheet('name')
+  }
+
+  async function onSaveName() {
+    const next = nameDraft.trim()
+    if (!user?.id || !next || savingName) {
+      setSheet(null)
+      return
+    }
+    setSavingName(true)
+    try {
+      const { error } = await saveDisplayName(supabase, user.id, next)
+      if (error) {
+        Alert.alert(tx('nameSheet.saveFailedTitle'), tx('nameSheet.saveFailedMessage'))
+        return
+      }
+      setLocalDisplayName(next)
+      setSheet(null)
+    } finally {
+      setSavingName(false)
+    }
+  }
+
+  function onUnlinkTelegram() {
+    Alert.alert(tx('telegram.unlinkAlert.title'), tx('telegram.unlinkAlert.message'), [
+      { text: tx('common:cancel'), style: 'cancel' },
+      {
+        text: tx('telegram.unlinkAlert.confirm'),
+        style: 'destructive',
+        onPress: async () => {
+          setTelegramBusy(true)
+          try {
+            await unlinkTelegram()
+            setTelegram(UNLINKED)
+            setSheet(null)
+          } catch (err) {
+            Alert.alert(
+              tx('telegram.unlinkFailedTitle'),
+              actionFailureMessage('AccountScreen.unlinkTelegram', err, tx),
+            )
+          } finally {
+            setTelegramBusy(false)
+          }
+        },
+      },
+    ])
+  }
+
+  function onSignOut() {
+    Alert.alert(tx('settings:signOutAlert.title'), tx('settings:signOutAlert.message'), [
+      { text: tx('common:cancel'), style: 'cancel' },
+      {
+        text: tx('settings:signOutAlert.confirm'),
+        style: 'destructive',
+        onPress: () => void supabase.auth.signOut(),
+      },
+    ])
+  }
+
+  function onDeleteAccount() {
+    Alert.alert(tx('settings:deleteAccountAlert.title'), tx('settings:deleteAccountAlert.message'), [
+      { text: tx('common:cancel'), style: 'cancel' },
+      {
+        text: tx('settings:deleteAccountAlert.confirm'),
+        style: 'destructive',
+        onPress: async () => {
+          // Unchanged from Profile & Settings: the SECURITY DEFINER RPC removes
+          // auth.users and cascades. The session then invalidates and the root
+          // auth listener redirects to /login.
+          const { error } = await supabase.rpc('delete_user')
+          if (error) {
+            Alert.alert(
+              tx('settings:deleteFailedAlert.title'),
+              tx('settings:deleteFailedAlert.message'),
+            )
+            return
+          }
+          await supabase.auth.signOut()
+        },
+      },
+    ])
+  }
+
+  const linkedDate = formatLinkedDate(telegram.linkedAt, i18n.language)
+  const telegramValue = telegram.linked
+    ? linkedDate
+      ? tx('telegram.linkedOn', { date: linkedDate })
+      : tx('telegram.linked')
+    : tx('telegram.link')
+
+  return (
+    <Screen edges={['left', 'right']}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingHorizontal: t.spacing.lg,
+          paddingTop: barH + t.spacing.sm,
+          paddingBottom: insets.bottom + t.spacing.xxl,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: t.typography.largeTitle.fontSize,
+            fontWeight: t.typography.largeTitle.fontWeight,
+            letterSpacing: t.typography.largeTitle.letterSpacing,
+            color: t.colors.ink,
+            paddingHorizontal: t.spacing.xs,
+            paddingBottom: t.spacing.md,
+          }}
+        >
+          {tx('title')}
+        </Text>
+
+        {/* PROFILE */}
+        <SectionHeader label={tx('sections.profile')} />
+        <Card>
+          <ListRow
+            title={tx('appIcon')}
+            accessibilityLabel={tx('appIcon')}
+            leading={
+              <View
+                style={{
+                  width: 29,
+                  height: 29,
+                  borderRadius: t.radii.pill,
+                  backgroundColor: t.colors.accentSoft,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                {spriteSource ? (
+                  <Image source={spriteSource} style={{ width: 29, height: 29 }} resizeMode="cover" />
+                ) : (
+                  <SymbolIcon name="person" size={16} color={t.colors.accent} />
+                )}
+              </View>
+            }
+            chevron
+            onPress={() => router.push({ pathname: '/choose-icon', params: { mode: 'edit' } })}
+          />
+          <ListRow
+            title={tx('name')}
+            leading={<RowIcon name="person" />}
+            value={shownName}
+            accessibilityLabel={`${tx('name')}, ${shownName}`}
+            chevron
+            onPress={openNameSheet}
+          />
+          {/* Read-only. Changing the email address is a separate feature. Apple
+              private-relay addresses show as-is. */}
+          <ListRow
+            title={tx('email')}
+            leading={<RowIcon name="envelope" />}
+            value={email}
+            accessibilityLabel={`${tx('email')}, ${email}`}
+            isLast
+          />
+        </Card>
+
+        {/* SECURITY — only for accounts that have a password to change. */}
+        {hasEmailIdentity ? (
+          <>
+            <SectionHeader label={tx('sections.security')} />
+            <Card>
+              <ListRow
+                title={tx('changePassword')}
+                leading={<RowIcon name="lock" />}
+                chevron
+                isLast
+                onPress={() => router.push('/account/password')}
+              />
+            </Card>
+          </>
+        ) : null}
+
+        {/* CONNECTIONS */}
+        <SectionHeader label={tx('sections.connections')} />
+        <Card>
+          <ListRow
+            title={tx('telegram.title')}
+            leading={<RowIcon name="paperplane.fill" />}
+            value={telegramValue}
+            accessibilityLabel={`${tx('telegram.title')}, ${telegramValue}`}
+            chevron
+            isLast
+            onPress={() => {
+              if (telegram.linked) {
+                setSheet('telegram')
+                return
+              }
+              // In-app browser, so dismissing it returns here rather than
+              // leaving the app. Refetch on dismissal: the link may have just
+              // completed, and this is the tightest signal we get.
+              void WebBrowser.openBrowserAsync(telegramProfileUrl()).then(() => loadTelegram())
+            }}
+          />
+        </Card>
+        {!telegram.linked ? (
+          <Text
+            style={{
+              paddingHorizontal: t.spacing.md,
+              paddingTop: t.spacing.sm,
+              fontSize: 12.5,
+              lineHeight: 17,
+              color: t.colors.sec,
+            }}
+          >
+            {tx('telegram.linkHint')}
+          </Text>
+        ) : null}
+
+        <DangerCard label={tx('logOut')} onPress={onSignOut} hint={tx('logOutHint')} />
+        <DangerCard
+          label={tx('deleteAccount')}
+          onPress={onDeleteAccount}
+          hint={tx('deleteAccountHint')}
+        />
+      </ScrollView>
+
+      {/* Scroll-behind top bar, matching Profile & Settings. */}
+      <GlassSurface
+        fallbackColor={t.colors.bg}
+        fallbackHairline
+        onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          paddingTop: insets.top,
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={tx('common:back')}
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+        >
+          <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>
+            {tx('settings:title')}
+          </Text>
+        </Pressable>
+      </GlassSurface>
+
+      <NameSheet
+        visible={sheet === 'name'}
+        value={nameDraft}
+        onChange={setNameDraft}
+        busy={savingName}
+        onSave={() => void onSaveName()}
+        onClose={() => setSheet(null)}
+      />
+      <TelegramSheet
+        visible={sheet === 'telegram'}
+        linkedDate={linkedDate}
+        busy={telegramBusy}
+        onUnlink={onUnlinkTelegram}
+        onClose={() => setSheet(null)}
+      />
+    </Screen>
+  )
+}
+
+type NameSheetProps = {
+  visible: boolean
+  value: string
+  onChange: (v: string) => void
+  busy: boolean
+  onSave: () => void
+  onClose: () => void
+}
+
+function NameSheet(props: NameSheetProps) {
+  useFormSheet(props.visible, () => <NameSheetContent {...props} />, props.onClose)
+  return null
+}
+
+function NameSheetContent({ value, onChange, busy, onSave }: NameSheetProps) {
+  const t = useTheme()
+  const { t: tx } = useTranslation('profile')
+  return (
+    <FormSheetShell
+      title={tx('nameSheet.title')}
+      actionLabel={busy ? tx('nameSheet.saving') : tx('nameSheet.save')}
+      onAction={onSave}
+    >
+      <View style={{ padding: t.spacing.lg, gap: t.spacing.sm }}>
+        <TextInput
+          value={value}
+          onChangeText={onChange}
+          placeholder={tx('nameSheet.placeholder')}
+          placeholderTextColor={t.colors.sec}
+          autoCapitalize="words"
+          autoCorrect={false}
+          autoFocus
+          returnKeyType="done"
+          onSubmitEditing={onSave}
+          accessibilityLabel={tx('nameSheet.title')}
+          style={{
+            height: 52,
+            paddingHorizontal: t.spacing.md + 2,
+            borderRadius: t.radii.md,
+            backgroundColor: t.colors.surfaceAlt,
+            borderWidth: 1,
+            borderColor: t.colors.border,
+            fontSize: t.typography.body.fontSize,
+            color: t.colors.ink,
+          }}
+        />
+        <Text style={{ fontSize: 12.5, lineHeight: 17, color: t.colors.sec }}>
+          {tx('nameSheet.hint')}
+        </Text>
+      </View>
+    </FormSheetShell>
+  )
+}
+
+type TelegramSheetProps = {
+  visible: boolean
+  linkedDate: string | null
+  busy: boolean
+  onUnlink: () => void
+  onClose: () => void
+}
+
+function TelegramSheet(props: TelegramSheetProps) {
+  useFormSheet(props.visible, () => <TelegramSheetContent {...props} />, props.onClose)
+  return null
+}
+
+function TelegramSheetContent({ linkedDate, busy, onUnlink, onClose }: TelegramSheetProps) {
+  const t = useTheme()
+  const { t: tx } = useTranslation('profile')
+  return (
+    <FormSheetShell title={tx('telegram.title')} onAction={onClose}>
+      <View style={{ paddingBottom: t.spacing.lg }}>
+        <ListRow
+          title={tx('telegram.status')}
+          value={linkedDate ? tx('telegram.linkedOn', { date: linkedDate }) : tx('telegram.linked')}
+          accessibilityLabel={tx('telegram.status')}
+        />
+        <ListRow
+          title={busy ? tx('telegram.unlinking') : tx('telegram.unlink')}
+          accessibilityLabel={tx('telegram.unlink')}
+          isLast
+          onPress={busy ? undefined : onUnlink}
+          trailing={
+            <SymbolIcon name="xmark.circle.fill" size={16} color={t.colors.danger} />
+          }
+        />
+      </View>
+    </FormSheetShell>
+  )
+}

--- a/apps/mobile/src/screens/ChangePasswordScreen.tsx
+++ b/apps/mobile/src/screens/ChangePasswordScreen.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react'
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Screen from '../components/Screen'
+import TextField from '../components/TextField'
+import SymbolIcon from '../components/SymbolIcon'
+import GlassSurface from '../components/GlassSurface'
+import ConstrainedContent from '../components/ConstrainedContent'
+import { useTheme } from '../theme/ThemeProvider'
+import { supabase } from '../lib/supabase'
+import { useCurrentUser } from '../lib/currentUser'
+import { changePassword } from '../lib/passwordChange'
+import { MIN_PASSWORD_LENGTH } from '../lib/authValidation'
+
+// Account → Change password. The orchestration (verify → update → drop other
+// sessions) lives in src/lib/passwordChange.ts so it unit-tests headless; this
+// screen is the form and the error surface.
+//
+// NOTHING on this screen may be logged or reported: no password values in
+// console output, breadcrumbs or analytics, and no analytics events at all.
+// Errors are rendered inline and are never destructive — a wrong current
+// password leaves the user signed in and the form filled.
+
+export default function ChangePasswordScreen() {
+  const t = useTheme()
+  const { t: tx } = useTranslation(['auth', 'profile', 'common'])
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const user = useCurrentUser()
+
+  const [current, setCurrent] = useState('')
+  const [next, setNext] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [barH, setBarH] = useState(0)
+
+  async function onSubmit() {
+    if (busy) return
+    setError(null)
+    const email = user?.email
+    if (!email) {
+      setError('errors.generic')
+      return
+    }
+    setBusy(true)
+    try {
+      const result = await changePassword(supabase, {
+        email,
+        currentPassword: current,
+        newPassword: next,
+        confirmPassword: confirm,
+      })
+      if (!result.ok) {
+        setError(result.error ?? 'errors.generic')
+        return
+      }
+      if (!result.othersSignedOut) {
+        // The password did change; only the other-device sign-out failed. Worth
+        // a line in the log, never worth telling the user the change failed.
+        console.error('[ChangePassword] password changed but signing out other sessions failed')
+      }
+      Alert.alert(tx('changePassword.successTitle'), tx('changePassword.successMessage'), [
+        { text: tx('common:ok'), onPress: () => router.back() },
+      ])
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Screen edges={['left', 'right']}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{
+            paddingHorizontal: t.spacing.lg,
+            paddingTop: barH + t.spacing.sm,
+            paddingBottom: insets.bottom + t.spacing.xxl,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: t.typography.largeTitle.fontSize,
+              fontWeight: t.typography.largeTitle.fontWeight,
+              letterSpacing: t.typography.largeTitle.letterSpacing,
+              color: t.colors.ink,
+              paddingHorizontal: t.spacing.xs,
+              paddingBottom: t.spacing.md,
+            }}
+          >
+            {tx('changePassword.title')}
+          </Text>
+
+          <ConstrainedContent tier="form">
+            <View style={{ gap: t.spacing.lg }}>
+              {/* autoComplete/textContentType are set so the OS offers the SAVED
+                  password for the current field and a NEW one for the others —
+                  never autofilling the current password into the new fields. */}
+              <TextField
+                label={tx('changePassword.current')}
+                icon="lock"
+                value={current}
+                onChangeText={setCurrent}
+                secureTextEntry
+                autoComplete="current-password"
+                textContentType="password"
+              />
+              <TextField
+                label={tx('changePassword.new')}
+                icon="lock"
+                value={next}
+                onChangeText={setNext}
+                secureTextEntry
+                autoComplete="new-password"
+                textContentType="newPassword"
+                helperText={tx('changePassword.requirements', { min: MIN_PASSWORD_LENGTH })}
+              />
+              <TextField
+                label={tx('changePassword.confirm')}
+                icon="lock"
+                value={confirm}
+                onChangeText={setConfirm}
+                secureTextEntry
+                autoComplete="new-password"
+                textContentType="newPassword"
+              />
+
+              {error ? (
+                <Text
+                  accessibilityLiveRegion="polite"
+                  style={{ fontSize: 13.5, color: t.colors.danger }}
+                >
+                  {tx(error, { defaultValue: error, min: MIN_PASSWORD_LENGTH })}
+                </Text>
+              ) : null}
+
+              <Pressable
+                onPress={() => void onSubmit()}
+                disabled={busy}
+                accessibilityRole="button"
+                accessibilityLabel={tx('changePassword.submit')}
+                style={({ pressed }) => ({
+                  height: 50,
+                  borderRadius: t.radii.md,
+                  backgroundColor: t.colors.accent,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: t.spacing.sm,
+                  opacity: busy ? 0.5 : pressed ? 0.85 : 1,
+                })}
+              >
+                <Text style={{ fontSize: 16.5, fontWeight: '700', color: t.colors.onAccent }}>
+                  {busy ? tx('pleaseWait') : tx('changePassword.submit')}
+                </Text>
+              </Pressable>
+
+              <Text style={{ fontSize: 12.5, lineHeight: 17, color: t.colors.sec }}>
+                {tx('changePassword.otherDevicesNote')}
+              </Text>
+            </View>
+          </ConstrainedContent>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <GlassSurface
+        fallbackColor={t.colors.bg}
+        fallbackHairline
+        onLayout={(e) => setBarH(e.nativeEvent.layout.height)}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          paddingTop: insets.top,
+          paddingHorizontal: t.spacing.md,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={tx('common:back')}
+          hitSlop={8}
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}
+        >
+          <SymbolIcon name="chevron.left" size={22} color={t.colors.accent} />
+          <Text style={{ fontSize: 16, fontWeight: '500', color: t.colors.textAccent }}>
+            {tx('profile:title')}
+          </Text>
+        </Pressable>
+      </GlassSurface>
+    </Screen>
+  )
+}

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -8,14 +8,14 @@ import Card from '../components/Card'
 import ListRow from '../components/ListRow'
 import SectionHeader from '../components/SectionHeader'
 import SymbolIcon from '../components/SymbolIcon'
+import RowIcon from '../components/RowIcon'
 import GlassSurface from '../components/GlassSurface'
 import FormSheetShell from '../components/FormSheetShell'
 import { useFormSheet } from '../lib/formSheetHost'
 import { useTheme } from '../theme/ThemeProvider'
-import type { Tokens } from '@gracechords/tokens/native'
-import { supabase } from '../lib/supabase'
 import { useCurrentUser } from '../lib/currentUser'
 import { useProfileSprite } from '../lib/useProfileSprite'
+import { useDisplayName } from '../lib/useDisplayName'
 import {
   setDefaultChordStyle,
   setDefaultDailyWordDestination,
@@ -38,10 +38,13 @@ import ReminderTimeSheet from '../components/reader/ReminderTimeSheet'
 import { setStreakEnabled, useReadingStreak } from '../lib/readingStreak'
 
 // The grouped "Profile & Settings" screen (design: [CONTENT] Settings Content).
-// Built from Stage-0 primitives — a Profile card, three grouped Cards
-// (Settings / Library / Support), and destructive Log out + Delete account
-// cards. Theme + chord style are app-wide DEFAULTS written here and read by the
-// Song Viewer / Performer / Daily Word.
+// Built from Stage-0 primitives — a Profile card and grouped Cards
+// (Settings / Reader / Library / Support). Theme + chord style are app-wide
+// DEFAULTS written here and read by the Song Viewer / Performer / Daily Word.
+//
+// The profile card now pushes ACCOUNT (app icon, name, email, change password,
+// Telegram) rather than the sprite picker directly. Log out and Delete account
+// live there too — moved, not copied, so there is only one of each.
 
 const HELP_URL = 'https://gracechords.com/help'
 const FEEDBACK_MAILTO = 'mailto:support@gracechords.com?subject=GraceChords%20feedback'
@@ -63,55 +66,6 @@ const DAILY_WORD_OPTIONS: { value: DailyWordDestination; labelKey: string }[] = 
 
 // Sentinel for "no override — follow the device language" in the picker.
 const LANGUAGE_SYSTEM = 'system'
-
-/** Rounded leading icon chip used on the grouped rows. */
-function RowIcon({ name, t }: { name: Parameters<typeof SymbolIcon>[0]['name']; t: Tokens }) {
-  return (
-    <View
-      style={{
-        width: 29,
-        height: 29,
-        borderRadius: 7,
-        backgroundColor: t.colors.accentSoft,
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <SymbolIcon name={name} size={16} color={t.colors.accent} />
-    </View>
-  )
-}
-
-/** A standalone destructive action card (Log out / Delete account). */
-function DangerCard({
-  label,
-  onPress,
-  accessibilityLabel,
-}: {
-  label: string
-  onPress: () => void
-  accessibilityLabel?: string
-}) {
-  const t = useTheme()
-  return (
-    <Card style={{ marginTop: t.spacing.lg }}>
-      <Pressable
-        onPress={onPress}
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel ?? label}
-        style={({ pressed }) => ({
-          paddingVertical: 13,
-          alignItems: 'center',
-          backgroundColor: pressed ? t.colors.surfaceAlt : 'transparent',
-        })}
-      >
-        <Text style={{ fontSize: t.typography.body.fontSize, fontWeight: '600', color: t.colors.danger }}>
-          {label}
-        </Text>
-      </Pressable>
-    </Card>
-  )
-}
 
 /** Radio list of options with a checkmark on the current value, presented via
  * the native formSheet route (src/lib/formSheetHost.ts). */
@@ -179,10 +133,10 @@ export default function SettingsScreen() {
   // Measured glass-bar height feeds the scroll-behind top inset.
   const [barH, setBarH] = useState(0)
 
-  const meta = (user?.user_metadata ?? {}) as Record<string, unknown>
-  const fullName = ((meta.full_name ?? meta.name) as string | undefined)?.trim()
   const email = user?.email ?? ''
-  const displayName = fullName || (email ? email.split('@')[0] : tx('yourAccount'))
+  // The edited name from public.users.display_name, falling back to the provider
+  // profile then the email local part — see resolveDisplayName in profile.ts.
+  const displayName = useDisplayName() ?? tx('yourAccount')
 
   const themeOptions = THEME_OPTIONS.map((o) => ({ value: o.value, label: tx(o.labelKey) }))
   const chordOptions = CHORD_OPTIONS.map((o) => ({ value: o.value, label: tx(o.labelKey) }))
@@ -226,38 +180,6 @@ export default function SettingsScreen() {
     }
   }
 
-  function onSignOut() {
-    Alert.alert(tx('signOutAlert.title'), tx('signOutAlert.message'), [
-      { text: tx('common:cancel'), style: 'cancel' },
-      { text: tx('signOutAlert.confirm'), style: 'destructive', onPress: () => void supabase.auth.signOut() },
-    ])
-  }
-
-  function onDeleteAccount() {
-    Alert.alert(
-      tx('deleteAccountAlert.title'),
-      tx('deleteAccountAlert.message'),
-      [
-        { text: tx('common:cancel'), style: 'cancel' },
-        {
-          text: tx('deleteAccountAlert.confirm'),
-          style: 'destructive',
-          onPress: async () => {
-            // Reuses the existing SECURITY DEFINER RPC (same path web uses):
-            // removes auth.users + cascades. Session then invalidates and the
-            // root auth listener redirects to /login.
-            const { error } = await supabase.rpc('delete_user')
-            if (error) {
-              Alert.alert(tx('deleteFailedAlert.title'), tx('deleteFailedAlert.message'))
-              return
-            }
-            await supabase.auth.signOut()
-          },
-        },
-      ],
-    )
-  }
-
   return (
     <Screen edges={['left', 'right']}>
       <ScrollView
@@ -284,9 +206,9 @@ export default function SettingsScreen() {
         {/* Profile card */}
         <Card>
           <Pressable
-            onPress={() => router.push({ pathname: '/choose-icon', params: { mode: 'edit' } })}
+            onPress={() => router.push('/account')}
             accessibilityRole="button"
-            accessibilityLabel={tx('changeYourIcon')}
+            accessibilityLabel={tx('openAccount')}
             style={({ pressed }) => ({
               flexDirection: 'row',
               alignItems: 'center',
@@ -336,28 +258,28 @@ export default function SettingsScreen() {
         <Card>
           <ListRow
             title={tx('appearance')}
-            leading={<RowIcon name="circle.lefthalf.filled" t={t} />}
+            leading={<RowIcon name="circle.lefthalf.filled" />}
             value={themeOptions.find((o) => o.value === defaults.theme)?.label ?? ''}
             chevron
             onPress={() => setSheet('theme')}
           />
           <ListRow
             title={tx('language')}
-            leading={<RowIcon name="globe" t={t} />}
+            leading={<RowIcon name="globe" />}
             value={localeLabel(resolvedLanguage)}
             chevron
             onPress={() => setSheet('language')}
           />
           <ListRow
             title={tx('chordStyle')}
-            leading={<RowIcon name="music.note" t={t} />}
+            leading={<RowIcon name="music.note" />}
             value={chordOptions.find((o) => o.value === defaults.chordStyle)?.label ?? ''}
             chevron
             onPress={() => setSheet('chordStyle')}
           />
           <ListRow
             title={tx('offlineDownloads')}
-            leading={<RowIcon name="arrow.down.circle" t={t} />}
+            leading={<RowIcon name="arrow.down.circle" />}
             chevron
             isLast
             onPress={() => router.push('/offline')}
@@ -369,14 +291,14 @@ export default function SettingsScreen() {
         <Card>
           <ListRow
             title={tx('dailyWordEntry')}
-            leading={<RowIcon name="book" t={t} />}
+            leading={<RowIcon name="book" />}
             value={dailyWordOptions.find((o) => o.value === defaults.dailyWordDestination)?.label ?? ''}
             chevron
             onPress={() => setSheet('dailyEntry')}
           />
           <ListRow
             title={tx('reminder.dailyReminder')}
-            leading={<RowIcon name="bell" t={t} />}
+            leading={<RowIcon name="bell" />}
             trailing={
               <Switch
                 value={reminder.enabled}
@@ -390,7 +312,7 @@ export default function SettingsScreen() {
           {reminder.enabled ? (
             <ListRow
               title={tx('reminder.time')}
-              leading={<RowIcon name="clock" t={t} />}
+              leading={<RowIcon name="clock" />}
               value={formatReminderTime(reminder.hour, reminder.minute, i18n.language)}
               chevron
               onPress={() => setSheet('reminderTime')}
@@ -398,7 +320,7 @@ export default function SettingsScreen() {
           ) : null}
           <ListRow
             title={tx('readingStreak.title')}
-            leading={<RowIcon name="flame.fill" t={t} />}
+            leading={<RowIcon name="flame.fill" />}
             isLast
             trailing={
               <Switch
@@ -416,13 +338,13 @@ export default function SettingsScreen() {
         <Card>
           <ListRow
             title={tx('starred')}
-            leading={<RowIcon name="star" t={t} />}
+            leading={<RowIcon name="star" />}
             chevron
             onPress={() => router.push('/songs')}
           />
           <ListRow
             title={tx('mySetlists')}
-            leading={<RowIcon name="music.note.list" t={t} />}
+            leading={<RowIcon name="music.note.list" />}
             chevron
             isLast
             onPress={() => router.push('/setlists')}
@@ -434,27 +356,24 @@ export default function SettingsScreen() {
         <Card>
           <ListRow
             title={tx('helpCenter')}
-            leading={<RowIcon name="questionmark.circle" t={t} />}
+            leading={<RowIcon name="questionmark.circle" />}
             chevron
             onPress={() => void Linking.openURL(HELP_URL)}
           />
           <ListRow
             title={tx('sendFeedback')}
-            leading={<RowIcon name="envelope" t={t} />}
+            leading={<RowIcon name="envelope" />}
             chevron
             onPress={() => void Linking.openURL(FEEDBACK_MAILTO)}
           />
           <ListRow
             title={tx('aboutGraceChords')}
-            leading={<RowIcon name="info.circle" t={t} />}
+            leading={<RowIcon name="info.circle" />}
             chevron
             isLast
             onPress={() => router.push('/about')}
           />
         </Card>
-
-        <DangerCard label={tx('logOut')} onPress={onSignOut} />
-        <DangerCard label={tx('deleteAccount')} onPress={onDeleteAccount} />
       </ScrollView>
 
       {/* Scroll-behind top bar: Liquid Glass on iOS 26, opaque page-bg bar on

--- a/apps/web/functions/api/telegram/link-token.js
+++ b/apps/web/functions/api/telegram/link-token.js
@@ -1,0 +1,118 @@
+// POST /api/telegram/link-token
+//   Headers: Authorization: Bearer <supabase access token>
+//   Returns: { url, expires_in }
+//
+// Mints a short-lived, single-use token and returns the Telegram deep link that
+// carries it. The app opens that URL; the user taps START; the bot redeems the
+// token and writes the association. This is the NATIVE linking path — the
+// Telegram Login Widget (see link.js) is browser-only and has no mobile
+// equivalent, which is why this exists.
+//
+// The token is minted by the bot worker rather than here, because BOT_KV — the
+// namespace it is stored in — is bound to that worker. This endpoint's job is
+// the part the worker cannot do: prove who the caller is. It reuses
+// BOT_INTERNAL_URL + BOT_WEBHOOK_TOKEN, both already configured for
+// /api/telegram/push, so there is no new secret to provision or rotate.
+//
+// Status and unlink stay on link.js (GET / DELETE). Nothing here duplicates them.
+
+// The bot username is not a secret and is already hardcoded in the web widget
+// (components/TelegramLoginButton.jsx) and the mobile client
+// (apps/mobile/src/lib/telegramPush.ts). Keep the three in step.
+const BOT_USERNAME = 'gracechords_bot'
+
+// Mirrors TTL_SECONDS in workers/telegram-bot/src/linkToken.js. Reported to the
+// client so it can tell the user when a link has gone stale.
+const TOKEN_TTL_SECONDS = 600
+
+function json(body, init = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(init.headers || {}) }
+  return new Response(JSON.stringify(body), { ...init, headers })
+}
+function jsonError(msg, status) {
+  return json({ error: msg }, { status })
+}
+
+// Same delegation as link.js: let Supabase validate the signature so this keeps
+// working through JWT signing-key rotations without SUPABASE_JWT_SECRET in env.
+async function verifySupabaseJwt(request, env) {
+  const auth = request.headers.get('Authorization') || ''
+  if (!auth.startsWith('Bearer ')) {
+    return { error: 'Missing bearer token', status: 401 }
+  }
+  const token = auth.slice(7).trim()
+
+  const resp = await fetch(`${env.SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (resp.status === 401) return { error: 'Invalid or expired token', status: 401 }
+  if (!resp.ok) return { error: `Auth check failed: ${resp.status}`, status: 502 }
+  const user = await resp.json().catch(() => null)
+  if (!user?.id) return { error: 'Auth response missing user id', status: 502 }
+  return { userId: user.id }
+}
+
+export async function onRequest(context) {
+  const { request, env } = context
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Access-Control-Allow-Origin': new URL(request.url).origin,
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      },
+    })
+  }
+
+  if (request.method !== 'POST') {
+    return jsonError('Method not allowed', 405)
+  }
+
+  if (!env.BOT_INTERNAL_URL || !env.BOT_WEBHOOK_TOKEN) {
+    return jsonError('Server not configured', 503)
+  }
+
+  const auth = await verifySupabaseJwt(request, env)
+  if (auth.error) return jsonError(auth.error, auth.status)
+
+  // Bounded like push.js: a misconfigured or unreachable worker must fail fast,
+  // because someone is watching a spinner on a settings row.
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 5000)
+  let botResp
+  try {
+    botResp = await fetch(`${env.BOT_INTERNAL_URL.replace(/\/$/, '')}/internal/link-token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.BOT_WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ user_id: auth.userId }),
+      signal: controller.signal,
+    })
+  } catch (err) {
+    clearTimeout(timeout)
+    return jsonError(`Bot unreachable: ${err?.message || err}`, 503)
+  }
+  clearTimeout(timeout)
+
+  if (!botResp.ok) {
+    const text = await botResp.text().catch(() => '')
+    return jsonError(`Bot returned ${botResp.status}: ${text}`.trim(), 502)
+  }
+
+  const body = await botResp.json().catch(() => null)
+  if (!body?.token) {
+    return jsonError('Bot response missing token', 502)
+  }
+
+  return json({
+    url: `https://t.me/${BOT_USERNAME}?start=${body.token}`,
+    expires_in: TOKEN_TTL_SECONDS,
+  })
+}

--- a/workers/telegram-bot/ARCHITECTURE.md
+++ b/workers/telegram-bot/ARCHITECTURE.md
@@ -28,6 +28,7 @@ Replaces the old GitHub Action; that workflow can be deleted.
 | Group / supergroup mentions | Same webhook, when the bot is `@`-mentioned in a group it's a member of | `POST /webhook` |
 | Guest-chat mentions | Same webhook, payload arrives under `update.guest_message` (BotFather → Guest Chat Mode → On) | `POST /webhook` |
 | Feature announcements | `feature-post.yml` on PR merge — fires on `feat(` prefix OR `post` label OR `#post` in title/body. The worker then drops backend-only scopes (`feat(cli)`, `feat(worker)`, …) unless the `post`/`#post` override forced it. Body is rewritten through Workers AI into a warm, end-user tone before posting; the post links to the app, not GitHub. | `POST /internal/feature` |
+| Account linking (mobile) | App taps "Link Telegram" → web `POST /api/telegram/link-token` → this worker mints a token → app opens `t.me/<bot>?start=<token>` → user taps START | `POST /internal/link-token`, then `POST /webhook` |
 | Mon + Fri digest | Cloudflare cron `0 22 * * 1,5` | `scheduled()` handler |
 
 `src/index.js` is the HTTP router; auth lives in `src/auth.js`. Each
@@ -41,10 +42,11 @@ flows based on chat type and the presence of `update.guest_message`.
 |---|---|
 | `src/index.js` | HTTP router + `scheduled()`. Verifies webhook secret, dispatches. |
 | `src/auth.js` | `verifyTelegramWebhook()` and internal bearer auth for `/internal/feature`. |
-| `src/webhook.js` | Router for DM, group, and guest-chat flows. Handles `/start`, `/help`, free-text song queries, callback queries from inline buttons, and the dedicated `handleGuestMessage` path. Owns the JPG-vs-PDF UX. |
+| `src/webhook.js` | Router for DM, group, and guest-chat flows. Handles `/start` (bare **and** `/start <link-token>`), `/help`, free-text song queries, callback queries from inline buttons, and the dedicated `handleGuestMessage` path. Owns the JPG-vs-PDF UX. |
+| `src/linkToken.js` | Mint/redeem short-lived account-link tokens in BOT_KV (`linktok:<token>`, 10-min TTL, deleted on read). The encoding is load-bearing — see the header comment on Telegram's 64-char / `[A-Za-z0-9_-]` start-payload limit. |
 | `src/parseRequest.js` | Message text → list of `{ title, key? }` items. Handles "Song A in G, Song B" syntax. Same parser is used by all three message flows. |
 | `src/searchClient.js` | Calls the site's `/api/bot/*` Pages Functions. Talks to `songs/search`, `song/[id]`, `setlist`. Also classifies match quality (auto vs disambiguate vs no-match); `classifyMatch(results, query)` short-circuits to `auto` when any candidate's title exactly equals the parsed query. |
-| `src/supabase.js` | Direct DB reads via PostgREST. Used for `findUserByTelegramId` and the digest's recent-songs/posts queries. |
+| `src/supabase.js` | Direct DB reads via PostgREST (`findUserByTelegramId`, digest queries) plus the ONE write: `linkTelegramAccount` sets `telegram_user_id` + `telegram_linked_at` and nothing else. service_role bypasses RLS, so that narrowness is the only guard. |
 | `src/ratelimit.js` | KV-backed per-user limiter for DM — 30 requests / hour. |
 | `src/groupRateLimit.js` | KV-backed per-chat cooldown for group + guest traffic — 6 renders / minute. Independent of the DM limiter. |
 | `src/pdfRender.js` | PDF generation (always) and JPG rasterization (best-effort). Imports the shared `pdf_mvp/pure.js` engine + jsPDF; uses bundled pdfium WASM to rasterize the resulting PDF to PNG bytes for `sendPhoto`. |
@@ -74,6 +76,13 @@ WASM, jsPDF, transposition, and the chord-chart engine in
    to `findUserByTelegramId` (Supabase) on miss. Onboarding text if not
    linked. `/start` and `/help` route to `startText(name)` and
    `helpText()` respectively when the user is linked.
+   - **`/start <token>` is intercepted before that lookup.** Only a payload
+     matching the 43-char mint shape counts; a bare `/start` behaves exactly
+     as it always has. The handler redeems the token, writes the association,
+     and then **deletes `userlookup:<tg_id>`** — that cache holds negative
+     answers for 5 minutes, so without the purge the next message after a
+     successful link would still get the onboarding text. An already-linked
+     Telegram account is REFUSED, never transferred.
 5. `parseRequest(text)` produces `[{ title, key }]` items.
 6. `checkRateLimit` consumes one slot from the per-user KV bucket.
 7. `advanceResolution` (`resolver.js`) walks the items, calling

--- a/workers/telegram-bot/src/index.js
+++ b/workers/telegram-bot/src/index.js
@@ -3,6 +3,7 @@
 //   POST /webhook            — Telegram updates (DM flow)
 //   POST /internal/feature       — GitHub Action calls this on merged "post" PRs
 //   POST /internal/push          — Pages Function pushes a song/setlist to a linked user
+//   POST /internal/link-token    — Pages Function mints a short-lived account-link token
 //   POST /internal/report-alert  — Pages Function alerts admin about a reported reflection
 //   GET  /healthz                — liveness
 // Scheduled: digest cron, Mon + Fri 17:00 ET (see wrangler.toml).
@@ -13,6 +14,7 @@ import { runDigest } from './digest.js'
 import { postFeature } from './feature.js'
 import { pushToUser } from './push.js'
 import { sendReportAlert } from './reportAlert.js'
+import { createLinkToken } from './linkToken.js'
 
 function notFound() {
   return new Response('Not found', { status: 404 })
@@ -83,6 +85,34 @@ export default {
         })
       )
       return ok()
+    }
+
+    if (url.pathname === '/internal/link-token') {
+      if (request.method !== 'POST') return new Response('Method not allowed', { status: 405 })
+      if (!verifyInternalBearer(request, env)) return unauthorized()
+      let body
+      try {
+        body = await request.json()
+      } catch {
+        return new Response('Invalid JSON', { status: 400 })
+      }
+      const userId = body?.user_id
+      if (!userId || typeof userId !== 'string') {
+        return new Response('Missing user_id', { status: 400 })
+      }
+      // Minted here rather than in the Pages Function because BOT_KV is bound to
+      // this worker. The caller has already verified the user's Supabase JWT —
+      // this endpoint trusts BOT_WEBHOOK_TOKEN and nothing else, so it must never
+      // be exposed to app clients directly.
+      try {
+        const token = await createLinkToken(env, userId)
+        return new Response(JSON.stringify({ token }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      } catch (err) {
+        return new Response(`Mint failed: ${err.message || err}`, { status: 500 })
+      }
     }
 
     if (url.pathname === '/internal/report-alert') {

--- a/workers/telegram-bot/src/linkToken.js
+++ b/workers/telegram-bot/src/linkToken.js
@@ -1,0 +1,81 @@
+// Short-lived account-link tokens for the mobile "Link Telegram" flow.
+//
+// The app asks the web API for a token, opens https://t.me/<bot>?start=<token>,
+// and the user taps START. Telegram hands the token to /start, which is the only
+// way the bot learns which GraceChords account the sender belongs to.
+//
+// TELEGRAM'S START PAYLOAD IS CAPPED AT 64 CHARACTERS AND RESTRICTED TO THE
+// ALPHABET [A-Za-z0-9_-]. 32 random bytes encoded as base64url WITHOUT PADDING
+// is exactly 43 characters drawn from precisely that alphabet, so it fits with
+// room for the caller to prefix if that is ever needed.
+//
+// Do not "simplify" the encoding:
+//   - hex would be 64 characters — exactly at the limit, no headroom;
+//   - standard base64 emits '+', '/' and '=', all outside the permitted set;
+//   - anything JSON-shaped blows the budget immediately.
+// Telegram does not reject an over-long or out-of-alphabet start parameter with
+// an error. It truncates or drops it, so the failure appears as "linking just
+// doesn't work" for real users and never once in local testing.
+
+const TOKEN_BYTES = 32
+const TTL_SECONDS = 10 * 60
+
+// The exact shape mintTokenValue produces: 32 bytes → 43 base64url characters.
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/
+
+const keyFor = (token) => `linktok:${token}`
+
+function base64url(bytes) {
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function mintTokenValue() {
+  return base64url(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)))
+}
+
+/** Mint a token for `userId` and stash it in KV under a 10-minute TTL. */
+export async function createLinkToken(env, userId) {
+  if (!env.BOT_KV) throw new Error('BOT_KV is not bound')
+  const token = mintTokenValue()
+  await env.BOT_KV.put(keyFor(token), String(userId), { expirationTtl: TTL_SECONDS })
+  return token
+}
+
+/**
+ * Exchange a token for the user id it was minted for, deleting it so it cannot
+ * be reused.
+ *
+ * KV is eventually consistent, so the delete leaves a replay window on the order
+ * of a minute. That is accepted, not engineered around: the token already
+ * expires in ten minutes, it is delivered over Telegram's own transport to a
+ * chat the recipient controls, and the alternatives (a Durable Object, or a
+ * Postgres row plus a migration) are a large amount of machinery for a
+ * ten-minute secret.
+ */
+export async function redeemLinkToken(env, token) {
+  if (!env.BOT_KV) return null
+  if (!looksLikeLinkToken(token)) return null
+  const key = keyFor(token)
+  const userId = await env.BOT_KV.get(key)
+  if (!userId) return null
+  await env.BOT_KV.delete(key)
+  return userId
+}
+
+/**
+ * Shape check before touching KV, so a junk or hand-typed /start payload never
+ * becomes a lookup. A bare `/start` has no payload at all and must keep its
+ * existing welcome behaviour — callers check this first and fall through.
+ */
+export function looksLikeLinkToken(value) {
+  return typeof value === 'string' && TOKEN_PATTERN.test(value)
+}
+
+/** The deep link the app opens. `t.me` is a Telegram universal link: it opens
+ * the installed app directly and falls back to the web client otherwise, so no
+ * `tg://` probe (and no LSApplicationQueriesSchemes entry) is needed. */
+export function linkUrlFor(botUsername, token) {
+  return `https://t.me/${botUsername}?start=${token}`
+}

--- a/workers/telegram-bot/src/supabase.js
+++ b/workers/telegram-bot/src/supabase.js
@@ -19,6 +19,53 @@ async function get(env, path) {
   return resp.json()
 }
 
+/**
+ * Associate a Telegram account with a GraceChords user.
+ *
+ * THE WRITE IS DELIBERATELY NARROW. service_role bypasses RLS entirely, so the
+ * only thing standing between this call and any column on public.users is the
+ * body below — there is no policy backstop. Write telegram_user_id and
+ * telegram_linked_at and nothing else, ever.
+ *
+ * REFUSES rather than transfers. users_telegram_user_id_key is UNIQUE
+ * (20260521000000_telegram_link.sql:19, codified again in 20260806000000), so
+ * pointing a second GraceChords account at an already-linked Telegram id fails
+ * at the constraint and surfaces here as 'already_linked_elsewhere'. Do not
+ * "fix" that by clearing the other row first: whoever most recently ran /start
+ * would silently inherit the other account, which is exactly the takeover this
+ * refusal exists to prevent.
+ */
+export async function linkTelegramAccount(env, { userId, telegramUserId }) {
+  const resp = await fetch(
+    `${env.SUPABASE_URL}/rest/v1/users?id=eq.${encodeURIComponent(userId)}`,
+    {
+      method: 'PATCH',
+      headers: { ...headers(env), 'Content-Type': 'application/json', Prefer: 'return=representation' },
+      body: JSON.stringify({
+        telegram_user_id: telegramUserId,
+        telegram_linked_at: new Date().toISOString(),
+      }),
+    },
+  )
+
+  if (resp.ok) {
+    const rows = await resp.json().catch(() => [])
+    // An empty representation means the id matched no row — treat as failure
+    // rather than reporting a link that does not exist.
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return { status: 'error', detail: 'no matching user row' }
+    }
+    return { status: 'ok' }
+  }
+
+  const text = await resp.text().catch(() => '')
+  // Same detection the web endpoint uses (functions/api/telegram/link.js:206).
+  if (resp.status === 409 || /telegram_user_id/.test(text)) {
+    return { status: 'already_linked_elsewhere' }
+  }
+  return { status: 'error', detail: `${resp.status} ${text}` }
+}
+
 export async function findUserByTelegramId(env, telegramUserId) {
   const rows = await get(
     env,

--- a/workers/telegram-bot/src/webhook.js
+++ b/workers/telegram-bot/src/webhook.js
@@ -2,7 +2,8 @@
 // and inline-button callback queries. Channel posts and edited messages are
 // silently ignored.
 
-import { findUserByTelegramId } from './supabase.js'
+import { findUserByTelegramId, linkTelegramAccount } from './supabase.js'
+import { looksLikeLinkToken, redeemLinkToken } from './linkToken.js'
 import { checkRateLimit, formatCooldown } from './ratelimit.js'
 import { checkGroupRateLimit } from './groupRateLimit.js'
 import { parseRequest } from './parseRequest.js'
@@ -76,7 +77,8 @@ function onboardingText() {
     'I send chord charts as JPGs for you to use in the moment, or PDFs to download/share.',
     'To get started, link your GraceChords account to your Telegram so I know it\'s you.',
     '',
-    '➡️ Open https://www.gracechords.com/profile and use the "Link Telegram" section.',
+    '➡️ In the app: Profile & Settings → Account → Telegram → "Link Telegram".',
+    '➡️ On the web: open https://www.gracechords.com/profile and use the "Link Telegram" section.',
     '',
     'Once linked, just send me a song title (or a comma-separated setlist) and I\'ll do the rest.',
   ].join('\n')
@@ -104,8 +106,10 @@ function helpText() {
   ].join('\n')
 }
 
+const userCacheKey = (telegramUserId) => `userlookup:${telegramUserId}`
+
 async function getLinkedUser(env, telegramUserId) {
-  const cacheKey = `userlookup:${telegramUserId}`
+  const cacheKey = userCacheKey(telegramUserId)
   if (env.BOT_KV) {
     const cached = await env.BOT_KV.get(cacheKey, 'json')
     if (cached) return cached.linked ? cached.user : null
@@ -117,6 +121,55 @@ async function getLinkedUser(env, telegramUserId) {
     })
   }
   return user
+}
+
+/**
+ * Drop the cached lookup for one Telegram user.
+ *
+ * getLinkedUser caches the NEGATIVE answer too, for USER_CACHE_TTL_S. Without
+ * this purge, the message a user sends straight after linking would still be
+ * answered with the onboarding text for up to five minutes — the flow would
+ * appear broken exactly once, for every single user, and never in testing.
+ */
+async function forgetLinkedUser(env, telegramUserId) {
+  if (!env.BOT_KV) return
+  await env.BOT_KV.delete(userCacheKey(telegramUserId))
+}
+
+/**
+ * `/start <token>` — the mobile account-link handoff.
+ *
+ * Reached only from a DM whose payload matches the minted token shape; a bare
+ * /start never gets here.
+ */
+async function handleLinkToken(env, { chatId, telegramUserId, token }) {
+  const reply = (text) => sendMessage(env.TELEGRAM_BOT_TOKEN, { chat_id: chatId, text })
+
+  const userId = await redeemLinkToken(env, token)
+  if (!userId) {
+    return reply(
+      'That link has expired or was already used.\n\n' +
+        'Open GraceChords → Profile & Settings → Account → Telegram and tap "Link Telegram" to get a fresh one.',
+    )
+  }
+
+  const result = await linkTelegramAccount(env, { userId, telegramUserId })
+
+  if (result.status === 'already_linked_elsewhere') {
+    return reply(
+      'This Telegram account is already linked to a different GraceChords account.\n\n' +
+        'Unlink it from that account first, then try again.',
+    )
+  }
+  if (result.status !== 'ok') {
+    console.warn('telegram link write failed', result.detail)
+    return reply('Something went wrong linking your account. Please try again in a moment.')
+  }
+
+  await forgetLinkedUser(env, telegramUserId)
+  const user = await getLinkedUser(env, telegramUserId)
+  const name = (user?.display_name || '').trim()
+  return reply(`✅ Your account is linked!\n\n${startText(name)}`)
 }
 
 async function loadSetlistToken(env, token) {
@@ -149,6 +202,16 @@ async function handleTextMessage(env, ctx, message, options = {}) {
       })
       return
     }
+    // `/start <token>` carries the mobile link handoff. ONLY a payload matching
+    // the minted token shape is treated as one — a bare /start, /help, and any
+    // other payload fall straight through to the welcome text below, byte for
+    // byte the behaviour they had before this branch existed.
+    const startPayload = startMatch ? (text.match(/^\/start(?:@\S+)?\s+(\S+)/i)?.[1] ?? '') : ''
+    if (looksLikeLinkToken(startPayload)) {
+      await handleLinkToken(env, { chatId, telegramUserId, token: startPayload })
+      return
+    }
+
     const user = await getLinkedUser(env, telegramUserId)
     if (!user) {
       await sendMessage(env.TELEGRAM_BOT_TOKEN, { chat_id: chatId, text: onboardingText() })


### PR DESCRIPTION
Two commits, reviewable in order:

1. **`feat(mobile)`** — the Account screen (mobile only, no backend change)
2. **`feat(telegram)`** — native account linking (bot worker + one new Pages Function)

---

## 1. Account screen

Profile & Settings → header card → **Account** → icon picker (unchanged, now one row among others).

- **PROFILE** — App icon (pushes the existing picker untouched), Name (editable), Email (read-only)
- **SECURITY** — Change password, rendered conditionally
- **CONNECTIONS** — Telegram
- **Footer** — Log out and Delete account, **moved** from Profile & Settings, not duplicated

Duplicating destructive actions would double both the mis-tap surface and the confirm-dialog maintenance. Guideline 5.1.1(v) wants deletion discoverable in-app but not necessarily top-level, so one level down matches how Apple's own Settings treats Apple ID sign-out.

### Name storage — no migration

Stored on `public.users.display_name`, **not** `auth.users.user_metadata`: OAuth providers repopulate `user_metadata` on sign-in, so a name edited there is overwritten by the next Google or Apple sign-in.

Nothing to migrate — the column already exists, `handle_new_user()` seeds it from `full_name` at signup and never runs again, and `authenticated` already holds column-level UPDATE on it (`20260806000500`). `guard_users_role_change` only fires when `role` changes, so a name write passes. Precedence lives in a pure `resolveDisplayName()` so it's tested, not inferred from a screen.

### Change password

Renders **if and only if** the account carries an `email` identity:

```ts
(user?.identities ?? []).some(i => i.provider === 'email')
```

Not inferred from the absence of Google/Apple — identity linking means one user can hold both at once.

Flow: `signInWithPassword` (verify) → `updateUser` → `signOut({ scope: 'others' })`. A wrong current password returns early; supabase-js leaves the stored session untouched, so the user is never signed out. A `signOut` failure still reports success, because the password *did* change.

The current-password prompt is a **UX guard against an accidental change, not a security control** — "Require current password when updating" is off, so `updateUser()` succeeds on the session alone. Chosen over `reauthenticate()` because that needs an email round trip, which fails in the low-connectivity settings this app is used in.

The policy (8 chars; lower, upper, digit, symbol) is mirrored in `authValidation.ts` with a comment naming the dashboard as its source — there is no `supabase/config.toml`, so it isn't machine-readable. The server's own `weak_password` rejection is surfaced inline regardless. Rate limiting is a distinct error state whose copy says the throttle affects signing in **anywhere**.

No password values in logs or breadcrumbs; no analytics on this screen.

---

## 2. Native Telegram linking

Tap **Link Telegram** → Telegram opens on `@gracechords_bot` → tap START → linked.

The Login Widget is browser-only (injects a script, calls back with an HMAC-signed payload), so it has no native equivalent. The bot's start parameter is the documented mechanism.

### Token

32 random bytes, base64url **without padding**, in `BOT_KV` under `linktok:<token>`, 10-minute TTL, deleted on read. Opaque and random rather than signed: nothing to provision or rotate in two places, and single-use falls out of the KV delete.

**The encoding is load-bearing.** Telegram caps the start payload at 64 characters and restricts it to `[A-Za-z0-9_-]`. 32 bytes as base64url-unpadded is exactly 43 characters in exactly that alphabet. Hex would be 64 (at the limit); standard base64 emits `+`, `/`, `=`. Telegram doesn't error on a bad payload — it truncates or drops it, so the failure is invisible in testing and total in production. **Verified across 20,000 samples: always 43 chars, no character outside the permitted set.**

KV is eventually consistent, so the delete leaves a replay window on the order of a minute. Documented as accepted, not engineered around.

### Redemption

Only a payload matching the 43-char mint shape is treated as a token — a bare `/start`, `/help`, and anything else fall through to the existing welcome text byte-for-byte.

**Already-linked accounts are refused, never transferred.** `users_telegram_user_id_key` is UNIQUE, so a second account pointing at the same Telegram id fails at the constraint and gets a plain-language reply. Reassigning would let anyone gaining control of a Telegram account inherit the GraceChords account behind it.

**Bug caught in review of the existing code:** `getLinkedUser` caches the *negative* lookup in `BOT_KV` for 5 minutes, so a successful link now purges `userlookup:<tg_id>`. Without that, the next message after linking would still get the onboarding text — broken exactly once, for every user, and never in testing.

### Mint endpoint

`POST /api/telegram/link-token` verifies the caller's Supabase JWT the same way `link.js` does, then asks the worker to mint (`BOT_KV` is bound there, not to Pages). Reuses `BOT_INTERNAL_URL` + `BOT_WEBHOOK_TOKEN`, already configured for `/api/telegram/push` — **no new secret**. `GET`/`DELETE /api/telegram/link` are untouched and still serve status and unlink.

Uses `https://t.me/...` only — a Telegram universal link, so it opens the installed app and falls back to the web client otherwise. No `tg://` probe, no `LSApplicationQueriesSchemes`, no native rebuild.

---

## Schema

**No migration.** `telegram_user_id`/`telegram_linked_at` and the UNIQUE constraint all exist — confirmed in both `20260521000000_telegram_link.sql:19` and the `20260806000000` codification. No duplicate check needed. No handle is shown; there is no username column.

## ⚠️ Deploy prerequisite

**The bot's deployed `SUPABASE_SERVICE_ROLE_KEY` must be write-capable.** `wrangler.toml` describes it as "read-only role recommended for digest queries", and worker secrets can't be read back, so this is unverified. If it's read-only, `/start <token>` fails at the write — the fix is either swapping the secret or routing the write through a Pages Function (which demonstrably has a write-capable key today).

The write is scoped in code to `telegram_user_id` and `telegram_linked_at` because service_role bypasses RLS and there's no policy backstop.

Note: `20260806000500_users_grant_hardening.sql:33` documents `link.js` as the *only* writer of those columns. This PR makes that comment stale — worth a follow-up line in that header.

## Verification

- `tsc --noEmit` — clean
- `npm run test` — 528 passing, 33 new
- `npm run i18n:check` — all locales in sync, `needsReview: true` on every non-English file, no signed-off entry touched
- `expo export --platform ios` — bundles clean
- `wrangler deploy --dry-run` — builds clean, `BOT_KV` bound

**Two pre-existing failures in `launchStorage.test.ts` are not from this branch** — it imports `getColumnMode` from `viewerPrefs`, which exports `getColumns`. Fails identically at `main`.

**Not verified — needs a device and a deploy:** rendering, light/dark, Dynamic Type, VoiceOver, the provider-detection cases, and the Telegram round trip.

### Check before merging

`hasEmailIdentity` reads `user.identities` from the **session** user (`currentUser.ts` deliberately never calls `getUser()`). If GoTrue omits `identities` from the session payload, the expression yields `[]` and Change password hides for everyone. An account with email + Google + Apple is the ideal check.

## Notes

- **Known follow-up:** `validateSignUp()` still checks length only, so signup can fail server-side against the character-class policy. Left alone deliberately; `validatePasswordStrength()` now exists, so wiring it in is two lines.
- `settings.json` keys `logOut`, `deleteAccount`, `changeYourIcon` are now unreferenced. Left in place rather than deleted across four locales. The alert strings *are* still used, from Account via the `settings:` prefix.
- `apps/web/src/content/delete-account.md` documents the mobile path as "Profile & Settings → Delete Account", now one level stale. Out of scope.
- The linked Telegram row opens a native `formSheet` with status + destructive Unlink rather than pushing a detail route, since there's no handle to display.
- The bot worker has no test harness, so the token encoding was verified by direct execution rather than a committed regression test. Happy to add vitest to that worker if you want it guarded permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
