### PR TITLE
feat(mobile): native in-app review request after a positive interaction

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -46,3 +46,16 @@ EXPO_PUBLIC_R2_PUBLIC_URL=https://assets.gracechords.com
 # google-signin -> iosUrlScheme, then rebuild the dev client.
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=1234567890-web.apps.googleusercontent.com
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=1234567890-ios.apps.googleusercontent.com
+
+# Which eas.json build profile produced this binary. Injected automatically by
+# EAS Build (see the `env` block on each profile in eas.json) — you do NOT need
+# it in a local .env, and leaving it unset is the correct local behaviour.
+#
+# Read by src/lib/reviewService.ts, which will not request an in-app review
+# unless this is "production". It is the only signal that separates a real
+# Android release from a `preview` APK or a dev client. NOTE: it does NOT
+# separate the Play internal-testing track from production — `eas submit`
+# promotes the same production AAB to both, so no build-time value can tell
+# them apart. On iOS the stronger check is expo-store-review's own
+# isAvailableAsync(), which is false for TestFlight and Xcode installs.
+# EXPO_PUBLIC_BUILD_PROFILE=production

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -395,6 +395,68 @@ duplicate logic here and never edit core internals to suit mobile.
   Viewer/Performer seed their chord style read-on-open; in-session changes don't
   write back.
 
+## In-app review request
+
+Native store review (`expo-store-review` → `SKStoreReviewController` on iOS, Play
+In-App Review on Android), asked for after a genuinely positive interaction. **The
+OS sheet is the entire UI** — there is no pre-prompt, no "Enjoying GraceChords?"
+gate, no stars of our own, and deliberately no "Rate GraceChords" Settings row
+(if one is ever added it must DEEP-LINK to the store page, never call
+`requestReview`, because a tap that silently does nothing is worse than no row).
+
+The platform gives **no callback**: we cannot tell whether the sheet rendered,
+whether anyone rated, or whether the OS silently swallowed the call because its
+own cap (~3/year on iOS) was spent. Every request is therefore a spent,
+unverifiable attempt, which is why the gates below are as conservative as they
+are — and why the attempt is banked *before* the native call is awaited.
+
+- `src/lib/routeDwell.ts` — **pure**, injected clock. Accumulates foreground-only
+  time on the current route. Backgrounded time does not count, and the shared
+  `sheet` route is treated as an **overlay** (freeze, then resume) rather than a
+  departure, because every sheet in the app is a real router navigation via
+  `formSheetHost`. Dwell is keyed on the resolved `usePathname()`, so song A →
+  song B ends A's visit instead of pooling two half-reads.
+- `src/lib/reviewEligibility.ts` — **pure**. The whole policy in one function,
+  returning a decision *plus a human-readable reason*. Triggers: 90 s+ foreground
+  dwell on `viewer/[slug]` or `perform/[id]`, or leaving the reader with a
+  4+ day streak. Then: production build, no session error, 7+ days since first
+  launch, 3+ distinct open days, intro seen before *this* launch, under 3 lifetime
+  requests, 120+ days since the last.
+- `src/lib/reviewState.ts` — device-local persistence (`gc.review.v1`, joined to
+  the `launchStorage.ts` batch). **Bounded by construction:** distinct open days
+  are a count plus one date, never a list. Nothing touches the Supabase profile.
+- `src/lib/sessionError.ts` — in-memory only, never persisted. `markSessionError`
+  is called from `errors.ts` (below the `isAbortError` check — a user
+  cancellation is not a bad experience), `api.ts`, `exportSong.ts` and
+  `AuthScreen.tsx`. Asking someone to rate the app minutes after their export
+  failed is the most expensive mistake this feature can make.
+- `src/lib/reviewService.ts` — the native half (`expo-store-review`, `AppState`,
+  `useSegments`/`usePathname`), mounted **once** as `useReviewObserver()` in the
+  root layout. Same pure-store/service split as `readerReminder*.ts`.
+
+Two things to know before touching it:
+
+- **It derives everything from navigation state.** The Song Viewer, Performer and
+  Daily Word reader know nothing about it and must stay that way.
+- **Production detection is asymmetric.** On iOS, `StoreReview.isAvailableAsync()`
+  is a genuine signal — its native implementation returns false when the bundle
+  has a sandbox receipt and no embedded provisioning profile, i.e. TestFlight and
+  Xcode installs. On **Android it is not**: it only checks that the Play Store app
+  is installed, and Play internal/closed testing serves the *same production AAB*
+  from the same store, so `EXPO_PUBLIC_BUILD_PROFILE` (injected per profile in
+  `eas.json`) can rule out dev clients and `preview` APKs but **cannot** rule out
+  the internal-testing track. Nothing available at runtime can. Do not "fix" this
+  with `expo-application`'s `getIosApplicationReleaseTypeAsync()` either — it
+  reports `APP_STORE` for TestFlight builds too, since neither has an embedded
+  profile.
+
+Because the sheet does not appear in TestFlight and is unreliable in Play internal
+testing, **dev builds never call the API**: eligibility is evaluated in full, the
+decision and every input are logged (`[review] would request now (trigger=dwell,
+…)`), and near-misses log the specific failing gate. That log is the supported way
+to verify changes here; `src/lib/__tests__/reviewFlow.test.ts` covers the same
+scenarios headless.
+
 ## Data & stubs
 
 - Song data uses core's `fetchSongList` (widen columns via its `opts.columns`);

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { flushPendingSprite } from '../src/lib/profile'
 import { primeLaunchStorage } from '../src/lib/launchStorage'
 import { hydrateDefaults } from '../src/lib/defaults'
 import { hydrateIntroSeen, useIntroSeen } from '../src/lib/introSeen'
+import { startReviewSession, useReviewObserver } from '../src/lib/reviewService'
 import { hydrateBibleTranslationPref } from '../src/lib/bibleTranslationPref'
 import { prefetchToday } from '../src/lib/bibleSource'
 import { hydrateDownloads } from '../src/lib/downloads/manifest'
@@ -251,11 +252,12 @@ export default function RootLayout() {
     // session read were nested behind it the two would serialise and cold launch
     // would regress — the whole point of batching is to be no slower.
     const sessionRead = resolveInitialSession(supabase.auth)
-    // One AsyncStorage round trip for all 14 launch keys instead of 14 separate
+    // One AsyncStorage round trip for all 15 launch keys instead of 15 separate
     // getItem calls. The stores themselves are untouched: they receive a
     // KVStorage that answers from the batch, so every missing/null/malformed
     // fallback is byte-for-byte what it was. See launchStorage.ts.
-    const hydrated = primeLaunchStorage(AsyncStorage).then((store) =>
+    const primed = primeLaunchStorage(AsyncStorage)
+    const hydrated = primed.then((store) =>
       Promise.all([
         hydrateDefaults(store),
         hydrateDownloads(store),
@@ -275,6 +277,15 @@ export default function RootLayout() {
         hydrateIntroSeen(store),
       ]),
     )
+    // In-app review bookkeeping (src/lib/reviewService.ts). Deliberately its own
+    // chain rather than a member of the splash gate below: nothing on screen
+    // depends on it, and the review gate cannot fire until the user has
+    // navigated somewhere. It waits on `hydrated` only so the intro flag is
+    // resolved before it snapshots "was the intro already seen BEFORE this
+    // launch" — the whole point of that gate is to exclude a first run.
+    void Promise.all([primed, hydrated])
+      .then(([store]) => startReviewSession(store))
+      .catch(() => {})
     Promise.all([
       sessionRead,
       hydrated,
@@ -390,6 +401,10 @@ export default function RootLayout() {
   }, [router])
 
   useProtectedRoute(session, ready, beginHandoff)
+  // Watches navigation + app lifecycle to time the in-app review request. Reads
+  // navigation state only — the Song Viewer, Performer and Daily Word reader are
+  // untouched and know nothing about it. See src/lib/reviewService.ts.
+  useReviewObserver()
 
   if (supabaseConfigError) {
     return <ConfigErrorScreen message={supabaseConfigError} />

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -7,12 +7,18 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_BUILD_PROFILE": "development"
+      },
       "ios": {
         "resourceClass": "m-medium"
       }
     },
     "preview": {
       "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_BUILD_PROFILE": "preview"
+      },
       "ios": {
         "resourceClass": "m-medium",
         "simulator": false
@@ -20,6 +26,9 @@
     },
     "production": {
       "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_BUILD_PROFILE": "production"
+      },
       "ios": {
         "resourceClass": "m-medium"
       }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -46,6 +46,7 @@
     "expo-sharing": "~55.0.21",
     "expo-splash-screen": "~55.0.22",
     "expo-status-bar": "~55.0.6",
+    "expo-store-review": "~55.0.16",
     "expo-symbols": "~55.0.9",
     "expo-web-browser": "~55.0.17",
     "i18next": "^26.0.8",

--- a/apps/mobile/src/lib/__tests__/launchStorage.test.ts
+++ b/apps/mobile/src/lib/__tests__/launchStorage.test.ts
@@ -45,9 +45,11 @@ function makeStore(seed: Record<string, string> = {}) {
 }
 
 describe('LAUNCH_STORAGE_KEYS', () => {
-  it('covers the 14 keys the splash gate reads', () => {
-    expect(LAUNCH_STORAGE_KEYS).toHaveLength(14)
-    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(14)
+  // 14 splash-gating keys plus gc.review.v1, which rides the same batch without
+  // gating first paint (see the list's own comment in launchStorage.ts).
+  it('covers the 15 keys read at launch', () => {
+    expect(LAUNCH_STORAGE_KEYS).toHaveLength(15)
+    expect(new Set(LAUNCH_STORAGE_KEYS).size).toBe(15)
   })
 })
 
@@ -69,8 +71,8 @@ describe('primeLaunchStorage', () => {
 
   it('falls back to the real store when multiGet rejects', async () => {
     // Today each module does its own getItem behind its own try/catch, so one
-    // failing read can only affect one module. A batch that reset all 14
-    // keys to defaults at once would be a far worse failure.
+    // failing read can only affect one module. A batch that reset every batched
+    // preference to its default at once would be a far worse failure.
     const { store } = makeStore({ 'gc.defaults.theme': 'dark' })
     store.multiGet = () => Promise.reject(new Error('storage unavailable'))
     const primed = await primeLaunchStorage(store)

--- a/apps/mobile/src/lib/__tests__/reviewEligibility.test.ts
+++ b/apps/mobile/src/lib/__tests__/reviewEligibility.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DAILY_TAB_ROUTE,
+  DWELL_THRESHOLD_MS,
+  evaluateReviewEligibility,
+  READER_ROUTE,
+  SET_VIEWER_ROUTE,
+  SONG_VIEWER_ROUTE,
+  daysBetweenDayKeys,
+  type EligibilityInput,
+} from '../reviewEligibility'
+import { DEFAULT_REVIEW_STATE } from '../reviewState'
+
+// Mirrors the verification checklist for the feature. Every gate is asserted by
+// NAME as well as by outcome, because the reason string is what the dev-build
+// debug override prints — it is the only way to exercise this logic on a device,
+// since the OS sheet does not render in TestFlight.
+
+const DAY = 86_400_000
+const NOW = Date.UTC(2026, 7, 7, 12, 0, 0)
+const TODAY = '2026-08-07'
+
+/** A departure that passes every gate. Each test spoils exactly one thing. */
+function eligibleInput(over: Partial<EligibilityInput> = {}): EligibilityInput {
+  return {
+    routeKey: SONG_VIEWER_ROUTE,
+    pathname: '/viewer/still-alive',
+    dwellMs: 94_000,
+    streak: 0,
+    dailyWordDestination: 'landing',
+    isProductionBuild: true,
+    hasSessionError: false,
+    introSeenAtLaunch: true,
+    state: {
+      ...DEFAULT_REVIEW_STATE,
+      firstLaunchDate: '2026-07-27', // 11 days back
+      openDays: 5,
+      lastOpenDate: TODAY,
+    },
+    now: NOW,
+    today: TODAY,
+    ...over,
+  }
+}
+
+describe('daysBetweenDayKeys', () => {
+  it('counts whole days and ignores DST by working in UTC', () => {
+    expect(daysBetweenDayKeys('2026-03-01', '2026-03-31')).toBe(30)
+    expect(daysBetweenDayKeys('2026-08-07', '2026-08-07')).toBe(0)
+  })
+
+  it('returns null for a missing or malformed key', () => {
+    expect(daysBetweenDayKeys(null, TODAY)).toBeNull()
+    expect(daysBetweenDayKeys('garbage', TODAY)).toBeNull()
+  })
+})
+
+describe('evaluateReviewEligibility — triggers', () => {
+  it('is eligible after a long song-viewer read', () => {
+    const d = evaluateReviewEligibility(eligibleInput())
+    expect(d.eligible).toBe(true)
+    expect(d.eligible && d.trigger).toBe('dwell')
+    expect(d.reason).toContain('would request now')
+    expect(d.reason).toContain('dwell=94s')
+  })
+
+  it('is eligible after a long set-viewer (Performer) session', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ routeKey: SET_VIEWER_ROUTE, pathname: '/perform/abc' }),
+    )
+    expect(d.eligible).toBe(true)
+    expect(d.eligible && d.trigger).toBe('dwell')
+  })
+
+  it('names the dwell gate for a ~10s song-viewer visit', () => {
+    const d = evaluateReviewEligibility(eligibleInput({ dwellMs: 10_000 }))
+    expect(d.eligible).toBe(false)
+    expect(!d.eligible && d.gate).toBe('dwell')
+    expect(d.reason).toContain('dwell 10s < 90s')
+  })
+
+  it('rejects a visit that only reaches the threshold by counting background time', () => {
+    // The tracker already excludes it; this asserts the boundary the policy sees.
+    const d = evaluateReviewEligibility(eligibleInput({ dwellMs: DWELL_THRESHOLD_MS - 1 }))
+    expect(!d.eligible && d.gate).toBe('dwell')
+  })
+
+  it('needs a streak of 4 to fire on the reader, not 3', () => {
+    const three = evaluateReviewEligibility(
+      eligibleInput({ routeKey: READER_ROUTE, pathname: '/daily/reader', dwellMs: 5_000, streak: 3 }),
+    )
+    expect(three.eligible).toBe(false)
+    expect(!three.eligible && three.gate).toBe('streak')
+    expect(three.reason).toContain('streak 3 < 4')
+
+    const four = evaluateReviewEligibility(
+      eligibleInput({ routeKey: READER_ROUTE, pathname: '/daily/reader', dwellMs: 5_000, streak: 4 }),
+    )
+    expect(four.eligible).toBe(true)
+    expect(four.eligible && four.trigger).toBe('streak')
+  })
+
+  it('treats the Daily Word TAB as the reader only when the pref says so', () => {
+    const asReader = evaluateReviewEligibility(
+      eligibleInput({
+        routeKey: DAILY_TAB_ROUTE,
+        pathname: '/daily',
+        dwellMs: 5_000,
+        streak: 8,
+        dailyWordDestination: 'reader',
+      }),
+    )
+    expect(asReader.eligible).toBe(true)
+
+    const asLanding = evaluateReviewEligibility(
+      eligibleInput({
+        routeKey: DAILY_TAB_ROUTE,
+        pathname: '/daily',
+        dwellMs: 5_000,
+        streak: 8,
+        dailyWordDestination: 'landing',
+      }),
+    )
+    expect(!asLanding.eligible && asLanding.gate).toBe('route')
+  })
+
+  it('ignores non-qualifying routes quietly', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ routeKey: '(tabs)/songs', pathname: '/songs', dwellMs: 600_000 }),
+    )
+    expect(!d.eligible && d.gate).toBe('route')
+  })
+
+  it('never evaluates the overlay route', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ routeKey: 'sheet', pathname: '/sheet', dwellMs: 600_000 }),
+    )
+    expect(!d.eligible && d.gate).toBe('route')
+  })
+
+  it('does not let a setlist BUILDER visit qualify as a set viewer', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ routeKey: 'setlist/[id]', pathname: '/setlist/abc' }),
+    )
+    expect(!d.eligible && d.gate).toBe('route')
+  })
+})
+
+describe('evaluateReviewEligibility — ambient gates', () => {
+  it('blocks a non-production build', () => {
+    const d = evaluateReviewEligibility(eligibleInput({ isProductionBuild: false }))
+    expect(!d.eligible && d.gate).toBe('production')
+  })
+
+  it('blocks when anything failed this session', () => {
+    const d = evaluateReviewEligibility(eligibleInput({ hasSessionError: true }))
+    expect(!d.eligible && d.gate).toBe('sessionError')
+    expect(d.reason).toContain('an error occurred this session')
+  })
+
+  it('blocks inside the first 7 days', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ state: { ...eligibleInput().state, firstLaunchDate: '2026-08-02' } }),
+    )
+    expect(!d.eligible && d.gate).toBe('firstLaunchAge')
+  })
+
+  it('allows exactly 7 days', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ state: { ...eligibleInput().state, firstLaunchDate: '2026-07-31' } }),
+    )
+    expect(d.eligible).toBe(true)
+  })
+
+  it('blocks a missing or malformed first-launch date rather than trusting it', () => {
+    const missing = evaluateReviewEligibility(
+      eligibleInput({ state: { ...eligibleInput().state, firstLaunchDate: null } }),
+    )
+    expect(!missing.eligible && missing.gate).toBe('firstLaunchAge')
+
+    const bad = evaluateReviewEligibility(
+      eligibleInput({ state: { ...eligibleInput().state, firstLaunchDate: 'not-a-date' } }),
+    )
+    expect(!bad.eligible && bad.gate).toBe('firstLaunchAge')
+  })
+
+  it('blocks under 3 distinct open days', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({ state: { ...eligibleInput().state, openDays: 2 } }),
+    )
+    expect(!d.eligible && d.gate).toBe('openDays')
+  })
+
+  it('blocks when the intro was not already seen before this launch', () => {
+    const d = evaluateReviewEligibility(eligibleInput({ introSeenAtLaunch: false }))
+    expect(!d.eligible && d.gate).toBe('intro')
+  })
+
+  it('blocks permanently after 3 lifetime requests', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({
+        state: { ...eligibleInput().state, requestCount: 3, lastRequestAt: NOW - 900 * DAY },
+      }),
+    )
+    expect(!d.eligible && d.gate).toBe('maxRequests')
+  })
+
+  it('blocks a request 10 days ago and allows one 130 days ago', () => {
+    const recent = evaluateReviewEligibility(
+      eligibleInput({
+        state: { ...eligibleInput().state, requestCount: 1, lastRequestAt: NOW - 10 * DAY },
+      }),
+    )
+    expect(!recent.eligible && recent.gate).toBe('recentRequest')
+    expect(recent.reason).toContain('last request 10 days ago < 120')
+
+    const old = evaluateReviewEligibility(
+      eligibleInput({
+        state: { ...eligibleInput().state, requestCount: 1, lastRequestAt: NOW - 130 * DAY },
+      }),
+    )
+    expect(old.eligible).toBe(true)
+  })
+
+  it('reports the permanent cap before the temporary cooling-off', () => {
+    const d = evaluateReviewEligibility(
+      eligibleInput({
+        state: { ...eligibleInput().state, requestCount: 3, lastRequestAt: NOW - 1 * DAY },
+      }),
+    )
+    expect(!d.eligible && d.gate).toBe('maxRequests')
+  })
+
+  it('puts every input in the reason string, whatever the outcome', () => {
+    const d = evaluateReviewEligibility(eligibleInput({ hasSessionError: true }))
+    for (const fragment of [
+      'trigger=dwell',
+      'route=viewer/[slug]',
+      'dwell=94s',
+      'streak=0',
+      'days=11',
+      'opens=5',
+      'priorRequests=0',
+      'production=true',
+    ]) {
+      expect(d.reason).toContain(fragment)
+    }
+  })
+})

--- a/apps/mobile/src/lib/__tests__/reviewFlow.test.ts
+++ b/apps/mobile/src/lib/__tests__/reviewFlow.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createRouteDwellTracker, OVERLAY_ROUTE_KEY, type DwellEvent } from '../routeDwell'
+import {
+  READER_ROUTE,
+  SONG_VIEWER_ROUTE,
+  evaluateReviewEligibility,
+  type EligibilityDecision,
+} from '../reviewEligibility'
+import {
+  __resetReviewStateForTest,
+  getReviewState,
+  hydrateReviewState,
+  recordAppOpen,
+  recordReviewRequest,
+} from '../reviewState'
+import { __resetSessionErrorForTest, hasSessionError, markSessionError } from '../sessionError'
+
+// End-to-end over the seam the unit tests can't reach on their own: navigation
+// → dwell accounting → eligibility. This is the same composition reviewService.ts
+// performs, with the native half (expo-store-review, AppState, expo-router)
+// replaced by the driver below — so every scenario on the verification checklist
+// is asserted here rather than only through the on-device console.
+
+const SONGS = '(tabs)/songs'
+const DAY = 86_400_000
+const TODAY = '2026-08-07'
+const NOW = Date.UTC(2026, 7, 7, 12)
+
+/**
+ * Drives the tracker exactly as the observer's navigation effect does, judging
+ * departures with the real policy. Returns every decision the service WOULD have
+ * evaluated — crucially, only on departure, never while a route is still open.
+ */
+function makeApp(opts: { introSeenAtLaunch?: boolean; production?: boolean } = {}) {
+  const tracker = createRouteDwellTracker()
+  const decisions: Array<{ event: DwellEvent; decision: EligibilityDecision }> = []
+  let streak = 0
+  let dailyWordDestination: 'landing' | 'reader' = 'landing'
+
+  return {
+    decisions,
+    setStreak(v: number) {
+      streak = v
+    },
+    setDailyWordDestination(v: 'landing' | 'reader') {
+      dailyWordDestination = v
+    },
+    background(at: number) {
+      tracker.onBackground(at)
+    },
+    foreground(at: number) {
+      tracker.onForeground(at)
+    },
+    navigate(routeKey: string, pathname: string, at: number) {
+      const departed = tracker.onRoute(routeKey, pathname, at)
+      if (!departed) return
+      decisions.push({
+        event: departed,
+        decision: evaluateReviewEligibility({
+          routeKey: departed.routeKey,
+          pathname: departed.pathname,
+          dwellMs: departed.dwellMs,
+          streak,
+          dailyWordDestination,
+          isProductionBuild: opts.production ?? true,
+          hasSessionError: hasSessionError(),
+          introSeenAtLaunch: opts.introSeenAtLaunch ?? true,
+          state: getReviewState(),
+          now: NOW + at,
+          today: TODAY,
+        }),
+      })
+    },
+    last() {
+      return decisions[decisions.length - 1]
+    },
+  }
+}
+
+/** A well-established install: first launch 11 days ago, opened on 5 days. */
+async function seedEstablishedInstall(over: Record<string, unknown> = {}) {
+  const data = new Map<string, string>([
+    [
+      'gc.review.v1',
+      JSON.stringify({
+        firstLaunchDate: '2026-07-27',
+        openDays: 4,
+        lastOpenDate: '2026-08-06',
+        lastRequestAt: null,
+        requestCount: 0,
+        ...over,
+      }),
+    ],
+  ])
+  await hydrateReviewState({
+    getItem: async (k) => data.get(k) ?? null,
+    setItem: async (k, v) => {
+      data.set(k, v)
+    },
+    removeItem: async (k) => {
+      data.delete(k)
+    },
+  })
+  recordAppOpen(new Date(2026, 7, 7)) // → openDays 5
+  return data
+}
+
+beforeEach(() => {
+  __resetReviewStateForTest()
+  __resetSessionErrorForTest()
+})
+
+describe('review flow — dwell trigger', () => {
+  it('song viewer, ~10s dwell, then back out: NOT eligible, names the dwell gate', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.navigate(SONGS, '/songs', 0)
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 1_000)
+    app.navigate(SONGS, '/songs', 11_000)
+
+    const { decision } = app.last()
+    expect(decision.eligible).toBe(false)
+    expect(!decision.eligible && decision.gate).toBe('dwell')
+  })
+
+  it('song viewer, 90+s dwell, then back out: eligible, logged with the dwell trigger', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.navigate(SONGS, '/songs', 0)
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 1_000)
+    app.navigate(SONGS, '/songs', 95_000)
+
+    const { decision } = app.last()
+    expect(decision.eligible).toBe(true)
+    expect(decision.eligible && decision.trigger).toBe('dwell')
+    expect(decision.reason).toMatch(/would request now .*trigger=dwell.*dwell=94s/)
+  })
+
+  it('90+s of which most was backgrounded: NOT eligible', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.background(20_000)
+    app.foreground(600_000) // ten minutes on the lock screen
+    app.navigate(SONGS, '/songs', 610_000)
+
+    const { event, decision } = app.last()
+    expect(event.dwellMs).toBe(30_000)
+    expect(!decision.eligible && decision.gate).toBe('dwell')
+  })
+
+  it('eligibility is never evaluated while still on the qualifying route', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    // Long past the threshold, still reading, sheet opened and closed.
+    app.navigate(OVERLAY_ROUTE_KEY, '/sheet', 100_000)
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 120_000)
+    expect(app.decisions).toHaveLength(0)
+
+    app.navigate(SONGS, '/songs', 130_000)
+    expect(app.decisions).toHaveLength(1)
+    expect(app.last().decision.eligible).toBe(true)
+  })
+
+  it('opening the export sheet does not end the read, and time in it does not count', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.navigate(OVERLAY_ROUTE_KEY, '/sheet', 60_000)
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 300_000) // four minutes in the sheet
+    app.navigate(SONGS, '/songs', 320_000)
+
+    const { event, decision } = app.last()
+    expect(event.dwellMs).toBe(80_000)
+    expect(!decision.eligible && decision.gate).toBe('dwell')
+  })
+})
+
+describe('review flow — streak trigger', () => {
+  it('reader exit with a streak of 3: NOT eligible; 4+: eligible', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.setStreak(3)
+    app.navigate(READER_ROUTE, '/daily/reader', 0)
+    app.navigate(SONGS, '/songs', 5_000)
+    const three = app.last().decision
+    expect(!three.eligible && three.gate).toBe('streak')
+
+    app.setStreak(4)
+    app.navigate(READER_ROUTE, '/daily/reader', 6_000)
+    app.navigate(SONGS, '/songs', 11_000)
+    const four = app.last().decision
+    expect(four.eligible).toBe(true)
+    expect(four.eligible && four.trigger).toBe('streak')
+  })
+})
+
+describe('review flow — session error', () => {
+  it('an export failure disqualifies the rest of the session, and relaunch clears it', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+
+    // A Cloudflare Pages Function export failure, as api.ts's apiError marks it.
+    markSessionError('api 500')
+
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.navigate(SONGS, '/songs', 95_000)
+    const blocked = app.last().decision
+    expect(blocked.eligible).toBe(false)
+    expect(!blocked.eligible && blocked.gate).toBe('sessionError')
+    expect(blocked.reason).toContain('an error occurred this session')
+
+    // Relaunch: the flag is in memory only, so a new process starts clean.
+    __resetSessionErrorForTest()
+    const relaunched = makeApp()
+    relaunched.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    relaunched.navigate(SONGS, '/songs', 95_000)
+    expect(relaunched.last().decision.eligible).toBe(true)
+  })
+})
+
+describe('review flow — launch and history gates', () => {
+  it('same launch as the intro: NOT eligible', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp({ introSeenAtLaunch: false })
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.navigate(SONGS, '/songs', 95_000)
+    const d = app.last().decision
+    expect(!d.eligible && d.gate).toBe('intro')
+  })
+
+  it('a prior request 10 days ago blocks; 130 days ago allows', async () => {
+    await seedEstablishedInstall({ lastRequestAt: NOW - 10 * DAY, requestCount: 1 })
+    const recent = makeApp()
+    recent.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    recent.navigate(SONGS, '/songs', 95_000)
+    const recentDecision = recent.last().decision
+    expect(!recentDecision.eligible && recentDecision.gate).toBe('recentRequest')
+
+    __resetReviewStateForTest()
+    await seedEstablishedInstall({ lastRequestAt: NOW - 130 * DAY, requestCount: 1 })
+    const old = makeApp()
+    old.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    old.navigate(SONGS, '/songs', 95_000)
+    expect(old.last().decision.eligible).toBe(true)
+  })
+
+  it('3 lifetime requests blocks permanently, however long ago they were', async () => {
+    await seedEstablishedInstall({ lastRequestAt: NOW - 900 * DAY, requestCount: 3 })
+    const app = makeApp()
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.navigate(SONGS, '/songs', 95_000)
+    const d = app.last().decision
+    expect(!d.eligible && d.gate).toBe('maxRequests')
+  })
+
+  it('a non-production build blocks', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp({ production: false })
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.navigate(SONGS, '/songs', 95_000)
+    const d = app.last().decision
+    expect(!d.eligible && d.gate).toBe('production')
+  })
+})
+
+describe('review flow — the request records itself', () => {
+  it('a made request immediately blocks the next one, with no success callback', async () => {
+    await seedEstablishedInstall()
+    const app = makeApp()
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/a', 0)
+    app.navigate(SONGS, '/songs', 95_000)
+    expect(app.last().decision.eligible).toBe(true)
+
+    // What requestReviewNow does BEFORE awaiting the native call — nothing
+    // confirms the sheet appeared, so the attempt is banked regardless.
+    recordReviewRequest(NOW + 95_000)
+    expect(getReviewState()).toMatchObject({ requestCount: 1, lastRequestAt: NOW + 95_000 })
+
+    app.navigate(SONG_VIEWER_ROUTE, '/viewer/b', 96_000)
+    app.navigate(SONGS, '/songs', 200_000)
+    const next = app.last().decision
+    expect(!next.eligible && next.gate).toBe('recentRequest')
+  })
+})

--- a/apps/mobile/src/lib/__tests__/reviewState.test.ts
+++ b/apps/mobile/src/lib/__tests__/reviewState.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  DEFAULT_REVIEW_STATE,
+  REVIEW_STORAGE_KEY,
+  __resetReviewStateForTest,
+  getReviewState,
+  hydrateReviewState,
+  recordAppOpen,
+  recordReviewRequest,
+} from '../reviewState'
+
+// Storage is injected (defaults.ts pattern), so this runs headless.
+
+function makeStore(seed: Record<string, string> = {}) {
+  const data = new Map(Object.entries(seed))
+  return {
+    data,
+    store: {
+      getItem: async (k: string) => data.get(k) ?? null,
+      setItem: async (k: string, v: string) => {
+        data.set(k, v)
+      },
+      removeItem: async (k: string) => {
+        data.delete(k)
+      },
+    },
+  }
+}
+
+beforeEach(__resetReviewStateForTest)
+
+describe('hydrateReviewState', () => {
+  it('falls back to the zeroed default when unset', async () => {
+    const { store } = makeStore()
+    expect(await hydrateReviewState(store)).toEqual(DEFAULT_REVIEW_STATE)
+  })
+
+  it('falls back to the default on malformed JSON', async () => {
+    const { store } = makeStore({ [REVIEW_STORAGE_KEY]: '{{{' })
+    expect(await hydrateReviewState(store)).toEqual(DEFAULT_REVIEW_STATE)
+  })
+
+  it('falls back to the default on a wrong-shaped payload', async () => {
+    const { store } = makeStore({ [REVIEW_STORAGE_KEY]: '{"openDays":"lots"}' })
+    expect(await hydrateReviewState(store)).toEqual(DEFAULT_REVIEW_STATE)
+  })
+
+  it('falls back to the default when the read throws', async () => {
+    const store = {
+      getItem: async () => {
+        throw new Error('nope')
+      },
+      setItem: async () => {},
+      removeItem: async () => {},
+    }
+    expect(await hydrateReviewState(store)).toEqual(DEFAULT_REVIEW_STATE)
+  })
+
+  it('restores a stored state verbatim', async () => {
+    const stored = {
+      firstLaunchDate: '2026-01-01',
+      openDays: 9,
+      lastOpenDate: '2026-08-06',
+      lastRequestAt: 1_700_000_000_000,
+      requestCount: 2,
+    }
+    const { store } = makeStore({ [REVIEW_STORAGE_KEY]: JSON.stringify(stored) })
+    expect(await hydrateReviewState(store)).toEqual(stored)
+  })
+})
+
+describe('recordAppOpen', () => {
+  it('seeds the first-launch date and counts the first day', async () => {
+    const { store, data } = makeStore()
+    await hydrateReviewState(store)
+    recordAppOpen(new Date(2026, 7, 7))
+    expect(getReviewState()).toMatchObject({
+      firstLaunchDate: '2026-08-07',
+      openDays: 1,
+      lastOpenDate: '2026-08-07',
+    })
+    expect(JSON.parse(data.get(REVIEW_STORAGE_KEY)!).openDays).toBe(1)
+  })
+
+  it('is idempotent within a calendar day', async () => {
+    const { store } = makeStore()
+    await hydrateReviewState(store)
+    recordAppOpen(new Date(2026, 7, 7, 8))
+    recordAppOpen(new Date(2026, 7, 7, 13))
+    recordAppOpen(new Date(2026, 7, 7, 22))
+    expect(getReviewState().openDays).toBe(1)
+  })
+
+  it('counts each new calendar day and never stores a list of them', async () => {
+    const { store, data } = makeStore()
+    await hydrateReviewState(store)
+    for (const day of [5, 6, 9, 30]) recordAppOpen(new Date(2026, 7, day))
+    expect(getReviewState().openDays).toBe(4)
+    // Bounded by construction: a count plus one date, whatever the install's age.
+    const raw = JSON.parse(data.get(REVIEW_STORAGE_KEY)!)
+    expect(Object.keys(raw).sort()).toEqual([
+      'firstLaunchDate',
+      'lastOpenDate',
+      'lastRequestAt',
+      'openDays',
+      'requestCount',
+    ])
+    expect(raw.firstLaunchDate).toBe('2026-08-05')
+  })
+
+  it('keeps the original first-launch date across later opens', async () => {
+    const { store } = makeStore({
+      [REVIEW_STORAGE_KEY]: JSON.stringify({
+        ...DEFAULT_REVIEW_STATE,
+        firstLaunchDate: '2025-01-01',
+        openDays: 40,
+        lastOpenDate: '2026-08-06',
+      }),
+    })
+    await hydrateReviewState(store)
+    recordAppOpen(new Date(2026, 7, 7))
+    expect(getReviewState()).toMatchObject({ firstLaunchDate: '2025-01-01', openDays: 41 })
+  })
+})
+
+describe('recordReviewRequest', () => {
+  it('stamps the time and increments the lifetime count immediately', async () => {
+    const { store, data } = makeStore()
+    await hydrateReviewState(store)
+    recordReviewRequest(1_700_000_000_000)
+    expect(getReviewState()).toMatchObject({
+      lastRequestAt: 1_700_000_000_000,
+      requestCount: 1,
+    })
+    // Written through, not merely cached: the OS gives no success callback, so
+    // the attempt must survive the app being killed a second later.
+    expect(JSON.parse(data.get(REVIEW_STORAGE_KEY)!)).toMatchObject({
+      lastRequestAt: 1_700_000_000_000,
+      requestCount: 1,
+    })
+  })
+
+  it('accumulates toward the lifetime cap', async () => {
+    const { store } = makeStore()
+    await hydrateReviewState(store)
+    recordReviewRequest(1)
+    recordReviewRequest(2)
+    recordReviewRequest(3)
+    expect(getReviewState().requestCount).toBe(3)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/routeDwell.test.ts
+++ b/apps/mobile/src/lib/__tests__/routeDwell.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { createRouteDwellTracker, OVERLAY_ROUTE_KEY } from '../routeDwell'
+
+// The clock is injected, so "90 seconds of foreground dwell" is exact arithmetic
+// here rather than a timing test.
+
+const VIEWER = 'viewer/[slug]'
+const SONGS = '(tabs)/songs'
+
+describe('createRouteDwellTracker', () => {
+  it('does not emit for the first route of a session', () => {
+    const t = createRouteDwellTracker()
+    expect(t.onRoute(SONGS, '/songs', 0)).toBeNull()
+  })
+
+  it('emits foreground dwell for the route just left', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(SONGS, '/songs', 0)
+    t.onRoute(VIEWER, '/viewer/a', 1_000)
+    expect(t.onRoute(SONGS, '/songs', 95_000)).toEqual({
+      routeKey: VIEWER,
+      pathname: '/viewer/a',
+      dwellMs: 94_000,
+    })
+  })
+
+  it('excludes backgrounded time — a phone left open on a song earns nothing', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    t.onBackground(10_000) // 10s of real reading
+    t.onForeground(3_600_000) // an hour face-down on a music stand
+    const left = t.onRoute(SONGS, '/songs', 3_605_000) // then 5s more
+    expect(left?.dwellMs).toBe(15_000)
+  })
+
+  it('counts a visit that is still backgrounded at departure as paused', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    t.onBackground(20_000)
+    // A deep link can navigate while backgrounded; the paused clock must not
+    // suddenly bank the whole background interval.
+    expect(t.onRoute(SONGS, '/songs', 900_000)?.dwellMs).toBe(20_000)
+  })
+
+  it('treats a sheet as an overlay, not a departure, and resumes on close', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    // Export & share opens: presented through the shared formSheet route.
+    expect(t.onRoute(OVERLAY_ROUTE_KEY, '/sheet', 30_000)).toBeNull()
+    // Time inside the sheet does not count toward reading the chart.
+    expect(t.onRoute(VIEWER, '/viewer/a', 50_000)).toBeNull()
+    expect(t.onRoute(SONGS, '/songs', 110_000)?.dwellMs).toBe(90_000)
+  })
+
+  it('emits the frozen visit when a sheet dismisses into a different route', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    t.onRoute(OVERLAY_ROUTE_KEY, '/sheet', 95_000)
+    const left = t.onRoute(SONGS, '/songs', 200_000)
+    expect(left).toEqual({ routeKey: VIEWER, pathname: '/viewer/a', dwellMs: 95_000 })
+  })
+
+  it('does not resume a covered visit on foreground — only closing the sheet does', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    t.onRoute(OVERLAY_ROUTE_KEY, '/sheet', 10_000)
+    t.onBackground(20_000)
+    t.onForeground(30_000)
+    // Still covered: the 30s→60s window must not accumulate.
+    expect(t.onRoute(VIEWER, '/viewer/a', 60_000)).toBeNull()
+    expect(t.onRoute(SONGS, '/songs', 70_000)?.dwellMs).toBe(20_000)
+  })
+
+  it('keys dwell on the resolved pathname, so song A → song B ends A', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    const left = t.onRoute(VIEWER, '/viewer/b', 50_000)
+    expect(left).toEqual({ routeKey: VIEWER, pathname: '/viewer/a', dwellMs: 50_000 })
+    // B starts fresh — two half-reads never pool into one qualifying visit.
+    expect(t.peek(60_000)?.dwellMs).toBe(10_000)
+  })
+
+  it('ignores a re-report of the unchanged route', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 0)
+    expect(t.onRoute(VIEWER, '/viewer/a', 10_000)).toBeNull()
+    expect(t.peek(20_000)?.dwellMs).toBe(20_000)
+  })
+
+  it('never lets a backwards clock subtract from banked dwell', () => {
+    const t = createRouteDwellTracker()
+    t.onRoute(VIEWER, '/viewer/a', 100_000)
+    // NTP correction / manual clock change mid-visit.
+    expect(t.onRoute(SONGS, '/songs', 40_000)?.dwellMs).toBe(0)
+  })
+})

--- a/apps/mobile/src/lib/__tests__/sessionError.test.ts
+++ b/apps/mobile/src/lib/__tests__/sessionError.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetSessionErrorForTest,
+  hasSessionError,
+  markSessionError,
+  sessionErrorScope,
+} from '../sessionError'
+import { actionFailureMessage, failureDetailKey, reportFailure, saveFailureKey } from '../errors'
+
+beforeEach(() => {
+  __resetSessionErrorForTest()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('sessionError', () => {
+  it('starts clean', () => {
+    expect(hasSessionError()).toBe(false)
+    expect(sessionErrorScope()).toBeNull()
+  })
+
+  it('is one-way, and the first failure wins', () => {
+    markSessionError('useSong')
+    markSessionError('SetlistBuilder.export')
+    expect(hasSessionError()).toBe(true)
+    expect(sessionErrorScope()).toBe('useSong')
+  })
+})
+
+describe('errors.ts marks the session', () => {
+  it('on a reported load failure', () => {
+    expect(reportFailure('useSongList', new Error('boom'))).toBe(true)
+    expect(hasSessionError()).toBe(true)
+  })
+
+  it('NOT on a deliberate cancellation', () => {
+    const abort = Object.assign(new Error('Aborted'), { name: 'AbortError' })
+    expect(reportFailure('downloads', abort)).toBe(false)
+    expect(hasSessionError()).toBe(false)
+  })
+
+  it('on an offline detail lookup', () => {
+    failureDetailKey('useSong', new TypeError('Network request failed'))
+    expect(hasSessionError()).toBe(true)
+  })
+
+  it('on a failed save', () => {
+    saveFailureKey('useSetlistBuilder.save', new Error('boom'))
+    expect(hasSessionError()).toBe(true)
+  })
+
+  it('on a user-facing action failure, which returns before failureDetailKey', () => {
+    const err = Object.assign(new Error('bad base url'), { name: 'UserFacingError' })
+    actionFailureMessage('SetlistBuilder.export', err, (k) => k)
+    expect(hasSessionError()).toBe(true)
+    expect(sessionErrorScope()).toBe('SetlistBuilder.export')
+  })
+})

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase'
 import { UserFacingError } from './errors'
+import { markSessionError } from './sessionError'
 import { FOREGROUND_MS, withRequestBudget } from './requestBudget'
 
 // Shared client for the web app's Pages Functions API (/api/export/song,
@@ -25,7 +26,12 @@ export function apiBase(): string {
 async function authHeader(): Promise<{ Authorization: string }> {
   const { data } = await supabase.auth.getSession()
   const session = data?.session
-  if (!session) throw new Error('not_signed_in')
+  if (!session) {
+    // Every caller turns this into a "Sign in to export" alert, so it is a
+    // visible failure even though it never reached the network.
+    markSessionError('api.authHeader')
+    throw new Error('not_signed_in')
+  }
   return { Authorization: `Bearer ${session.access_token}` }
 }
 
@@ -64,6 +70,11 @@ export async function apiPost(path: string, body: unknown): Promise<Response> {
 // Read the API's { error } body into a thrown-Error message, with a
 // targeted hint for the redirect case a retry couldn't fix.
 export async function apiError(res: Response, fallback: string): Promise<Error> {
+  // The chokepoint for every non-ok Pages Function response — song, songbook and
+  // setlist exports, and Telegram pushes. It catches the failures raised inside
+  // the Song Viewer and the Performer, which alert raw messages without going
+  // through errors.ts and which this change is not allowed to edit.
+  markSessionError(`api ${res.status}`)
   if (res.status === 405) {
     // UserFacingError so actionFailureMessage shows this verbatim instead of
     // replacing it with generic copy: it names the exact misconfiguration and the

--- a/apps/mobile/src/lib/errors.ts
+++ b/apps/mobile/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { isAbortError, isRequestTimeout } from './requestBudget'
+import { markSessionError } from './sessionError'
 
 // Supabase errors are plain objects ({ message, details, hint, code }), not Error
 // instances — so `String(err)` yields "[object Object]". Extract a readable
@@ -32,6 +33,10 @@ export function errMessage(err: unknown): string {
  */
 export function reportFailure(scope: string, err: unknown): boolean {
   if (isAbortError(err)) return false
+  // Below the abort check on purpose: a user-cancelled download is not a bad
+  // experience, and marking it would needlessly disqualify the session from an
+  // in-app review request. See sessionError.ts.
+  markSessionError(scope)
   console.error(`[${scope}] failed: ${describeReason(err)}`)
   return true
 }
@@ -90,6 +95,7 @@ const GENERIC_DETAIL_KEY = 'errors:tryAgain'
  */
 export function failureDetailKey(scope: string, err: unknown): string {
   const offline = isRequestTimeout(err) || isNetworkFailure(err)
+  markSessionError(scope)
   console.error(`[${scope}] failed: ${describeReason(err)}`)
   return offline ? OFFLINE_DETAIL_KEY : GENERIC_DETAIL_KEY
 }
@@ -110,6 +116,10 @@ export function actionFailureMessage(
   t: (key: string) => string,
 ): string {
   if (isUserFacingError(err)) {
+    // This branch returns before failureDetailKey can mark the session, so it
+    // marks its own — a misconfigured API base URL is still a failed action in
+    // front of whoever is holding the device.
+    markSessionError(scope)
     console.error(`[${scope}] failed: ${errMessage(err)}`)
     return errMessage(err).replace(/^UserFacingError:\s*/, '')
   }
@@ -123,6 +133,7 @@ export function actionFailureMessage(
  * nothing for the user to tap.
  */
 export function saveFailureKey(scope: string, err: unknown): string {
+  markSessionError(scope)
   console.error(`[${scope}] save failed: ${describeReason(err)}`)
   return 'errors:saveFailed'
 }

--- a/apps/mobile/src/lib/exportSong.ts
+++ b/apps/mobile/src/lib/exportSong.ts
@@ -1,5 +1,6 @@
 import { File, Paths } from 'expo-file-system'
 import { apiError, apiPost } from './api'
+import { markSessionError } from './sessionError'
 
 // Server-side song export. Calls the web app's Pages Function
 // POST /api/export/song, which renders with the same pure pdf_mvp engine the
@@ -22,8 +23,13 @@ export async function exportSong(opts: {
     format,
   })
 
-  // 501 = server rasteriser unavailable; caller should offer PDF instead.
-  if (res.status === 501) throw new Error('image_unavailable')
+  // 501 = server rasteriser unavailable; caller should offer PDF instead. It is
+  // the one export failure that does not pass through apiError, so it marks the
+  // session itself — the user still tapped JPG and got an alert instead.
+  if (res.status === 501) {
+    markSessionError('exportSong.imageUnavailable')
+    throw new Error('image_unavailable')
+  }
   if (!res.ok) throw await apiError(res, 'export_failed')
 
   const contentType = res.headers.get('content-type') || ''

--- a/apps/mobile/src/lib/launchStorage.ts
+++ b/apps/mobile/src/lib/launchStorage.ts
@@ -2,7 +2,8 @@
 //
 // The launch path hydrates ten device-local stores before first paint, and
 // between them they read 14 keys with 14 separate getItem calls (five in
-// defaults.ts alone). This module reads all 14 in a single multiGet and hands
+// defaults.ts alone). This module reads those — plus the one non-splash-gating
+// key that rides along (see the list below) — in a single multiGet and hands
 // back a KVStorage-shaped facade served from the result.
 //
 // The point of the facade — rather than teaching each store to accept a
@@ -51,21 +52,26 @@ export const LAUNCH_STORAGE_KEYS = [
   'gc.bible.translation.v1', // bibleTranslationPref.ts → '' (no prior choice)
   'gc.reflection.today.v1', // reflectionDayStore.ts   → null (nothing cached)
   'gc.intro.seen.v1', // introSeen.ts            → false ('1' is the only true)
+  // reviewState.ts → DEFAULT_REVIEW_STATE. The odd one out: it does NOT gate the
+  // splash (nothing on screen depends on it, and the review gate cannot fire
+  // before the user has navigated somewhere). It rides this batch anyway rather
+  // than adding a fifteenth round trip for a key that is read on every launch.
+  'gc.review.v1',
 ] as const
 
 /**
  * Read `keys` in one batch and return a KVStorage that serves those reads from
  * memory.
  *
- * Behaviour that is deliberately identical to 14 separate getItem calls:
+ * Behaviour that is deliberately identical to one getItem call per key:
  *
  * - A key absent from storage yields null, which is what every store's
  *   missing-value branch already handles. multiGet reports an absent key as
  *   [key, null], and a pair missing from the response falls to null too.
  * - A REJECTING multiGet returns the raw store untouched, so each module does
  *   its own getItem behind its own try/catch just as it does today. Without
- *   this, one failed batch would reset all 14 keys to defaults at once — a far
- *   worse failure than the per-module degradation we have now.
+ *   this, one failed batch would reset every batched preference to its default
+ *   at once — a far worse failure than the per-module degradation we have now.
  *
  * The facade is a correct KVStorage for the app's whole lifetime, not just for
  * the launch read: the stores keep whatever storage they were handed for

--- a/apps/mobile/src/lib/reviewEligibility.ts
+++ b/apps/mobile/src/lib/reviewEligibility.ts
@@ -1,0 +1,257 @@
+import { OVERLAY_ROUTE_KEY } from './routeDwell'
+import type { ReviewState } from './reviewState'
+
+// The one place that decides whether to ask for an App Store / Play review.
+//
+// Everything the decision needs is passed in — no storage, no navigation, no
+// native modules, no clock — so the whole policy is a pure function that
+// unit-tests headless and can be reasoned about in one sitting. reviewService.ts
+// gathers the inputs; this file owns the rules.
+//
+// WHY THE RULES ARE THIS STRICT. The OS gives no callback: we cannot tell
+// whether the sheet rendered, whether the user rated, or whether the platform
+// silently swallowed the call because its own cap (~3/year on iOS) was already
+// spent. Every request is therefore an unverifiable, non-refundable attempt.
+// The cost of asking at a bad moment is a 1-star rating; the cost of not asking
+// is nothing at all. When those are the stakes, the gates should be boring.
+
+/** Foreground seconds on a viewer that count as "they were really reading it". */
+export const DWELL_THRESHOLD_MS = 90_000
+/** Consecutive reading days that count as a habit rather than a visit. */
+export const STREAK_THRESHOLD = 4
+/** Nobody is asked to rate an app they installed this week. */
+export const MIN_DAYS_SINCE_FIRST_LAUNCH = 7
+/** Distinct calendar days opened — filters the install-once-never-return case. */
+export const MIN_OPEN_DAYS = 3
+/** Cooling-off between attempts. Comfortably wider than the iOS annual cap. */
+export const MIN_DAYS_BETWEEN_REQUESTS = 120
+/** Hard lifetime ceiling. Once spent, this install is never asked again. */
+export const MAX_LIFETIME_REQUESTS = 3
+
+// Route patterns, as useSegments() reports them (joined by '/'). Matching is on
+// the PATTERN, so dynamic segments stay literal and no per-song logic exists.
+/** app/viewer/[slug].tsx — the Song Viewer. */
+export const SONG_VIEWER_ROUTE = 'viewer/[slug]'
+/** app/perform/[id].tsx — the Performer, a.k.a. the Setlist Viewer. */
+export const SET_VIEWER_ROUTE = 'perform/[id]'
+/** app/daily/reader.tsx — the M'Cheyne reader pushed from the Daily Word landing. */
+export const READER_ROUTE = 'daily/reader'
+/**
+ * app/(tabs)/daily.tsx — the Daily Word TAB, which renders the reader itself
+ * (not the landing) when the device-local `dailyWordDestination` preference is
+ * 'reader'. So this route qualifies for the streak trigger conditionally; see
+ * triggerFor.
+ */
+export const DAILY_TAB_ROUTE = '(tabs)/daily'
+
+export type ReviewTrigger = 'dwell' | 'streak'
+
+export type EligibilityInput = {
+  /** The route the user just LEFT (never the one they are on). */
+  routeKey: string
+  pathname: string
+  /** Foreground-only dwell on that route, in milliseconds. */
+  dwellMs: number
+  /** currentStreak() — already 0 when disabled, absent, or stale. */
+  streak: number
+  /** getDefaultsSnapshot().dailyWordDestination — decides what the Daily Word tab was. */
+  dailyWordDestination: 'landing' | 'reader'
+  /**
+   * A real store build, as strongly as the platform can tell us. On iOS this is
+   * the sandbox-receipt check inside expo-store-review's isAvailableAsync (which
+   * is false for TestFlight and Xcode installs); on Android it is the build
+   * profile, which CANNOT see the Play testing track. See reviewService.ts.
+   */
+  isProductionBuild: boolean
+  /** Anything visibly failed this run — see sessionError.ts. */
+  hasSessionError: boolean
+  /**
+   * Whether the intro had ALREADY been seen when this launch started. False
+   * covers both "never seen" and "seen during this very launch", which are the
+   * same disqualifier: a first-run user has not formed an opinion yet.
+   */
+  introSeenAtLaunch: boolean
+  state: ReviewState
+  /** Epoch milliseconds. */
+  now: number
+  /** Today's local date key (YYYY-MM-DD). */
+  today: string
+}
+
+export type EligibilityDecision =
+  | { eligible: true; trigger: ReviewTrigger; reason: string }
+  | { eligible: false; gate: EligibilityGate; reason: string }
+
+export type EligibilityGate =
+  | 'route'
+  | 'dwell'
+  | 'streak'
+  | 'production'
+  | 'sessionError'
+  | 'firstLaunchAge'
+  | 'openDays'
+  | 'intro'
+  | 'maxRequests'
+  | 'recentRequest'
+
+/** Whether a route is one whose dwell can ever earn a request. */
+function isViewerRoute(routeKey: string): boolean {
+  return routeKey === SONG_VIEWER_ROUTE || routeKey === SET_VIEWER_ROUTE
+}
+
+/** Whether a route was showing the M'Cheyne reader. */
+function isReaderRoute(routeKey: string, destination: 'landing' | 'reader'): boolean {
+  if (routeKey === READER_ROUTE) return true
+  return routeKey === DAILY_TAB_ROUTE && destination === 'reader'
+}
+
+/** Parse a YYYY-MM-DD key to a UTC timestamp, so day arithmetic ignores DST. */
+function parseDayKey(key: string | null): number | null {
+  if (!key) return null
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(key)
+  if (!m) return null
+  const ms = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+  return Number.isNaN(ms) ? null : ms
+}
+
+/** Whole days from `fromKey` to `toKey`, or null if either is missing/malformed. */
+export function daysBetweenDayKeys(fromKey: string | null, toKey: string | null): number | null {
+  const from = parseDayKey(fromKey)
+  const to = parseDayKey(toKey)
+  if (from === null || to === null) return null
+  return Math.floor((to - from) / 86_400_000)
+}
+
+/**
+ * A single line naming every input the decision saw, appended to both the
+ * "would request" log and every near-miss so the gate can be debugged from the
+ * console alone — which is the only way to exercise it, since the sheet does not
+ * render in TestFlight and is unreliable in Play internal testing.
+ */
+function describe(input: EligibilityInput, trigger: ReviewTrigger | null): string {
+  const daysSinceFirst = daysBetweenDayKeys(input.state.firstLaunchDate, input.today)
+  const daysSinceRequest =
+    input.state.lastRequestAt === null
+      ? null
+      : Math.floor((input.now - input.state.lastRequestAt) / 86_400_000)
+  return [
+    `trigger=${trigger ?? 'none'}`,
+    `route=${input.routeKey}`,
+    `path=${input.pathname}`,
+    `dwell=${Math.round(input.dwellMs / 1000)}s`,
+    `streak=${input.streak}`,
+    `days=${daysSinceFirst ?? 'n/a'}`,
+    `opens=${input.state.openDays}`,
+    `priorRequests=${input.state.requestCount}`,
+    `sinceRequest=${daysSinceRequest === null ? 'never' : `${daysSinceRequest}d`}`,
+    `production=${input.isProductionBuild}`,
+  ].join(', ')
+}
+
+/**
+ * Which positive signal (if any) this departure carries, ignoring every other
+ * gate. Exported for the tests and for the dev log's near-miss reporting.
+ */
+export function triggerFor(input: EligibilityInput): ReviewTrigger | null {
+  if (isViewerRoute(input.routeKey) && input.dwellMs >= DWELL_THRESHOLD_MS) return 'dwell'
+  if (isReaderRoute(input.routeKey, input.dailyWordDestination) && input.streak >= STREAK_THRESHOLD) {
+    return 'streak'
+  }
+  return null
+}
+
+/**
+ * The whole policy. Returns a decision plus a human-readable reason — the reason
+ * is the product here as much as the boolean, because the debug override in
+ * reviewService.ts is the only way to verify any of this end to end.
+ *
+ * Gate order is chosen so the reported failure is the most useful one: the
+ * trigger that ALMOST fired is named before the ambient gates, and the permanent
+ * disqualifier (lifetime cap) is named before the temporary one (cooling-off).
+ */
+export function evaluateReviewEligibility(input: EligibilityInput): EligibilityDecision {
+  const ctx = (trigger: ReviewTrigger | null) => describe(input, trigger)
+
+  // The overlay route never ends a visit and must never be evaluated; if one
+  // reaches here, something upstream is wrong. Fail closed rather than guess.
+  if (input.routeKey === OVERLAY_ROUTE_KEY) {
+    return { eligible: false, gate: 'route', reason: `overlay route (${ctx(null)})` }
+  }
+
+  const viewer = isViewerRoute(input.routeKey)
+  const reader = isReaderRoute(input.routeKey, input.dailyWordDestination)
+  if (!viewer && !reader) {
+    // Ordinary navigation, not a near-miss. The caller does not log this.
+    return { eligible: false, gate: 'route', reason: `not a qualifying route (${ctx(null)})` }
+  }
+
+  const trigger = triggerFor(input)
+  if (!trigger) {
+    return viewer
+      ? {
+          eligible: false,
+          gate: 'dwell',
+          reason: `dwell ${Math.round(input.dwellMs / 1000)}s < ${
+            DWELL_THRESHOLD_MS / 1000
+          }s (${ctx(null)})`,
+        }
+      : {
+          eligible: false,
+          gate: 'streak',
+          reason: `streak ${input.streak} < ${STREAK_THRESHOLD} (${ctx(null)})`,
+        }
+  }
+
+  const c = ctx(trigger)
+
+  if (!input.isProductionBuild) {
+    return { eligible: false, gate: 'production', reason: `not a production build (${c})` }
+  }
+  if (input.hasSessionError) {
+    return { eligible: false, gate: 'sessionError', reason: `an error occurred this session (${c})` }
+  }
+
+  const daysSinceFirst = daysBetweenDayKeys(input.state.firstLaunchDate, input.today)
+  // A null here means the first-launch date is missing or malformed, i.e. this
+  // install has not been stamped yet — treat it as brand new, never as eligible.
+  if (daysSinceFirst === null || daysSinceFirst < MIN_DAYS_SINCE_FIRST_LAUNCH) {
+    return {
+      eligible: false,
+      gate: 'firstLaunchAge',
+      reason: `${daysSinceFirst ?? 0} days since first launch < ${MIN_DAYS_SINCE_FIRST_LAUNCH} (${c})`,
+    }
+  }
+  if (input.state.openDays < MIN_OPEN_DAYS) {
+    return {
+      eligible: false,
+      gate: 'openDays',
+      reason: `opened on ${input.state.openDays} distinct days < ${MIN_OPEN_DAYS} (${c})`,
+    }
+  }
+  if (!input.introSeenAtLaunch) {
+    return {
+      eligible: false,
+      gate: 'intro',
+      reason: `intro not completed before this launch (${c})`,
+    }
+  }
+  if (input.state.requestCount >= MAX_LIFETIME_REQUESTS) {
+    return {
+      eligible: false,
+      gate: 'maxRequests',
+      reason: `${input.state.requestCount} lifetime requests >= ${MAX_LIFETIME_REQUESTS} (${c})`,
+    }
+  }
+  if (input.state.lastRequestAt !== null) {
+    const days = Math.floor((input.now - input.state.lastRequestAt) / 86_400_000)
+    if (days < MIN_DAYS_BETWEEN_REQUESTS) {
+      return {
+        eligible: false,
+        gate: 'recentRequest',
+        reason: `last request ${days} days ago < ${MIN_DAYS_BETWEEN_REQUESTS} (${c})`,
+      }
+    }
+  }
+
+  return { eligible: true, trigger, reason: `would request now (${c})` }
+}

--- a/apps/mobile/src/lib/reviewService.ts
+++ b/apps/mobile/src/lib/reviewService.ts
@@ -1,0 +1,254 @@
+import { useEffect } from 'react'
+import { AppState, Platform } from 'react-native'
+import { usePathname, useSegments } from 'expo-router'
+import * as StoreReview from 'expo-store-review'
+import { getDefaultsSnapshot, type KVStorage } from './defaults'
+import { hasSeenIntro } from './introSeen'
+import { currentStreak, streakDateKey } from './readingStreak'
+import { hasSessionError, sessionErrorScope } from './sessionError'
+import { createRouteDwellTracker, OVERLAY_ROUTE_KEY, type DwellEvent } from './routeDwell'
+import { evaluateReviewEligibility, triggerFor } from './reviewEligibility'
+import { getReviewState, hydrateReviewState, recordAppOpen, recordReviewRequest } from './reviewState'
+
+// Native wiring for the in-app review request. Keeps expo-store-review, AppState
+// and expo-router isolated from the pure policy in reviewEligibility.ts and the
+// pure clock in routeDwell.ts — the same split as readerReminder.ts /
+// readerReminderService.ts and accessibilityFlags.ts /
+// accessibilityFlagsService.ts.
+//
+// The feature has NO UI of its own. The OS sheet is the entire surface: no
+// pre-prompt, no "Enjoying GraceChords?" gate, no stars we drew ourselves.
+
+/**
+ * How long to let the destination screen settle before asking.
+ *
+ * The push animation has to be finished — a system sheet sliding up through a
+ * running transition looks broken — and this doubles as a grace period in which
+ * a user who is only passing through can navigate again and cancel the request.
+ */
+const SETTLE_MS = 1200
+
+/**
+ * The EAS build profile, injected at build time (see eas.json). The ONLY thing
+ * it can prove is that a binary did not come from the `development` or `preview`
+ * profile; it cannot see which Play track served it, because `eas submit`
+ * promotes one production AAB to internal testing and production alike.
+ */
+const BUILD_PROFILE = process.env.EXPO_PUBLIC_BUILD_PROFILE
+
+const tracker = createRouteDwellTracker()
+
+/** Snapshot of the intro flag as it stood when this launch began. */
+let introSeenAtLaunch = false
+/** Cached result of the platform availability check (null = not yet asked). */
+let available: boolean | null = null
+/** Pending settle timer, if a departure is waiting to be judged. */
+let pending: ReturnType<typeof setTimeout> | null = null
+/**
+ * Bumped on every navigation. Captured before an await and re-checked after, so
+ * a request can never land against a route the user has already left.
+ */
+let navGeneration = 0
+let currentRouteKey = ''
+/** One request per launch, whatever the gates say. */
+let requestedThisSession = false
+
+function log(message: string): void {
+  // Dev-only by construction: this is a debugging aid, not telemetry, and there
+  // is no analytics in this app by design.
+  if (__DEV__) console.log(`[review] ${message}`)
+}
+
+/**
+ * Whether the binary could plausibly be a real store install.
+ *
+ * iOS: expo-store-review's own isAvailableAsync is the strong signal and is
+ * checked separately — its native implementation returns false when the app has
+ * a sandbox receipt and no embedded provisioning profile, which is exactly the
+ * TestFlight (and Xcode-install) case. So iOS needs nothing more here beyond
+ * rejecting a mismatched build profile if one was injected.
+ *
+ * Android: THIS IS THE WEAK SPOT, and it is a platform limitation rather than an
+ * implementation shortcut. isAvailableAsync only checks that the Play Store app
+ * is installed, and Play internal/closed testing serves the SAME production AAB
+ * from the SAME store — getInstallerPackageName is 'com.android.vending' either
+ * way. Requiring the profile marker at least rules out dev clients and preview
+ * APKs; it cannot rule out an internal tester on the production track, and
+ * nothing available at runtime can.
+ */
+function isProductionProfile(): boolean {
+  if (__DEV__) return false
+  if (BUILD_PROFILE) return BUILD_PROFILE === 'production'
+  // Unset: trust iOS's receipt check, but refuse to guess on Android.
+  return Platform.OS === 'ios'
+}
+
+/** Ask the platform whether a review flow exists at all. Cached — it cannot change. */
+async function storeReviewAvailable(): Promise<boolean> {
+  if (available !== null) return available
+  try {
+    available = await StoreReview.isAvailableAsync()
+  } catch {
+    available = false
+  }
+  return available
+}
+
+function cancelPending(): void {
+  if (pending === null) return
+  clearTimeout(pending)
+  pending = null
+}
+
+/**
+ * Fire the request. Availability has already been confirmed by the caller, so
+ * reaching here always spends an attempt.
+ *
+ * The bookkeeping is written BEFORE the native call is awaited, and is not
+ * conditional on it resolving. Neither platform reports whether the sheet
+ * actually rendered — iOS silently no-ops once its own ~3/year cap is spent —
+ * so an attempt is spent and unverifiable the moment we ask. Recording
+ * afterwards, or only on success, would let a user be asked repeatedly.
+ */
+async function requestReviewNow(): Promise<void> {
+  requestedThisSession = true
+  recordReviewRequest(Date.now())
+  try {
+    await StoreReview.requestReview()
+  } catch {
+    // Nothing to do and nothing to tell the user: the sheet is the platform's,
+    // and a failure to present it is not their problem.
+  }
+}
+
+/**
+ * Judge a departure and, if it earns one, ask for a review.
+ *
+ * Called only after the destination has settled, and re-validated after every
+ * await so a late-resolving availability check cannot fire the sheet into a
+ * screen the user has since left.
+ */
+async function judgeDeparture(event: DwellEvent, generation: number): Promise<void> {
+  const stillHere = () =>
+    navGeneration === generation &&
+    AppState.currentState === 'active' &&
+    currentRouteKey !== OVERLAY_ROUTE_KEY
+
+  if (!stillHere()) return
+
+  const platformAvailable = await storeReviewAvailable()
+  if (!stillHere()) return
+
+  // In a dev build the production gate is SIMULATED as passing, so the rest of
+  // the policy can be exercised end to end — the sheet does not render in
+  // TestFlight and is unreliable in Play internal testing, which makes the log
+  // the only way to verify any of this. The API is never called below in dev,
+  // so nothing can leak from this.
+  const isProductionBuild = __DEV__ ? true : isProductionProfile() && platformAvailable
+
+  const decision = evaluateReviewEligibility({
+    routeKey: event.routeKey,
+    pathname: event.pathname,
+    dwellMs: event.dwellMs,
+    streak: currentStreak(),
+    dailyWordDestination: getDefaultsSnapshot().dailyWordDestination,
+    isProductionBuild,
+    hasSessionError: hasSessionError(),
+    introSeenAtLaunch,
+    state: getReviewState(),
+    now: Date.now(),
+    today: streakDateKey(new Date()),
+  })
+
+  if (!decision.eligible) {
+    // 'route' is ordinary navigation, not a near miss — logging every screen
+    // change would bury the near misses that matter.
+    if (decision.gate !== 'route') {
+      const scope = decision.gate === 'sessionError' ? ` [first failure: ${sessionErrorScope()}]` : ''
+      log(`blocked by ${decision.gate}: ${decision.reason}${scope}`)
+    }
+    return
+  }
+
+  if (__DEV__) {
+    log(`${decision.reason} — dev build, API NOT called`)
+    return
+  }
+  if (!platformAvailable) {
+    // Cannot happen (isProductionBuild folds this in), but an attempt must never
+    // be spent on a platform that has no review flow to show.
+    return
+  }
+  await requestReviewNow()
+}
+
+function scheduleJudgement(event: DwellEvent): void {
+  const generation = navGeneration
+  pending = setTimeout(() => {
+    pending = null
+    void judgeDeparture(event, generation)
+  }, SETTLE_MS)
+}
+
+/**
+ * Stamp the launch and snapshot the intro flag. Call once, after the launch
+ * stores have hydrated — recordAppOpen must not run against the default state or
+ * it would overwrite the real first-launch date with today's.
+ */
+export async function startReviewSession(store: KVStorage): Promise<void> {
+  // The intro gate needs "already seen BEFORE this launch". Reading hasSeenIntro
+  // here — after hydration, before the intro screen can mark it — gives exactly
+  // that, without the intro having to tell us anything.
+  introSeenAtLaunch = hasSeenIntro()
+  await hydrateReviewState(store)
+  recordAppOpen()
+  // Warm the availability cache so the request path has nothing to await.
+  void storeReviewAvailable().then((ok) => log(`store review available: ${ok}`))
+  const state = getReviewState()
+  log(
+    `session start (introSeenAtLaunch=${introSeenAtLaunch}, firstLaunch=${state.firstLaunchDate}, ` +
+      `opens=${state.openDays}, priorRequests=${state.requestCount})`,
+  )
+}
+
+/**
+ * Watch navigation and app lifecycle, and ask for a review after a genuinely
+ * positive departure. Mount ONCE, in the root layout.
+ *
+ * Reads navigation state only — the Song Viewer, Setlist Performer and Daily
+ * Word reader know nothing about this and are not touched.
+ */
+export function useReviewObserver(): void {
+  const segments = useSegments()
+  const pathname = usePathname()
+  // Depend on the joined STRING, not the array: useSegments returns a fresh
+  // array identity on re-render, and an effect keyed on it would cancel the
+  // settle timer on every incidental render of the root layout.
+  const routeKey = segments.join('/')
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      const now = Date.now()
+      if (state === 'active') {
+        tracker.onForeground(now)
+        return
+      }
+      tracker.onBackground(now)
+      // A sheet must never be queued up to appear on a screen the user walked
+      // away from, and iOS will not present one from the background anyway.
+      cancelPending()
+    })
+    return () => sub.remove()
+  }, [])
+
+  useEffect(() => {
+    navGeneration += 1
+    currentRouteKey = routeKey
+    // Any navigation invalidates a queued judgement: the user moved on.
+    cancelPending()
+
+    const departed = tracker.onRoute(routeKey, pathname, Date.now())
+    if (!departed || requestedThisSession) return
+    scheduleJudgement(departed)
+  }, [routeKey, pathname])
+}

--- a/apps/mobile/src/lib/reviewState.ts
+++ b/apps/mobile/src/lib/reviewState.ts
@@ -1,0 +1,130 @@
+import type { KVStorage } from './defaults'
+import { streakDateKey } from './readingStreak'
+
+// Device-local bookkeeping for the in-app review request.
+//
+// DELIBERATELY NOT ON THE SUPABASE PROFILE. Every value here describes this
+// INSTALL, not this account: the OS enforces its review quota per device, so a
+// user signing in on a second phone genuinely starts fresh, and syncing would
+// mean a schema change for data the server has no use for. Same reasoning as
+// gc.intro.seen.v1 (introSeen.ts).
+//
+// Follows the defaults.ts pattern — storage is INJECTED so the module is RN-free
+// and unit-testable headless. Unlike the stores in the splash gate, hydration
+// here does NOT block first paint: nothing on screen depends on it, and the
+// review gate cannot fire until the user has navigated somewhere anyway.
+//
+// The key rides the existing single multiGet in launchStorage.ts rather than
+// adding a fourteenth round trip.
+
+export type ReviewState = {
+  /** Local date key (YYYY-MM-DD) of the first launch we ever saw. */
+  firstLaunchDate: string | null
+  /**
+   * How many DISTINCT calendar days the app has been opened on.
+   *
+   * A count plus lastOpenDate, never a list of days: this store must not grow
+   * without bound over the years an install lives, and the gate only ever asks
+   * "at least 3?".
+   */
+  openDays: number
+  /** Local date key of the most recent open — guards openDays against double-counting. */
+  lastOpenDate: string | null
+  /** Epoch milliseconds of the last review request we made, or null. */
+  lastRequestAt: number | null
+  /** Lifetime count of review requests made from this install. */
+  requestCount: number
+}
+
+export const DEFAULT_REVIEW_STATE: ReviewState = {
+  firstLaunchDate: null,
+  openDays: 0,
+  lastOpenDate: null,
+  lastRequestAt: null,
+  requestCount: 0,
+}
+
+export const REVIEW_STORAGE_KEY = 'gc.review.v1'
+
+let cache: ReviewState = DEFAULT_REVIEW_STATE
+let storage: KVStorage | null = null
+
+function persist() {
+  storage?.setItem(REVIEW_STORAGE_KEY, JSON.stringify(cache)).catch(() => {})
+}
+
+function isReviewState(v: unknown): v is ReviewState {
+  if (!v || typeof v !== 'object') return false
+  const r = v as Record<string, unknown>
+  return (
+    (r.firstLaunchDate === null || typeof r.firstLaunchDate === 'string') &&
+    typeof r.openDays === 'number' &&
+    (r.lastOpenDate === null || typeof r.lastOpenDate === 'string') &&
+    (r.lastRequestAt === null || typeof r.lastRequestAt === 'number') &&
+    typeof r.requestCount === 'number'
+  )
+}
+
+/**
+ * Load the stored bookkeeping; a bad read falls back to the zeroed default.
+ *
+ * Falling back means "this install looks brand new", which RESTARTS the 7-day
+ * and 3-distinct-days clocks rather than skipping them — the safe direction,
+ * since the alternative would be treating a corrupt read as licence to prompt.
+ * The one value that would be unsafe to lose is requestCount, and losing it
+ * costs at most a re-earned attempt against a quota the OS enforces anyway.
+ */
+export async function hydrateReviewState(store: KVStorage): Promise<ReviewState> {
+  storage = store
+  try {
+    const parsed = JSON.parse((await store.getItem(REVIEW_STORAGE_KEY)) ?? 'null') as unknown
+    cache = isReviewState(parsed) ? parsed : DEFAULT_REVIEW_STATE
+  } catch {
+    cache = DEFAULT_REVIEW_STATE
+  }
+  return cache
+}
+
+/** Synchronous read (safe before hydrate — returns the zeroed default). */
+export function getReviewState(): ReviewState {
+  return cache
+}
+
+/**
+ * Stamp this launch: seed the first-launch date if unset, and count today if it
+ * is a day we have not counted before. Idempotent within a calendar day, so
+ * calling it once per launch is correct even for a user who opens the app
+ * fifteen times before lunch.
+ */
+export function recordAppOpen(today: Date = new Date()): void {
+  const todayKey = streakDateKey(today)
+  if (cache.firstLaunchDate && cache.lastOpenDate === todayKey) return
+  cache = {
+    ...cache,
+    firstLaunchDate: cache.firstLaunchDate ?? todayKey,
+    openDays: cache.lastOpenDate === todayKey ? cache.openDays : cache.openDays + 1,
+    lastOpenDate: todayKey,
+  }
+  persist()
+}
+
+/**
+ * Record that a review request was MADE — not that a sheet appeared, and not
+ * that anyone rated anything.
+ *
+ * There is no success callback on either platform, and the OS silently declines
+ * to render the sheet once its own quota is hit. An attempt is therefore spent
+ * and unverifiable the moment we ask, so this must be called BEFORE (or at
+ * least independently of) the request resolving. See requestReviewNow in
+ * reviewService.ts.
+ */
+export function recordReviewRequest(at: number = Date.now()): void {
+  cache = { ...cache, lastRequestAt: at, requestCount: cache.requestCount + 1 }
+  persist()
+}
+
+/** Test-only reset so each test starts from a clean module state. */
+export function __resetReviewStateForTest(): void {
+  cache = DEFAULT_REVIEW_STATE
+  storage = null
+}

--- a/apps/mobile/src/lib/routeDwell.ts
+++ b/apps/mobile/src/lib/routeDwell.ts
@@ -1,0 +1,164 @@
+// How long the user actually spent on the route they just left.
+//
+// Feeds the in-app review gate (reviewEligibility.ts), which treats "read a song
+// chart for a minute and a half, then navigated away" as a positive signal. The
+// whole value of that signal rests on the number being honest, so this module is
+// deliberately fussy about three things:
+//
+//  1. BACKGROUNDED TIME DOES NOT COUNT. A phone left face-up on a music stand
+//     accumulates nothing. Dwell is a sum of foreground segments, not
+//     (leaveTime - enterTime).
+//  2. SHEETS ARE NOT A DEPARTURE. Every sheet in the app presents through the
+//     shared `formSheet` route (app/sheet.tsx via src/lib/formSheetHost.ts), so
+//     opening "Export & share" from the Song Viewer is a real router navigation
+//     to `sheet`. Naively that reads as "left the viewer after 20s". The overlay
+//     route instead FREEZES the current route's clock and emits nothing;
+//     returning to the same pathname resumes it.
+//  3. NOTHING IS PERSISTED. Dwell is per-session, in memory, and dies with the
+//     process.
+//
+// Routes are identified two ways, and the distinction is load-bearing:
+//   - `routeKey` is the useSegments() pattern joined by '/' ('viewer/[slug]'),
+//     which is what qualification matches on — every song is the same key.
+//   - `pathname` is the usePathname() resolved path ('/viewer/still-alive'),
+//     which is what the clock is keyed on — so song A → song B ends A's dwell
+//     rather than silently pooling two half-reads into one qualifying visit.
+//     This is the conservative reading of "left the viewer after 90+ seconds".
+//
+// Pure and RN-free (the clock is passed in, never read) so it unit-tests
+// headless, matching readingStreak.ts / readerReminder.ts.
+
+/** The shared native-sheet route. Treated as an overlay, never as a departure. */
+export const OVERLAY_ROUTE_KEY = 'sheet'
+
+export type DwellEvent = {
+  /** useSegments() pattern, joined by '/' — e.g. 'viewer/[slug]'. */
+  routeKey: string
+  /** usePathname() resolved path — e.g. '/viewer/still-alive'. */
+  pathname: string
+  /** Foreground-only time spent on that route, in milliseconds. */
+  dwellMs: number
+}
+
+type Visit = {
+  routeKey: string
+  pathname: string
+  /** Foreground milliseconds banked from completed segments. */
+  bankedMs: number
+  /** Start of the currently-running segment, or null while paused. */
+  segmentStart: number | null
+  /** True while an overlay route (a sheet) is covering this visit. */
+  covered: boolean
+}
+
+export type RouteDwellTracker = {
+  /**
+   * Report the currently focused route. Returns the departure event for the
+   * PREVIOUS route when this navigation ends a visit, or null when it does not
+   * (first route of the session, entering or leaving an overlay, or a no-op
+   * re-report of the same path).
+   */
+  onRoute(routeKey: string, pathname: string, now: number): DwellEvent | null
+  /** App went to background/inactive — stop the clock. */
+  onBackground(now: number): void
+  /** App came back to foreground — restart the clock if a visit is live. */
+  onForeground(now: number): void
+  /** Current visit's dwell so far, for assertions and dev logging. */
+  peek(now: number): DwellEvent | null
+}
+
+function bank(visit: Visit, now: number): void {
+  if (visit.segmentStart === null) return
+  // Guard against a non-monotonic clock (NTP correction, manual time change):
+  // a negative delta must never subtract from banked dwell.
+  visit.bankedMs += Math.max(0, now - visit.segmentStart)
+  visit.segmentStart = null
+}
+
+function toEvent(visit: Visit, now: number): DwellEvent {
+  const running = visit.segmentStart === null ? 0 : Math.max(0, now - visit.segmentStart)
+  return {
+    routeKey: visit.routeKey,
+    pathname: visit.pathname,
+    dwellMs: visit.bankedMs + running,
+  }
+}
+
+/**
+ * Create an independent tracker. The app uses a single module-level instance
+ * (see reviewService.ts); tests get their own so state cannot leak between them.
+ *
+ * `foreground` starts true: the tracker is created while the app is running, and
+ * AppState only reports CHANGES, so assuming background would strand the clock
+ * until the user backgrounded and returned.
+ */
+export function createRouteDwellTracker(): RouteDwellTracker {
+  let visit: Visit | null = null
+  let foreground = true
+
+  return {
+    onRoute(routeKey, pathname, now) {
+      if (routeKey === OVERLAY_ROUTE_KEY) {
+        // A sheet opened over the current route. Freeze its clock and stay put —
+        // the user has not left, and a sheet is also the one moment we must
+        // never fire a review request, which "no event" handles for free.
+        if (visit && !visit.covered) {
+          bank(visit, now)
+          visit.covered = true
+        }
+        return null
+      }
+
+      if (!visit) {
+        visit = {
+          routeKey,
+          pathname,
+          bankedMs: 0,
+          segmentStart: foreground ? now : null,
+          covered: false,
+        }
+        return null
+      }
+
+      if (visit.pathname === pathname) {
+        // Either the sheet closed back onto the route that opened it, or the
+        // router re-reported an unchanged route. Resume; never emit.
+        if (visit.covered) {
+          visit.covered = false
+          visit.segmentStart = foreground ? now : null
+        }
+        return null
+      }
+
+      // A genuine departure — including "sheet dismissed straight into a
+      // different route", where the visit being left is the frozen one.
+      const departed = toEvent(visit, now)
+      visit = {
+        routeKey,
+        pathname,
+        bankedMs: 0,
+        segmentStart: foreground ? now : null,
+        covered: false,
+      }
+      return departed
+    },
+
+    onBackground(now) {
+      foreground = false
+      if (visit) bank(visit, now)
+    },
+
+    onForeground(now) {
+      foreground = true
+      // A covered visit stays paused: the sheet is still up, and it is the
+      // overlay's own close that resumes it.
+      if (visit && !visit.covered && visit.segmentStart === null) {
+        visit.segmentStart = now
+      }
+    },
+
+    peek(now) {
+      return visit ? toEvent(visit, now) : null
+    },
+  }
+}

--- a/apps/mobile/src/lib/sessionError.ts
+++ b/apps/mobile/src/lib/sessionError.ts
@@ -1,0 +1,50 @@
+// Did anything fail during THIS run of the app?
+//
+// Exists for one consumer: the in-app review gate (reviewEligibility.ts). Asking
+// someone to rate the app minutes after their export failed or their sign-in
+// bounced is the single most expensive mistake this feature can make — the OS
+// gives no callback, so every request is a spent, unverifiable attempt, and a
+// spent attempt on an annoyed user is worse than no attempt at all.
+//
+// Deliberately IN-MEMORY ONLY. The flag dies with the process, so a relaunch
+// starts clean: a failure means "not this session", not "never again". It is
+// also one-way within a session — nothing clears it — because a later success
+// does not undo the user's memory of the failure.
+//
+// RN-free and dependency-free so the modules that mark it (errors.ts, api.ts)
+// stay unit-testable headless, exactly as they are today.
+
+let errored = false
+let firstScope: string | null = null
+
+/**
+ * Record that something visibly failed. `scope` is the same caller identifier
+ * the error logs already use ('useSong', 'SetlistBuilder.export', …) and is kept
+ * only for the dev-build review log, so a near-miss names what poisoned the
+ * session.
+ *
+ * Idempotent: the FIRST failure wins, since that is the one that set the tone.
+ * Callers must not pass deliberate cancellations — see reportFailure's
+ * isAbortError check in errors.ts.
+ */
+export function markSessionError(scope: string): void {
+  if (errored) return
+  errored = true
+  firstScope = scope
+}
+
+/** Whether any failure has been recorded this session. */
+export function hasSessionError(): boolean {
+  return errored
+}
+
+/** The scope of the first failure this session, for dev logging only. */
+export function sessionErrorScope(): string | null {
+  return firstScope
+}
+
+/** Test-only reset so each test starts from a clean module state. */
+export function __resetSessionErrorForTest(): void {
+  errored = false
+  firstScope = null
+}

--- a/apps/mobile/src/screens/AuthScreen.tsx
+++ b/apps/mobile/src/screens/AuthScreen.tsx
@@ -23,6 +23,7 @@ import { supabase } from '../lib/supabase'
 import { MIN_PASSWORD_LENGTH, validateSignIn, validateSignUp } from '../lib/authValidation'
 import { appleSignIn, emailSignIn, emailSignUp, googleSignIn, type AuthResult } from '../lib/authFlows'
 import { makeAppleDeps, makeGoogleDeps } from '../lib/authDeps'
+import { markSessionError } from '../lib/sessionError'
 
 // The auth screen per the design reference: one route, two modes (sign in /
 // sign up) toggled in place, with native Google + Apple sign-in below the
@@ -55,10 +56,19 @@ export default function AuthScreen() {
     setError(null)
     try {
       const result = await flow()
-      if (!result.ok && !result.canceled && result.error) setError(result.error)
+      if (!result.ok && !result.canceled && result.error) {
+        // Marked here rather than in authFlows.ts, which is a pure,
+        // injected-deps module the vitest harness runs headless — and because
+        // this is the point where a failure actually reaches the user. A
+        // CANCELLED Apple/Google sheet is excluded: dismissing a sign-in prompt
+        // is a choice, not a bad experience. See sessionError.ts.
+        markSessionError('AuthScreen.signIn')
+        setError(result.error)
+      }
       return result
     } catch {
       const result: AuthResult = { ok: false, error: 'errors.generic' }
+      markSessionError('AuthScreen.signIn')
       setError(result.error!)
       return result
     } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     },
     "apps/mobile": {
       "name": "@gracechords/mobile",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@gracechords/core": "*",
         "@gracechords/tokens": "*",
@@ -51,6 +51,7 @@
         "expo-sharing": "~55.0.21",
         "expo-splash-screen": "~55.0.22",
         "expo-status-bar": "~55.0.6",
+        "expo-store-review": "~55.0.16",
         "expo-symbols": "~55.0.9",
         "expo-web-browser": "~55.0.17",
         "i18next": "^26.0.8",
@@ -1426,6 +1427,16 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "apps/mobile/node_modules/expo-store-review": {
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-store-review/-/expo-store-review-55.0.16.tgz",
+      "integrity": "sha512-1vPnMhPaoInzXcNQy5GkIvssC2W2okAOdAtPbWMX2YuV1PKO3NR4jEcb/lxJRDvVyZPurIEDaFLFV00ShZnXzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },


### PR DESCRIPTION
Asks for an App Store / Play review via `expo-store-review` after the user has genuinely engaged. **The OS sheet is the entire feature** — no pre-prompt, no "Enjoying GraceChords?" gate, no stars we drew, and deliberately no "Rate GraceChords" settings row (if one is ever added it must *deep-link* to the store page, never call `requestReview`, since a tap that silently does nothing is worse than no row).

## Why the gates are this conservative

The platform gives **no callback**. We cannot tell whether the sheet rendered, whether anyone rated, or whether the OS silently swallowed the call because its own cap (~3/year on iOS) was already spent. Every request is a spent, unverifiable attempt. The cost of asking at a bad moment is a 1-star rating; the cost of not asking is nothing. That asymmetry drives everything here — including banking the attempt **before** the native call is awaited, rather than on a success that never arrives.

## Shape

Pure logic split from native wiring, matching the existing `readerReminder.ts` / `readerReminderService.ts` convention, so the whole policy unit-tests headless.

| File | Role |
|---|---|
| `src/lib/routeDwell.ts` | Pure, injected clock. Foreground-only dwell. |
| `src/lib/reviewEligibility.ts` | Pure. The entire policy in one function, returning a decision **plus a reason string**. |
| `src/lib/reviewState.ts` | Device-local `gc.review.v1`, bounded by construction. |
| `src/lib/sessionError.ts` | In-memory only, never persisted. |
| `src/lib/reviewService.ts` | Native half; mounted once as `useReviewObserver()` in the root layout. |

**Triggers** (either): 90 s+ foreground dwell on `viewer/[slug]` or `perform/[id]`; or leaving the Daily Word reader with a 4+ day streak.
**Then all of**: production build · no error this session · 7+ days since first launch · 3+ distinct open days · intro seen *before* this launch · under 3 lifetime requests · 120+ days since the last.

Everything derives from navigation state — **the Song Viewer, Performer and Daily Word reader are untouched** and know nothing about this.

## Three things worth a reviewer's attention

**1. Sheets are router navigations in this app.** Every sheet presents through the shared `formSheet` route via `formSheetHost`, so opening "Export & share" from the Viewer is a real navigation to `sheet` — which naively reads as "left the viewer after 20s". The tracker treats `sheet` as a freeze-and-resume **overlay**, which also satisfies "never ask while a sheet is open" for free.

**2. Production detection is asymmetric, and the Android half is a platform limit — not a shortcut.**
- **iOS: solid.** `StoreReview.isAvailableAsync()` returns false when the bundle has a sandbox receipt and no embedded provisioning profile — i.e. TestFlight and Xcode installs.
- **Android: not possible.** It only checks that the Play Store app is installed, and Play internal/closed testing serves the **same production AAB** from the same store. `EXPO_PUBLIC_BUILD_PROFILE` (added per profile in `eas.json`) rules out dev clients and `preview` APKs but **cannot** rule out the internal-testing track. Nothing available at runtime can.
- Note `expo-application`'s `getIosApplicationReleaseTypeAsync()` is **not** a substitute despite appearances — it reports `APP_STORE` for TestFlight too, since neither has an embedded profile. Also avoided `expo-store-review`'s own `hasAction()`, which returns true whenever a store URL exists and would defeat the TestFlight check entirely.

**3. Session errors are wired by adding call sites only** — no refactoring of existing error handling. `errors.ts` (below the `isAbortError` check, so a user cancellation isn't treated as a bad experience), `api.ts`, `exportSong.ts`, `AuthScreen.tsx`. Hooking `errors.ts` covers ~20 existing call sites app-wide without touching any of them.

Two failure paths remain **unreachable** because they live in out-of-scope files behind local helpers that bypass `errors.ts`: the Song Viewer's `handleEditPersonal` catch, and the Performer's live-session `start()`/`end()`.

## Verification

Because the sheet doesn't appear in TestFlight and is unreliable in Play internal testing, **dev builds never call the API**: eligibility is evaluated in full and logged, and near-misses log the specific failing gate.

Verified on the **iOS simulator and an Android emulator** via that log:

```
[review] blocked by dwell: dwell 57s < 90s (trigger=none, route=viewer/[slug], …)
[review] would request now (trigger=streak, route=daily/reader, dwell=14s, streak=4,
         days=11, opens=5, priorRequests=0) — dev build, API NOT called
[review] blocked by sessionError: an error occurred this session (…) [first failure: useSetlistBuilder.load]
```

- Short dwell blocked; 90 s+ dwell and a 4-day streak eligible
- **~3.5 min on a route, most of it backgrounded → measured as 20 s**
- Eligibility never evaluated while still on the qualifying route
- A real load failure blocked the same exit that was eligible moments before; relaunch cleared it
- `requestCount: 0` in storage after an eligible decision — nothing banked in dev
- Android identical: `blocked by dwell: dwell 12s < 90s (route=viewer/[slug]…)`

**64 new tests** (`routeDwell`, `reviewEligibility`, `reviewState`, `sessionError`, plus a `reviewFlow` integration suite over the navigation → dwell → eligibility seam). `git status` shows no changes to `android/` or `ios/`.

⚠️ Pre-existing on `main`, not from this branch: `launchStorage.test.ts` imports `getColumnMode`, which `viewerPrefs.ts` now exports as `getColumns` — 1 typecheck error and 2 test failures. Left alone as out of scope; happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
