### PR TITLE
feat(mobile): first-launch intro with reminder and streak opt-in

### DIFF
--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -222,6 +222,22 @@ duplicate logic here and never edit core internals to suit mobile.
   downloads — scaffolded, no download logic yet). `app/login.tsx` — the auth
   screen (sign in + sign up modes in `src/screens/AuthScreen.tsx`);
   `app/choose-icon.tsx` — the post-signup sprite avatar picker.
+- **First-launch intro** (`app/intro.tsx` → `src/screens/IntroScreen.tsx`): a
+  three-card pager shown once per device, post-auth. Card 1 is a centered title
+  card, card 2 lists features (each icon borrowed from the live UI that owns it),
+  and card 3 carries two **real settings** — the Daily Word reminder (with the
+  Settings screen's own `ReminderTimeSheet`) and the reading streak — both
+  presented pre-toggled ON. The seen-flag is device-local
+  (`src/lib/introSeen.ts`, `gc.intro.seen.v1`, in the splash `multiGet` batch so
+  the gate can read it synchronously); it is **not** on the Supabase profile, so a
+  returning user on a new device sees the intro again by design. `wantsIntro()` in
+  `app/_layout.tsx` scopes the redirect to the app's own entry points (bare root /
+  `(tabs)`) so an inbound deep link keeps its destination. Both exits land on
+  **Home**; "Get started" commits card 3's settings and is the **only** place
+  notification permission is requested (via `commitOnboardingReminder`, which
+  checks permission before prompting and fails silently on denial), while **Skip
+  commits nothing**. Settings → Support → "See onboarding again" clears the flag
+  to replay it.
 - **Authenticated-only.** `app/_layout.tsx` gates every route on the Supabase
   session (redirect to `/login` when signed out, into the tabs when signed in) and
   holds the native splash (`expo-splash-screen`) until the session resolves *and*
@@ -341,8 +357,12 @@ duplicate logic here and never edit core internals to suit mobile.
   (`supabase.rpc('delete_user')`). The Language row opens an `OptionSheet`
   (Automatic + the supported locales) and shows the resolved language — see the
   i18n section below.
-- **Daily Word reminder** (Settings → Reader) is an OPT-IN, off-by-default local
-  notification via **`expo-notifications`** (config plugin in `app.json`). The
+- **Daily Word reminder** (Settings → Reader) is an OPT-IN local notification via
+  **`expo-notifications`** (config plugin in `app.json`). The stored default is
+  **off at 8:00 AM** (`DEFAULT_READER_REMINDER`), but the first-launch intro's
+  card 3 presents it pre-toggled ON, so a user who taps "Get started" opts in
+  there rather than in Settings — see the first-launch intro bullet under
+  "Routing, screens & auth". The
   preference (enabled + local hour/minute) is device-local in AsyncStorage
   (`gc.readerReminder.v1`), following the `defaults.ts` injected-storage /
   `useSyncExternalStore` pattern. `src/lib/readerReminder.ts` is the **pure,
@@ -402,7 +422,10 @@ duplicate logic here and never edit core internals to suit mobile.
   and the Recent-songs card reopens the song in that key via the viewer's
   existing `initialKey` param (Library opens still use the default key).
 - **Reading streak** (`src/lib/readingStreak.ts`, same injected-storage /
-  `useSyncExternalStore` pattern): OPT-IN, off by default — the toggle lives in
+  `useSyncExternalStore` pattern): OPT-IN — the stored default is off
+  (`DEFAULT_READING_STREAK`), but like the reminder above, the first-launch
+  intro's card 3 presents it pre-toggled ON, so most new users arrive with it
+  enabled. The toggle also lives in
   **Settings → Reader** (alongside the Daily Word reminder), not the reader
   settings sheet, and `DailyWordScreen` marks a day read
   when one of TODAY's chapters renders. Home's Daily Word card shows the streak

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -22,6 +22,7 @@ import { setCurrentUserFromSession } from '../src/lib/currentUser'
 import { flushPendingSprite } from '../src/lib/profile'
 import { primeLaunchStorage } from '../src/lib/launchStorage'
 import { hydrateDefaults } from '../src/lib/defaults'
+import { hydrateIntroSeen, useIntroSeen } from '../src/lib/introSeen'
 import { hydrateBibleTranslationPref } from '../src/lib/bibleTranslationPref'
 import { prefetchToday } from '../src/lib/bibleSource'
 import { hydrateDownloads } from '../src/lib/downloads/manifest'
@@ -49,6 +50,31 @@ import SplashOverlay from '../src/components/SplashOverlay'
 // out user on first open.
 SplashScreen.preventAutoHideAsync().catch(() => {})
 
+/**
+ * Whether the first-launch intro (app/intro.tsx) should take over this route.
+ *
+ * Deliberately scoped to the app's OWN entry points — the bare root and the tab
+ * group — rather than "any route that isn't the intro". A deep link resolves to a
+ * specific screen (`viewer/[slug]`, `setlist/import`, the anonymous
+ * `session/[code]` follower), and hijacking that to show the intro would discard
+ * the destination the link was for. Leaving the flag unset instead means the
+ * intro simply shows on the next ordinary launch, which costs nothing.
+ *
+ * The `login` hand-off is NOT routed through here — it has its own branch,
+ * because it must send the user to the intro or the tabs, never leave them on
+ * /login. `choose-icon` is excluded so the post-signup avatar step is never
+ * interrupted mid-pick; its own replace('/') lands on the tab group and is
+ * caught here on the next pass.
+ */
+function wantsIntro(
+  session: Session | null,
+  seenIntro: boolean,
+  seg: string | undefined,
+): boolean {
+  if (!session || seenIntro) return false
+  return seg === undefined || seg === '(tabs)'
+}
+
 // Root layout: install the theme + safe-area providers, keep the native token
 // auto-refresh, and gate routes on the auth session using the standard
 // expo-router pattern — redirect to /login when signed out, and into the tabs
@@ -56,6 +82,10 @@ SplashScreen.preventAutoHideAsync().catch(() => {})
 function useProtectedRoute(session: Session | null, ready: boolean, beginHandoff: () => void) {
   const segments = useSegments()
   const router = useRouter()
+  // Device-local first-launch flag. Subscribed (not just read) so setting it from
+  // the intro re-runs the effects below with `seenIntro` already true — otherwise
+  // the redirect would fire again against the intro's own navigation.
+  const seenIntro = useIntroSeen()
 
   useEffect(() => {
     if (!ready) return
@@ -70,9 +100,12 @@ function useProtectedRoute(session: Session | null, ready: boolean, beginHandoff
     if (!session && !inAuthFlow && !isPublic) {
       router.replace('/login')
     } else if (session && seg === 'login') {
-      router.replace('/')
+      // The intro is post-auth: a first launch lands there instead of the tabs.
+      router.replace(seenIntro ? '/' : '/intro')
+    } else if (wantsIntro(session, seenIntro, seg)) {
+      router.replace('/intro')
     }
-  }, [session, ready, segments, router])
+  }, [session, ready, segments, router, seenIntro])
 
   // Lift the splash only once the session is resolved AND the visible route
   // matches the auth state, so the native splash covers the redirect frame and
@@ -87,9 +120,15 @@ function useProtectedRoute(session: Session | null, ready: boolean, beginHandoff
     const seg = segments[0] as string | undefined
     const inAuthFlow = seg === 'login' || seg === 'choose-icon'
     const isPublic = seg === 'session'
-    const settled = session ? seg !== 'login' : (inAuthFlow || isPublic)
+    // A signed-in first launch is not settled while the gate above still wants
+    // to replace this route with the intro — lifting the splash first would
+    // flash the tab group for a frame. Once /intro is mounted wantsIntro is
+    // false, so this settles normally.
+    const settled = session
+      ? seg !== 'login' && !wantsIntro(session, seenIntro, seg)
+      : (inAuthFlow || isPublic)
     if (settled) beginHandoff()
-  }, [session, ready, segments, beginHandoff])
+  }, [session, ready, segments, beginHandoff, seenIntro])
 
   // Safety net: if routing never "settles" for some reason, don't leave the
   // splash up indefinitely once the session has resolved. Note this can only arm
@@ -212,7 +251,7 @@ export default function RootLayout() {
     // session read were nested behind it the two would serialise and cold launch
     // would regress — the whole point of batching is to be no slower.
     const sessionRead = resolveInitialSession(supabase.auth)
-    // One AsyncStorage round trip for all 13 launch keys instead of 13 separate
+    // One AsyncStorage round trip for all 14 launch keys instead of 14 separate
     // getItem calls. The stores themselves are untouched: they receive a
     // KVStorage that answers from the batch, so every missing/null/malformed
     // fallback is byte-for-byte what it was. See launchStorage.ts.
@@ -231,6 +270,9 @@ export default function RootLayout() {
         // ordered against sessionRead: the stored entry names its own owner and
         // is only found by a lookup for that same user (reflectionDayStore.ts).
         hydrateTodayReflection(store),
+        // Must resolve before `ready` — the auth gate reads it synchronously to
+        // decide between /intro and the tabs while the splash is still up.
+        hydrateIntroSeen(store),
       ]),
     )
     Promise.all([
@@ -370,6 +412,7 @@ export default function RootLayout() {
             <Stack.Screen name="(tabs)" />
             <Stack.Screen name="login" />
             <Stack.Screen name="choose-icon" />
+            <Stack.Screen name="intro" />
             <Stack.Screen name="viewer/[slug]" />
             <Stack.Screen name="daily/reader" />
             <Stack.Screen name="daily/journal" />

--- a/apps/mobile/app/intro.tsx
+++ b/apps/mobile/app/intro.tsx
@@ -1,0 +1,16 @@
+import { Stack } from 'expo-router'
+import IntroScreen from '../src/screens/IntroScreen'
+
+// First-launch intro. A root-Stack sibling of (tabs) — full screen, no tab bar —
+// reached from the auth gate in app/_layout.tsx once a session exists and the
+// device-local seen-flag (src/lib/introSeen.ts) is unset. IntroScreen owns its
+// own safe-area padding, so there is no Screen wrapper here.
+
+export default function Intro() {
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false, gestureEnabled: false }} />
+      <IntroScreen />
+    </>
+  )
+}

--- a/apps/mobile/src/components/__tests__/symbolMap.test.ts
+++ b/apps/mobile/src/components/__tests__/symbolMap.test.ts
@@ -45,6 +45,23 @@ describe('symbolMap', () => {
     expect(collisions).toEqual([])
   })
 
+  it('maps the first-launch intro icons', () => {
+    // IntroScreen's card-2 feature rows each borrow the icon from the live UI
+    // that owns the feature, so all three are already mapped — this pins that.
+    // An unmapped name is invisible on iOS (SF Symbols renders it natively) and
+    // silently wrong on Android, which is exactly what this file guards.
+    for (const sf of [
+      'chevron.up.chevron.down', // transpose — Setlist Builder key chip
+      'antenna.radiowaves.left.and.right', // Live Sessions — Performer header
+      'square.and.arrow.up', // share — Song Viewer export button
+      'arrow.triangle.2.circlepath', // Settings → "See onboarding again"
+    ]) {
+      const glyph = SF_TO_MATERIAL[sf]
+      expect(glyph, `${sf} has no SF→Material mapping`).toBeDefined()
+      expect(MATERIAL_CODEPOINTS[glyph.md], `${glyph.md} is not bundled`).toBeDefined()
+    }
+  })
+
   it('maps the reader text-options icon used by the Daily Word control bar', () => {
     // DailyWordScreen renders <SymbolIcon name="textformat" /> for the reader
     // settings sheet; Android needs text_format present to avoid the fallback.

--- a/apps/mobile/src/i18n/locales/en/intro.json
+++ b/apps/mobile/src/i18n/locales/en/intro.json
@@ -1,0 +1,33 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "" },
+  "card1": {
+    "heading": "Welcome to GraceChords.",
+    "body": "Songs, setlists, and Scripture — whatever worship looks like for you today."
+  },
+  "card2": {
+    "heading": "Ready for the platform.",
+    "body": "Transpose to any key and read it clean under stage lights. Start a Live Session to keep the whole team on the same song, or share a chord sheet as a PDF or image in the key you're playing.",
+    "features": {
+      "transpose": "Transpose",
+      "liveSessions": "Live Sessions",
+      "share": "Share as PDF or image"
+    }
+  },
+  "card3": {
+    "heading": "Meditate on the Word.",
+    "body": "The M'Cheyne reading plan walks you through the whole Bible in a year, four passages a day. Download your favorite translation for offline use.",
+    "reminder": "Daily reminder",
+    "streak": "Track my streak"
+  },
+  "continue": "Continue",
+  "getStarted": "Get started",
+  "skip": "Skip",
+  "replay": {
+    "row": "See onboarding again",
+    "subtitle": "Replay the first-launch intro"
+  },
+  "a11y": {
+    "progress": "Step {{current}} of {{total}}",
+    "reminderTime": "Reminder time"
+  }
+}

--- a/apps/mobile/src/i18n/locales/es/intro.json
+++ b/apps/mobile/src/i18n/locales/es/intro.json
@@ -1,0 +1,33 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
+  "card1": {
+    "heading": "Bienvenido a GraceChords.",
+    "body": "Canciones, repertorios y las Escrituras — sea como sea tu adoración hoy."
+  },
+  "card2": {
+    "heading": "Listo para la plataforma.",
+    "body": "Transpón a cualquier tono y léelo con claridad bajo las luces del escenario. Inicia una sesión en vivo para que todo el equipo siga la misma canción, o comparte la hoja de acordes en PDF o imagen en el tono que estás tocando.",
+    "features": {
+      "transpose": "Transponer",
+      "liveSessions": "Sesiones en vivo",
+      "share": "Compartir en PDF o imagen"
+    }
+  },
+  "card3": {
+    "heading": "Medita en la Palabra.",
+    "body": "El plan de lectura M'Cheyne te lleva por toda la Biblia en un año, cuatro pasajes al día. Descarga tu traducción favorita para leerla sin conexión.",
+    "reminder": "Recordatorio diario",
+    "streak": "Seguir mi racha"
+  },
+  "continue": "Continuar",
+  "getStarted": "Empezar",
+  "skip": "Omitir",
+  "replay": {
+    "row": "Ver la introducción otra vez",
+    "subtitle": "Vuelve a mostrar la introducción de inicio"
+  },
+  "a11y": {
+    "progress": "Paso {{current}} de {{total}}",
+    "reminderTime": "Hora del recordatorio"
+  }
+}

--- a/apps/mobile/src/i18n/locales/ko/intro.json
+++ b/apps/mobile/src/i18n/locales/ko/intro.json
@@ -1,0 +1,33 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
+  "card1": {
+    "heading": "GraceChords에 오신 것을 환영합니다.",
+    "body": "찬양, 셋리스트, 그리고 말씀 — 오늘 예배가 어떤 모습이든."
+  },
+  "card2": {
+    "heading": "무대에 오를 준비 완료.",
+    "body": "어떤 키로든 조를 옮기고, 무대 조명 아래에서도 선명하게 읽을 수 있습니다. 라이브 세션을 시작해 팀 전체가 같은 곡을 보게 하거나, 연주하는 키 그대로 코드 악보를 PDF나 이미지로 공유하세요.",
+    "features": {
+      "transpose": "조 옮김",
+      "liveSessions": "라이브 세션",
+      "share": "PDF·이미지로 공유"
+    }
+  },
+  "card3": {
+    "heading": "말씀을 묵상하세요.",
+    "body": "맥체인 읽기 계획은 하루 네 본문으로 일 년에 성경 전체를 읽도록 이끌어 줍니다. 좋아하는 번역본을 다운로드하면 연결 없이도 읽을 수 있습니다.",
+    "reminder": "매일 알림",
+    "streak": "연속 기록 추적"
+  },
+  "continue": "계속",
+  "getStarted": "시작하기",
+  "skip": "건너뛰기",
+  "replay": {
+    "row": "온보딩 다시 보기",
+    "subtitle": "첫 실행 소개를 다시 재생합니다"
+  },
+  "a11y": {
+    "progress": "{{total}}단계 중 {{current}}단계",
+    "reminderTime": "알림 시간"
+  }
+}

--- a/apps/mobile/src/i18n/locales/tr/intro.json
+++ b/apps/mobile/src/i18n/locales/tr/intro.json
@@ -1,0 +1,33 @@
+{
+  "_meta": { "reviewer": "", "reviewedAt": "", "needsReview": true },
+  "card1": {
+    "heading": "GraceChords'a hoş geldiniz.",
+    "body": "İlahiler, set listeleri ve Kutsal Yazılar — bugün tapınma sizin için nasıl görünüyorsa."
+  },
+  "card2": {
+    "heading": "Sahneye hazır.",
+    "body": "İstediğiniz tona geçin ve sahne ışıkları altında rahatça okuyun. Tüm ekibin aynı ilahide kalması için canlı oturum başlatın ya da akor sayfasını çaldığınız tonda PDF veya görsel olarak paylaşın.",
+    "features": {
+      "transpose": "Ton değiştir",
+      "liveSessions": "Canlı oturumlar",
+      "share": "PDF veya görsel olarak paylaş"
+    }
+  },
+  "card3": {
+    "heading": "Söz üzerinde derin düşünün.",
+    "body": "M'Cheyne okuma planı, günde dört bölümle bir yılda Kutsal Kitap'ın tamamını okumanızı sağlar. Sevdiğiniz çeviriyi indirin, bağlantı olmadan da okuyun.",
+    "reminder": "Günlük hatırlatma",
+    "streak": "Serimi takip et"
+  },
+  "continue": "Devam et",
+  "getStarted": "Başla",
+  "skip": "Atla",
+  "replay": {
+    "row": "Tanıtımı yeniden gör",
+    "subtitle": "İlk açılış tanıtımını yeniden oynatır"
+  },
+  "a11y": {
+    "progress": "Adım {{current}} / {{total}}",
+    "reminderTime": "Hatırlatma saati"
+  }
+}

--- a/apps/mobile/src/lib/__tests__/introSeen.test.ts
+++ b/apps/mobile/src/lib/__tests__/introSeen.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasSeenIntro,
+  hydrateIntroSeen,
+  markIntroSeen,
+  type KVStorage,
+} from '../introSeen'
+
+function memoryStorage(initial: Record<string, string> = {}): KVStorage & { store: Map<string, string> } {
+  const store = new Map(Object.entries(initial))
+  return {
+    store,
+    getItem: async (k) => store.get(k) ?? null,
+    setItem: async (k, v) => void store.set(k, v),
+    removeItem: async (k) => void store.delete(k),
+  }
+}
+
+const KEY = 'gc.intro.seen.v1'
+
+describe('intro seen store', () => {
+  it('is false on a fresh install', async () => {
+    await hydrateIntroSeen(memoryStorage())
+    expect(hasSeenIntro()).toBe(false)
+  })
+
+  it('marks seen synchronously and writes through', async () => {
+    const s = memoryStorage()
+    await hydrateIntroSeen(s)
+    markIntroSeen()
+    // Synchronous: the auth gate reads this in the same tick the intro navigates.
+    expect(hasSeenIntro()).toBe(true)
+    expect(s.store.get(KEY)).toBe('1')
+  })
+
+  it('stays seen across a relaunch', async () => {
+    const s = memoryStorage()
+    await hydrateIntroSeen(s)
+    markIntroSeen()
+
+    // A different (empty) device reads false again — the flag is per-device.
+    await hydrateIntroSeen(memoryStorage())
+    expect(hasSeenIntro()).toBe(false)
+
+    // The original device still has it.
+    await hydrateIntroSeen(s)
+    expect(hasSeenIntro()).toBe(true)
+  })
+
+  it('hydrates true only from the exact stored value', async () => {
+    await hydrateIntroSeen(memoryStorage({ [KEY]: '1' }))
+    expect(hasSeenIntro()).toBe(true)
+
+    // Anything else means "not seen" — show the intro rather than swallow it.
+    for (const raw of ['0', '', 'true', 'yes']) {
+      await hydrateIntroSeen(memoryStorage({ [KEY]: raw }))
+      expect(hasSeenIntro(), `stored ${JSON.stringify(raw)}`).toBe(false)
+    }
+  })
+
+  it('falls back to not-seen when the read throws', async () => {
+    await hydrateIntroSeen(memoryStorage({ [KEY]: '1' }))
+    expect(hasSeenIntro()).toBe(true)
+
+    const broken: KVStorage = {
+      getItem: async () => {
+        throw new Error('storage unavailable')
+      },
+      setItem: async () => {},
+      removeItem: async () => {},
+    }
+    await hydrateIntroSeen(broken)
+    expect(hasSeenIntro()).toBe(false)
+  })
+
+  it('is idempotent — a second mark does not write again', async () => {
+    const s = memoryStorage()
+    await hydrateIntroSeen(s)
+    markIntroSeen()
+    expect(s.store.get(KEY)).toBe('1')
+
+    // Both CTAs can fire mark+navigate; the repeat must be a no-op so it can't
+    // re-emit and re-render the gate mid-navigation.
+    s.store.delete(KEY)
+    markIntroSeen()
+    expect(s.store.has(KEY)).toBe(false)
+    expect(hasSeenIntro()).toBe(true)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/launchStorage.test.ts
+++ b/apps/mobile/src/lib/__tests__/launchStorage.test.ts
@@ -13,7 +13,7 @@ import {
   reflectionCacheKey,
 } from '../reflectionDayStore'
 
-// The whole point of the facade is that the nine hydrate modules are unchanged,
+// The whole point of the facade is that the ten hydrate modules are unchanged,
 // so these tests assert the OUTCOME each module produces when fed through a
 // batch — not the facade in isolation. A silent change to any fallback here
 // would reset a real user's preference on upgrade.
@@ -45,9 +45,9 @@ function makeStore(seed: Record<string, string> = {}) {
 }
 
 describe('LAUNCH_STORAGE_KEYS', () => {
-  it('covers the 13 keys the splash gate reads', () => {
-    expect(LAUNCH_STORAGE_KEYS).toHaveLength(13)
-    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(13)
+  it('covers the 14 keys the splash gate reads', () => {
+    expect(LAUNCH_STORAGE_KEYS).toHaveLength(14)
+    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(14)
   })
 })
 
@@ -69,7 +69,7 @@ describe('primeLaunchStorage', () => {
 
   it('falls back to the real store when multiGet rejects', async () => {
     // Today each module does its own getItem behind its own try/catch, so one
-    // failing read can only affect one module. A batch that reset all 13
+    // failing read can only affect one module. A batch that reset all 14
     // keys to defaults at once would be a far worse failure.
     const { store } = makeStore({ 'gc.defaults.theme': 'dark' })
     store.multiGet = () => Promise.reject(new Error('storage unavailable'))

--- a/apps/mobile/src/lib/__tests__/readerReminder.test.ts
+++ b/apps/mobile/src/lib/__tests__/readerReminder.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   __resetReaderReminderForTest,
+  commitReminderOptIn,
   DEFAULT_READER_REMINDER,
   formatReminderTime,
   getReaderReminder,
@@ -117,5 +118,67 @@ describe('syncReminder', () => {
     await syncReminder({ enabled: true, hour: 7, minute: 15 }, CONTENT, backend)
     expect(backend.cancel).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID)
     expect(backend.scheduleDaily).not.toHaveBeenCalled()
+  })
+})
+
+// The first-launch intro's card 3 (app/intro.tsx). Its contract differs from the
+// Settings toggle in two ways that matter enough to pin: permission is checked
+// before prompting, and a denial is silent + leaves the preference off.
+describe('commitReminderOptIn (onboarding card 3)', () => {
+  beforeEach(() => __resetReaderReminderForTest())
+
+  it('does NOT re-request when permission is already granted', async () => {
+    const backend = fakeBackend(true)
+    const ok = await commitReminderOptIn(7, 30, CONTENT, backend)
+    expect(ok).toBe(true)
+    expect(backend.getPermissionGranted).toHaveBeenCalled()
+    expect(backend.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('prompts only when permission is not already held', async () => {
+    const backend = fakeBackend(true)
+    backend.getPermissionGranted.mockResolvedValueOnce(false)
+    const ok = await commitReminderOptIn(7, 30, CONTENT, backend)
+    expect(ok).toBe(true)
+    expect(backend.requestPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('actually SCHEDULES on grant — not just persists the preference', async () => {
+    const backend = fakeBackend(true)
+    await commitReminderOptIn(6, 45, CONTENT, backend)
+    // The whole point: the OS has the notification, not just AsyncStorage.
+    expect(backend.scheduleDaily).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID, 6, 45, CONTENT)
+    expect(getReaderReminder()).toEqual({ enabled: true, hour: 6, minute: 45 })
+  })
+
+  it('persists the chosen time, not the default', async () => {
+    const backend = fakeBackend(true)
+    await commitReminderOptIn(21, 5, CONTENT, backend)
+    expect(getReaderReminder().hour).toBe(21)
+    expect(getReaderReminder().minute).toBe(5)
+    expect(DEFAULT_READER_REMINDER.hour).toBe(8) // guards the 8:00 AM default itself
+  })
+
+  it('on denial: leaves the reminder OFF, schedules nothing, reports false', async () => {
+    const backend = fakeBackend(false)
+    const ok = await commitReminderOptIn(7, 30, CONTENT, backend)
+    expect(ok).toBe(false)
+    expect(getReaderReminder().enabled).toBe(false)
+    expect(backend.scheduleDaily).not.toHaveBeenCalled()
+  })
+
+  it('on denial: requests permission exactly once (no retry)', async () => {
+    const backend = fakeBackend(false)
+    await commitReminderOptIn(7, 30, CONTENT, backend)
+    expect(backend.requestPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('works from a cold store with no prior reminder state', async () => {
+    // No hydrate call at all — the module cache is the untouched default. This is
+    // the fresh-install case the intro always runs in.
+    expect(getReaderReminder()).toEqual(DEFAULT_READER_REMINDER)
+    const backend = fakeBackend(true)
+    await expect(commitReminderOptIn(8, 0, CONTENT, backend)).resolves.toBe(true)
+    expect(backend.scheduleDaily).toHaveBeenCalledWith(REMINDER_NOTIFICATION_ID, 8, 0, CONTENT)
   })
 })

--- a/apps/mobile/src/lib/introSeen.ts
+++ b/apps/mobile/src/lib/introSeen.ts
@@ -1,0 +1,92 @@
+import { useSyncExternalStore } from 'react'
+
+// Whether this device has already been shown the first-launch intro (the 3-card
+// pager at app/intro.tsx). PER-DEVICE UI state, deliberately NOT on the Supabase
+// profile: it says nothing about the account, and syncing it would mean a schema
+// change for a flag whose whole job is "has this install been introduced yet".
+// A returning user on a new device seeing the intro again is intended.
+//
+// Follows the same injected-KVStorage / hydrate-once / useSyncExternalStore
+// pattern as src/lib/defaults.ts, so this module is RN-free and unit-testable
+// headless. The read MUST be synchronous by the time the auth gate runs — the
+// gate in app/_layout.tsx decides between the intro and the tabs while the
+// native splash is still up, and an async read there would paint Home for a
+// frame first. That is why the key joins LAUNCH_STORAGE_KEYS' single multiGet
+// rather than doing its own getItem.
+
+export type KVStorage = {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+const STORAGE_KEY = 'gc.intro.seen.v1'
+
+// '1' is the only truthy value, matching gc.defaults.keepAwake. Anything else
+// (absent, '0', garbage) means "not seen" — the safe direction to fail, since a
+// spurious extra intro is recoverable and a silently skipped one is not.
+const SEEN_VALUE = '1'
+
+let cache = false
+let storage: KVStorage | null = null
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+/** Load the stored flag into the cache (false when unset). */
+export async function hydrateIntroSeen(store: KVStorage): Promise<boolean> {
+  storage = store
+  let value = false
+  try {
+    value = (await store.getItem(STORAGE_KEY)) === SEEN_VALUE
+  } catch {
+    // Best-effort — a bad read must never crash the app. Falling back to false
+    // shows the intro once more rather than swallowing it.
+  }
+  cache = value
+  emit()
+  return cache
+}
+
+/** Synchronous read — safe before hydrate (returns false). */
+export function hasSeenIntro(): boolean {
+  return cache
+}
+
+/**
+ * Record that the intro has been shown. Called on BOTH completion and skip —
+ * they are the same outcome, the user has seen it. Updates the cache
+ * synchronously (so the auth gate re-evaluates before the navigation lands and
+ * can't bounce back to the intro) and writes through best-effort.
+ */
+export function markIntroSeen(): void {
+  if (cache) return
+  cache = true
+  emit()
+  storage?.setItem(STORAGE_KEY, SEEN_VALUE).catch(() => {})
+}
+
+/**
+ * Clear the flag so the intro shows again. Backs the Settings → "See onboarding
+ * again" row, which exists so the intro can be re-checked without reinstalling.
+ * Finishing or skipping the replayed intro sets the flag again, so this is not a
+ * persistent "always show" mode.
+ */
+export function resetIntroSeen(): void {
+  if (!cache) return
+  cache = false
+  emit()
+  storage?.removeItem(STORAGE_KEY).catch(() => {})
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** Subscribing hook — re-renders the auth gate when the flag is set. */
+export function useIntroSeen(): boolean {
+  return useSyncExternalStore(subscribe, hasSeenIntro, hasSeenIntro)
+}

--- a/apps/mobile/src/lib/launchStorage.ts
+++ b/apps/mobile/src/lib/launchStorage.ts
@@ -1,8 +1,8 @@
 // One AsyncStorage round trip for the whole splash gate.
 //
-// The launch path hydrates nine device-local stores before first paint, and
-// between them they read 13 keys with 13 separate getItem calls (five in
-// defaults.ts alone). This module reads all 13 in a single multiGet and hands
+// The launch path hydrates ten device-local stores before first paint, and
+// between them they read 14 keys with 14 separate getItem calls (five in
+// defaults.ts alone). This module reads all 14 in a single multiGet and hands
 // back a KVStorage-shaped facade served from the result.
 //
 // The point of the facade — rather than teaching each store to accept a
@@ -50,20 +50,21 @@ export const LAUNCH_STORAGE_KEYS = [
   'gc.viewer.columnMode.v1', // viewerPrefs.ts       → EMPTY (default 'single')
   'gc.bible.translation.v1', // bibleTranslationPref.ts → '' (no prior choice)
   'gc.reflection.today.v1', // reflectionDayStore.ts   → null (nothing cached)
+  'gc.intro.seen.v1', // introSeen.ts            → false ('1' is the only true)
 ] as const
 
 /**
  * Read `keys` in one batch and return a KVStorage that serves those reads from
  * memory.
  *
- * Behaviour that is deliberately identical to 13 separate getItem calls:
+ * Behaviour that is deliberately identical to 14 separate getItem calls:
  *
  * - A key absent from storage yields null, which is what every store's
  *   missing-value branch already handles. multiGet reports an absent key as
  *   [key, null], and a pair missing from the response falls to null too.
  * - A REJECTING multiGet returns the raw store untouched, so each module does
  *   its own getItem behind its own try/catch just as it does today. Without
- *   this, one failed batch would reset all 13 keys to defaults at once — a far
+ *   this, one failed batch would reset all 14 keys to defaults at once — a far
  *   worse failure than the per-module degradation we have now.
  *
  * The facade is a correct KVStorage for the app's whole lifetime, not just for

--- a/apps/mobile/src/lib/readerReminder.ts
+++ b/apps/mobile/src/lib/readerReminder.ts
@@ -173,6 +173,45 @@ export async function syncReminder(
   await backend.scheduleDaily(REMINDER_NOTIFICATION_ID, pref.hour, pref.minute, content)
 }
 
+/**
+ * Commit the first-launch intro's reminder opt-in (app/intro.tsx card 3).
+ *
+ * Pure + injected like `syncReminder` above, so the decision logic is unit-tested
+ * headless; readerReminderService.ts wraps it with the real expo-notifications
+ * backend. Differs from the Settings toggle path in exactly two ways, both
+ * required by onboarding:
+ *
+ *  1. Permission is CHECKED before prompting, so a user who already granted
+ *     notifications is never asked twice. (Settings prompts on every toggle-on,
+ *     which is right there — the toggle IS the request — but wrong here, where
+ *     the request is deferred to "Get started".)
+ *  2. Denial FAILS SILENTLY and pins the preference off, so app state matches OS
+ *     state. Settings instead alerts and offers to open system settings;
+ *     onboarding must not interrupt with an error the user can't act on.
+ *
+ * Returns whether the reminder ended up scheduled. Callers ignore `false` — the
+ * intro proceeds either way.
+ */
+export async function commitReminderOptIn(
+  hour: number,
+  minute: number,
+  content: ReminderContent,
+  backend: NotificationBackend,
+): Promise<boolean> {
+  let granted = await backend.getPermissionGranted()
+  if (!granted) granted = await backend.requestPermission()
+  if (!granted) {
+    // No-op when already false (the default), so a denial writes nothing.
+    setReminderEnabled(false)
+    return false
+  }
+  setReminderTime(hour, minute)
+  setReminderEnabled(true)
+  // Not just the preference — this is what puts it on the OS schedule.
+  await syncReminder(cache, content, backend)
+  return true
+}
+
 /** Test-only reset so each test starts from a clean module state. */
 export function __resetReaderReminderForTest(): void {
   cache = DEFAULT_READER_REMINDER

--- a/apps/mobile/src/lib/readerReminderService.ts
+++ b/apps/mobile/src/lib/readerReminderService.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native'
 import * as Notifications from 'expo-notifications'
 import i18n from '../i18n'
 import {
+  commitReminderOptIn,
   getReaderReminder,
   REMINDER_NOTIFICATION_ID,
   setReminderEnabled,
@@ -129,6 +130,15 @@ export async function enableReaderReminder(hour: number, minute: number): Promis
   setReminderEnabled(true)
   await syncReminder(getReaderReminder(), reminderContent(), backend)
   return true
+}
+
+/**
+ * Commit the first-launch intro's reminder opt-in (app/intro.tsx card 3) against
+ * the real notification backend. All the logic — and the reasoning for why it
+ * differs from the Settings toggle path — lives in `commitReminderOptIn`.
+ */
+export function commitOnboardingReminder(hour: number, minute: number): Promise<boolean> {
+  return commitReminderOptIn(hour, minute, reminderContent(), backend)
 }
 
 /** Turn the reminder off and cancel the scheduled notification. */

--- a/apps/mobile/src/screens/IntroScreen.tsx
+++ b/apps/mobile/src/screens/IntroScreen.tsx
@@ -1,0 +1,446 @@
+import { useRef, useState } from 'react'
+import {
+  Pressable,
+  ScrollView,
+  Switch,
+  Text,
+  View,
+  useWindowDimensions,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native'
+import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTranslation } from 'react-i18next'
+import SymbolIcon, { type SymbolIconProps } from '../components/SymbolIcon'
+import SettingsCard from '../components/Card'
+import ListRow from '../components/ListRow'
+import ReminderTimeSheet from '../components/reader/ReminderTimeSheet'
+import { useTheme } from '../theme/ThemeProvider'
+import { useAccessibilityFlags } from '../lib/accessibilityFlags'
+import { markIntroSeen } from '../lib/introSeen'
+import { formatReminderTime, getReaderReminder } from '../lib/readerReminder'
+import { commitOnboardingReminder } from '../lib/readerReminderService'
+import { setStreakEnabled } from '../lib/readingStreak'
+import type { Tokens } from '@gracechords/tokens/native'
+
+// First-launch intro: three cards, shown once per device after the user has a
+// session (see the gate in app/_layout.tsx). Card 1 is a title card, card 2 is
+// informational, and card 3 carries two REAL settings (Daily Word reminder +
+// reading streak). It frames what the app does and lands the user on Home.
+//
+// Finishing and skipping both set the device-local seen-flag and replace to '/'.
+// `replace`, not `push`, so the intro leaves the back stack and a back gesture
+// can't return to it. They differ in ONE respect: "Get started" commits card 3's
+// two settings (and is the only place notification permission is ever
+// requested); Skip commits nothing and leaves both at their stored defaults.
+//
+// Phone layout only, per the brief — no tablet branch and no ConstrainedContent.
+//
+// The pager is a plain paging ScrollView rather than Reanimated: the interaction
+// is a discrete page snap with no finger-tracked affordances, so the reader's
+// ChapterSwipe machinery would be all cost and no benefit.
+
+/** Card 2's feature rows. Every icon is taken from the live UI that owns it. */
+const FEATURES: { key: string; icon: SymbolIconProps['name'] }[] = [
+  // The Setlist Builder's "change key" chip (SetlistTimeline) — and the compound
+  // of the TransposeBar's own chevron.up / chevron.down.
+  { key: 'transpose', icon: 'chevron.up.chevron.down' },
+  // The Performer header's live-session button.
+  { key: 'liveSessions', icon: 'antenna.radiowaves.left.and.right' },
+  // The Song Viewer's export/share button.
+  { key: 'share', icon: 'square.and.arrow.up' },
+]
+
+const CARD_COUNT = 3
+
+/**
+ * Card 3's leading icon chip. A local copy of SettingsScreen's `RowIcon` — that
+ * one is defined inside SettingsScreen.tsx and not exported, and extracting it
+ * would mean editing that screen. Geometry is kept identical (29 / radius 7 /
+ * accentSoft / 16px glyph) so the onboarding rows and the Settings rows they
+ * mirror are indistinguishable.
+ */
+function RowIcon({ name, t }: { name: SymbolIconProps['name']; t: Tokens }) {
+  return (
+    <View
+      style={{
+        width: 29,
+        height: 29,
+        borderRadius: 7,
+        backgroundColor: t.colors.accentSoft,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <SymbolIcon name={name} size={16} color={t.colors.accent} />
+    </View>
+  )
+}
+
+/** Rounded leading icon chip, mirroring the Settings/Utilities grouped-row look. */
+function FeatureRow({ icon, label, t }: { icon: SymbolIconProps['name']; label: string; t: Tokens }) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: t.spacing.md }}>
+      <View
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: t.radii.sm,
+          backgroundColor: t.colors.accentSoft,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <SymbolIcon name={icon} size={19} color={t.colors.accent} />
+      </View>
+      <Text
+        style={{
+          flex: 1,
+          fontSize: t.typography.rowTitle.fontSize,
+          fontWeight: t.typography.rowTitle.fontWeight,
+          letterSpacing: t.typography.rowTitle.letterSpacing,
+          color: t.colors.ink,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  )
+}
+
+// Intro-local type sizes. `tokens.typography` tops out at largeTitle (27) and
+// carries no display step above it, so — like the rest of the app's
+// screen-specific type (ListRow 17/13.5, SpritePickerScreen 16.5/14.5) — these
+// are local literals rather than a new token. TITLE is one step up from BODY_*
+// so card 1 outweighs the informational cards without a scale entry.
+const HEADING_SIZE = 30
+const HEADING_LINE = 38
+const TITLE_HEADING_SIZE = 34
+const TITLE_HEADING_LINE = 42
+
+function Card({
+  width,
+  topInset,
+  heading,
+  body,
+  t,
+  variant = 'info',
+  children,
+}: {
+  width: number
+  /**
+   * Distance from the top of the pager to the heading. A FIXED offset rather
+   * than `justifyContent: 'center'` on purpose: card 2 carries three extra
+   * feature rows, and centering would park its heading noticeably higher than
+   * cards 1 and 3, so the title would visibly jump as you page. Anchoring the
+   * top keeps the heading still and lets the extra content grow downward.
+   *
+   * The 'title' variant opts out of this — see `variant`.
+   */
+  topInset: number
+  heading: string
+  body: string
+  t: Tokens
+  /**
+   * 'info' (the default) is the left-aligned, top-anchored informational card —
+   * cards 2 and 3. 'title' is card 1 only: centered as a block with a larger
+   * heading, so the opener reads as a title page rather than a third bullet.
+   * Defaulted so the informational call sites stay untouched.
+   */
+  variant?: 'info' | 'title'
+  children?: React.ReactNode
+}) {
+  const isTitle = variant === 'title'
+  return (
+    <View
+      style={{
+        width,
+        flex: 1,
+        // Title card centers as a block; informational cards keep the shared
+        // top anchor that holds their headings still across page changes.
+        ...(isTitle
+          ? { justifyContent: 'center', alignItems: 'center' }
+          : { paddingTop: topInset }),
+        paddingHorizontal: t.spacing.xl,
+        gap: t.spacing.lg,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: isTitle ? TITLE_HEADING_SIZE : HEADING_SIZE,
+          fontWeight: '700',
+          letterSpacing: -0.5,
+          lineHeight: isTitle ? TITLE_HEADING_LINE : HEADING_LINE,
+          color: t.colors.ink,
+          ...(isTitle ? { textAlign: 'center' as const } : null),
+        }}
+      >
+        {heading}
+      </Text>
+      <Text
+        style={{
+          fontSize: 17,
+          lineHeight: 25,
+          color: t.colors.sec,
+          ...(isTitle ? { textAlign: 'center' as const } : null),
+        }}
+      >
+        {body}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+export default function IntroScreen() {
+  const t = useTheme()
+  const router = useRouter()
+  const { t: tx, i18n } = useTranslation('intro')
+  const insets = useSafeAreaInsets()
+  const { width, height } = useWindowDimensions()
+  const { reduceMotion } = useAccessibilityFlags()
+  const scroller = useRef<ScrollView>(null)
+  const [page, setPage] = useState(0)
+
+  const isLast = page === CARD_COUNT - 1
+  // Heading sits in the upper third — high enough that cards 1 and 3 don't read
+  // as empty, low enough that card 2's three feature rows still fit above the
+  // CTA on the shortest supported phone.
+  const topInset = Math.round(height * 0.16)
+
+  // Card 3's two settings, held LOCALLY until "Get started". Both default on.
+  // Seeded from the app's real stored defaults (8:00 AM — DEFAULT_READER_REMINDER),
+  // never from a literal, so onboarding and Settings can't drift.
+  const storedReminder = getReaderReminder()
+  const [reminderOn, setReminderOn] = useState(true)
+  const [streakOn, setStreakOn] = useState(true)
+  const [time, setTime] = useState({ hour: storedReminder.hour, minute: storedReminder.minute })
+  const [timeSheetOpen, setTimeSheetOpen] = useState(false)
+  // Guards the CTA while the permission prompt is up, so it can't be double-tapped
+  // into two commits / two navigations.
+  const [committing, setCommitting] = useState(false)
+
+  // Leaves the intro. `markIntroSeen` updates its cache synchronously, so the
+  // auth gate re-evaluates to "seen" before this navigation lands and can't
+  // bounce back here. Lands on HOME.
+  const leave = () => {
+    markIntroSeen()
+    router.replace('/')
+  }
+
+  // "Get started" — the ONLY place card 3's choices are persisted, and the only
+  // place notification permission is ever requested.
+  const finish = async () => {
+    if (committing) return
+    setCommitting(true)
+    try {
+      // Streak is independent of notifications: no permission, no prompt.
+      // Off needs no write — false is already the stored default.
+      if (streakOn) setStreakEnabled(true)
+      if (reminderOn) {
+        // Checks permission before prompting, persists + actually schedules on
+        // grant, and on denial pins the preference off and returns false. A
+        // denial is deliberately silent — we ignore the result and move on.
+        await commitOnboardingReminder(time.hour, time.minute)
+      }
+    } catch {
+      // Onboarding must never dead-end on a preference write.
+    } finally {
+      leave()
+    }
+  }
+
+  // Skip persists nothing but the seen-flag: no permission request, and
+  // reminder/streak stay at their stored defaults regardless of the toggles.
+  const skip = () => {
+    if (committing) return
+    leave()
+  }
+
+  const advance = () => {
+    if (isLast) {
+      void finish()
+      return
+    }
+    const next = page + 1
+    setPage(next)
+    scroller.current?.scrollTo({ x: next * width, animated: !reduceMotion })
+  }
+
+  // Round rather than floor so a page is considered changed at the halfway
+  // point; momentum-end alone can settle a pixel or two short of the boundary.
+  const onScrollEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const next = Math.round(e.nativeEvent.contentOffset.x / Math.max(1, width))
+    if (next !== page) setPage(Math.min(Math.max(next, 0), CARD_COUNT - 1))
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: t.colors.bg }}>
+      {/* Top bar: progress dots left, Skip right. Skip is available on every
+          card and behaves exactly like finishing. */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingTop: insets.top + t.spacing.sm,
+          paddingHorizontal: t.spacing.xl,
+          paddingBottom: t.spacing.sm,
+        }}
+      >
+        <View
+          style={{ flexDirection: 'row', gap: 7, alignItems: 'center' }}
+          accessibilityRole="progressbar"
+          accessibilityLabel={tx('a11y.progress', { current: page + 1, total: CARD_COUNT })}
+        >
+          {Array.from({ length: CARD_COUNT }, (_, i) => (
+            <View
+              key={i}
+              style={{
+                width: i === page ? 20 : 7,
+                height: 7,
+                borderRadius: t.radii.pill,
+                backgroundColor: i === page ? t.colors.accent : t.colors.off,
+              }}
+            />
+          ))}
+        </View>
+
+        <Pressable
+          onPress={skip}
+          accessibilityRole="button"
+          accessibilityLabel={tx('skip')}
+          hitSlop={8}
+          style={({ pressed }) => [{ paddingVertical: t.spacing.xs }, pressed && { opacity: 0.6 }]}
+        >
+          <Text style={{ fontSize: 16, fontWeight: '600', color: t.colors.textAccent }}>
+            {tx('skip')}
+          </Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        ref={scroller}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={onScrollEnd}
+        // Both handlers, because a slow drag that settles with no momentum does
+        // not reliably fire onMomentumScrollEnd on Android. onScrollEnd is
+        // idempotent (it no-ops when the rounded page is unchanged), so the
+        // overlap on a normal swipe costs nothing. The programmatic advance()
+        // path needs neither — it sets `page` itself before scrolling.
+        onScrollEndDrag={onScrollEnd}
+        style={{ flex: 1 }}
+      >
+        <Card
+          width={width}
+          topInset={topInset}
+          heading={tx('card1.heading')}
+          body={tx('card1.body')}
+          t={t}
+          variant="title"
+        />
+
+        <Card width={width} topInset={topInset} heading={tx('card2.heading')} body={tx('card2.body')} t={t}>
+          <View style={{ gap: t.spacing.md, marginTop: t.spacing.xs }}>
+            {FEATURES.map((f) => (
+              <FeatureRow
+                key={f.key}
+                icon={f.icon}
+                label={tx(`card2.features.${f.key}`)}
+                t={t}
+              />
+            ))}
+          </View>
+        </Card>
+
+        <Card width={width} topInset={topInset} heading={tx('card3.heading')} body={tx('card3.body')} t={t}>
+          {/* Two real settings, presented exactly as the Settings screen presents
+              them (Card + ListRow + RN Switch + the same SF Symbol names), so
+              what the user sets here looks identical to where they'll find it
+              later. Nothing here writes: the values are local until "Get
+              started". */}
+          <SettingsCard style={{ marginTop: t.spacing.xs }}>
+            <ListRow
+              title={tx('card3.reminder')}
+              leading={<RowIcon name="bell" t={t} />}
+              // Not `isLast`: the time row below (or the streak row) follows.
+              trailing={
+                <Switch
+                  value={reminderOn}
+                  onValueChange={setReminderOn}
+                  trackColor={{ true: t.colors.accent }}
+                  accessibilityLabel={tx('card3.reminder')}
+                />
+              }
+            />
+            {/* HIDDEN, not disabled, when the reminder is off — matching
+                SettingsScreen, which conditionally renders this same row. */}
+            {reminderOn ? (
+              <ListRow
+                title={tx('a11y.reminderTime')}
+                leading={<RowIcon name="clock" t={t} />}
+                value={formatReminderTime(time.hour, time.minute, i18n.language)}
+                chevron
+                onPress={() => setTimeSheetOpen(true)}
+                accessibilityLabel={tx('a11y.reminderTime')}
+              />
+            ) : null}
+            <ListRow
+              title={tx('card3.streak')}
+              leading={<RowIcon name="flame.fill" t={t} />}
+              isLast
+              trailing={
+                <Switch
+                  value={streakOn}
+                  onValueChange={setStreakOn}
+                  trackColor={{ true: t.colors.accent }}
+                  accessibilityLabel={tx('card3.streak')}
+                />
+              }
+            />
+          </SettingsCard>
+        </Card>
+      </ScrollView>
+
+      {/* The Settings screen's own picker — iOS wheels in a formSheet, Android's
+          native clock dialog. onConfirm updates the LOCAL draft only; the value
+          reaches the scheduler via commitOnboardingReminder on "Get started". */}
+      <ReminderTimeSheet
+        visible={timeSheetOpen}
+        hour={time.hour}
+        minute={time.minute}
+        onConfirm={(hour, minute) => setTime({ hour, minute })}
+        onClose={() => setTimeSheetOpen(false)}
+      />
+
+      <View
+        style={{
+          paddingHorizontal: t.spacing.xl,
+          paddingTop: t.spacing.lg,
+          paddingBottom: insets.bottom + t.spacing.lg,
+        }}
+      >
+        <Pressable
+          onPress={advance}
+          disabled={committing}
+          accessibilityRole="button"
+          style={({ pressed }) => ({
+            height: 50,
+            borderRadius: t.radii.md,
+            backgroundColor: t.colors.accent,
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: committing ? 0.5 : pressed ? 0.85 : 1,
+          })}
+        >
+          <Text style={{ fontSize: 16.5, fontWeight: '700', color: t.colors.onAccent }}>
+            {isLast ? tx('getStarted') : tx('continue')}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import FormSheetShell from '../components/FormSheetShell'
 import { useFormSheet } from '../lib/formSheetHost'
 import { useTheme } from '../theme/ThemeProvider'
 import { useCurrentUser } from '../lib/currentUser'
+import { resetIntroSeen } from '../lib/introSeen'
 import { useProfileSprite } from '../lib/useProfileSprite'
 import { useDisplayName } from '../lib/useDisplayName'
 import {
@@ -118,7 +119,7 @@ function OptionSheetContent<T extends string>({
 
 export default function SettingsScreen() {
   const t = useTheme()
-  const { t: tx, i18n } = useTranslation(['settings', 'common'])
+  const { t: tx, i18n } = useTranslation(['settings', 'common', 'intro'])
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const user = useCurrentUser()
@@ -370,8 +371,23 @@ export default function SettingsScreen() {
             title={tx('aboutGraceChords')}
             leading={<RowIcon name="info.circle" />}
             chevron
-            isLast
             onPress={() => router.push('/about')}
+          />
+          {/* Replays the first-launch intro without a reinstall. Clearing the
+              flag makes the auth gate itself want /intro; the replace below just
+              gets there without waiting a frame. Finishing or skipping the replay
+              sets the flag again. Wired for testing — if the intro settles, this
+              row and intro.replay.* in the locale files come out together. */}
+          <ListRow
+            title={tx('intro:replay.row')}
+            subtitle={tx('intro:replay.subtitle')}
+            leading={<RowIcon name="arrow.triangle.2.circlepath" />}
+            chevron
+            isLast
+            onPress={() => {
+              resetIntroSeen()
+              router.replace('/intro')
+            }}
           />
         </Card>
       </ScrollView>


### PR DESCRIPTION
Adds a three-card first-launch intro to the mobile app, shown once per device after auth, landing the user on Home.

## What's here

**Card 1** — centered title card. **Card 2** — three feature rows, each icon taken from the live UI that owns the feature (Setlist Builder key chip → `chevron.up.chevron.down`, Performer session button → `antenna.radiowaves.left.and.right`, Song Viewer share → `square.and.arrow.up`), so **no new `symbolMap.ts` entries and no font rebuild**. **Card 3** — two real settings.

Card 3 **reuses** the Settings screen's components rather than reimplementing them — RN `Switch`, `ListRow`/`Card`, and `ReminderTimeSheet` — plus the same SF Symbol names (`bell` / `clock` / `flame.fill`), so what the user sets here is visually identical to where they'll find it later. The time row is **hidden** (not disabled) when the reminder is off, matching Settings.

## Design notes worth reviewing

**Permission timing.** Requested *only* on "Get started", and only when the reminder toggle is on. `commitReminderOptIn` (pure + dependency-injected in `readerReminder.ts`, wrapped by `commitOnboardingReminder` in the service) checks existing permission **before** prompting, and on denial fails silently with the preference pinned off so app state matches OS state. Settings' existing `enableReaderReminder` prompts on every toggle-on — correct there, since the toggle *is* the request — which is why this needed its own entry point. Nothing existing changed, so Settings behaves exactly as before.

**Why the logic lives in the pure module.** `readerReminderService.ts` imports expo-notifications and can't be unit-tested headless, and AGENTS.md forbids `vi.mock`ing native modules. Following the existing `syncReminder` seam put the decision logic behind an injected backend and bought 7 headless tests.

**Synchronous seen-flag.** `gc.intro.seen.v1` joins the splash `multiGet` batch so the auth gate reads it synchronously — an async read would paint Home for a frame before the redirect landed. Device-local, deliberately **not** on the Supabase profile; a returning user on a new device seeing the intro again is intended.

**Deep links keep their destination.** `wantsIntro()` scopes the redirect to the app's own entry points (bare root / `(tabs)`) rather than "any route that isn't the intro", so an inbound `viewer/[slug]`, `setlist/import`, or anonymous `session/[code]` link isn't hijacked. The intro just shows on the next ordinary launch.

## Behaviour changes to be aware of

- Both card-3 toggles ship **default ON**, which flips the reminder and the reading streak from opt-in to opt-out for anyone passing through onboarding. AGENTS.md is updated in both places. Existing users are unaffected.
- **Existing installs will see the intro once** on their next launch, since the flag is absent for them.
- **Skip discards visibly-ON toggles** — a user who sees two ON switches and taps Skip gets neither. Intended, but it's the one place the UI's default state and the persisted outcome disagree.

## Verification (iOS 17 Pro simulator + Pixel 8 emulator)

- All four permission branches: not-determined → granted, already-granted (no second prompt), **denied** (no alert, 0 alarms, preference off, navigation proceeds), and reminder-off (0 alarms *with permission granted*, proving the commit never ran).
- **Scheduling proved at the OS level, not by reading the setting**: picked 9:00 AM in the wheel, and the simulator's `PendingNotifications.plist` carries `NS.hour => 9`, identifier `reader-daily-reminder`, title "Daily Word", deep link `/daily`. `dumpsys alarm` used for the negative cases on Android.
- No divergence: after a granted run, Settings showed reminder ON / 9:00 AM / streak ON, and Home's Daily Word card began showing a streak row.
- Skip from card 3 writes nothing. All three Material glyphs render on Android (no `help` fallback). Light + dark. Every user-facing string goes through `tx()`.
- `npm run i18n:check`: 0 issues across es/ko/tr (real translations, `needsReview: true`).
- Song Viewer, Set Viewer, Performer mode, `ReminderTimeSheet`, `symbolMap.ts`, `supabase/`, `android/`, `ios/` — all untouched.

Test suite matches `main`: the 2 `launchStorage.test.ts` failures (`getColumnMode` vs `getColumns`) are pre-existing on `main` and unrelated.

## Note on scope

This branch was cut from `main` and contains **only** this work. It was developed in a tree that also held unrelated in-flight work (in-app review prompts, route dwell, session errors, EAS config); `_layout.tsx`, `launchStorage.ts`, `launchStorage.test.ts` and `AGENTS.md` were entangled with it, so only the intro hunks were carried over here.

Rebased onto current `main` after #480/#481/#482 landed. The three-way conflicts in `_layout.tsx` and the two `launchStorage` files were resolved to **keep both sides** — `hydrateTodayReflection` and `hydrateIntroSeen` both run in the splash gate, both `gc.reflection.today.v1` and `gc.intro.seen.v1` are in the batch, and the key count is reconciled to **14** across the header comment, the docblock, and the test assertions.

Settings gains a **temporary** "See onboarding again" row for replay — it and `intro.replay.*` come out together whenever the intro settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
