### PR TITLE
fix(mobile): repair cross-origin redirects that stripped the auth header

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -8,11 +8,17 @@ EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your-public-anon-key
 
 # Base URL of the deployed web app (Cloudflare Pages) — the mobile app calls
-# its Pages Functions for song export (/api/export/song) and Telegram push
-# (/api/telegram/push). Use the CANONICAL domain (the one that serves the
-# site directly, e.g. https://www.gracechords.com): a redirecting domain
-# (apex → www) turns POSTs into GETs and the API answers 405.
-EXPO_PUBLIC_API_BASE_URL=https://www.gracechords.com
+# its Pages Functions for song export (/api/export/song), Telegram push
+# (/api/telegram/push) and Telegram account linking (/api/telegram/link).
+#
+# Use the CANONICAL origin — the one that serves the site DIRECTLY, which for
+# this project is the apex https://gracechords.com. www.gracechords.com
+# 301-redirects to it, and a redirecting host breaks authenticated calls twice
+# over: a cross-origin redirect STRIPS the Authorization header (every GET and
+# DELETE 401s with "Missing bearer token"), and a 301/302 rewrites POST to GET
+# (the API answers 405). api.ts repairs both, but the repair costs a round trip
+# and exists for the misconfigured case — do not rely on it.
+EXPO_PUBLIC_API_BASE_URL=https://gracechords.com
 
 # Base URL for Cloudflare R2 Bible assets (Daily Word reader). Same bucket the
 # web app reads via VITE_R2_PUBLIC_URL; mobile fetches the JSON directly.

--- a/apps/mobile/src/lib/__tests__/errors.test.ts
+++ b/apps/mobile/src/lib/__tests__/errors.test.ts
@@ -127,7 +127,7 @@ describe('actionFailureMessage', () => {
     // "Something went wrong" would strand whoever is testing a bad build.
     const hint =
       'The API rejected the request (405) — EXPO_PUBLIC_API_BASE_URL likely points at a ' +
-      'redirecting domain. Set it to the canonical one (e.g. https://www.gracechords.com).'
+      'redirecting domain. Set it to the canonical one (e.g. https://gracechords.com).'
     expect(actionFailureMessage('SongbookBuilder.export', new UserFacingError(hint), t)).toBe(hint)
   })
 

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -35,36 +35,49 @@ async function authHeader(): Promise<{ Authorization: string }> {
   return { Authorization: `Bearer ${session.access_token}` }
 }
 
-/**
- * GET or DELETE with the caller's Supabase bearer token.
- *
- * No 405-redirect retry, unlike apiPost: that retry exists because a redirect
- * rewrites POST to GET, which cannot happen to a method that is already safe or
- * idempotent (307/308 preserve the method, 301/302 on a GET are transparent).
- */
-export async function apiRequest(method: 'GET' | 'DELETE', path: string): Promise<Response> {
-  return budgetedFetch(`${apiBase()}${path}`, { method, headers: await authHeader() })
+// A CROSS-ORIGIN REDIRECT BREAKS AN AUTHENTICATED REQUEST IN TWO WAYS, and both
+// land as a status code we can recognise:
+//
+//   401 — fetch drops the Authorization header when a redirect crosses origins
+//         (www.gracechords.com → gracechords.com are different origins), so the
+//         API sees no credentials and answers "Missing bearer token".
+//   405 — a 301/302 rewrites POST to GET per spec, and the API rejects the
+//         method. (307/308 would preserve it; Cloudflare's apex/www rule is 301.)
+//
+// Neither is a failure the user can act on and neither is visible in the request
+// we issued, so on either status — and only when the response came back from a
+// DIFFERENT origin than we aimed at, which is proof a redirect happened — we
+// re-issue the original request, method and headers intact, against that final
+// origin. Once.
+//
+// This exists as a backstop, not a strategy: EXPO_PUBLIC_API_BASE_URL should
+// name the canonical origin (see .env.example) and then this never fires. It is
+// here because the failure it repairs is otherwise invisible — a stripped header
+// reads as "not linked" or "not signed in" rather than as a misconfiguration,
+// which is exactly how it survived into a shipped build once already.
+const REDIRECT_REPAIRABLE = new Set([401, 405])
+
+async function sendRepairingRedirect(path: string, init: RequestInit): Promise<Response> {
+  const target = `${apiBase()}${path}`
+  const res = await budgetedFetch(target, init)
+  if (!REDIRECT_REPAIRABLE.has(res.status) || !res.url) return res
+  const finalOrigin = new URL(res.url).origin
+  if (finalOrigin === new URL(target).origin) return res
+  return budgetedFetch(`${finalOrigin}${path}`, init)
 }
 
-// POST JSON with the caller's Supabase bearer token. If the configured base
-// URL redirects (e.g. apex → www), fetch follows the redirect but converts
-// the POST to a GET per spec, and the API answers 405 — so on a redirected
-// 405 we retry the POST once against the redirect's final origin.
-export async function apiPost(path: string, body: unknown): Promise<Response> {
-  const headers = {
-    ...(await authHeader()),
-    'Content-Type': 'application/json',
-  }
-  const payload = JSON.stringify(body)
+/** GET or DELETE with the caller's Supabase bearer token. */
+export async function apiRequest(method: 'GET' | 'DELETE', path: string): Promise<Response> {
+  return sendRepairingRedirect(path, { method, headers: await authHeader() })
+}
 
-  let res = await budgetedFetch(`${apiBase()}${path}`, { method: 'POST', headers, body: payload })
-  if (res.status === 405 && res.url) {
-    const finalOrigin = new URL(res.url).origin
-    if (finalOrigin !== new URL(apiBase()).origin) {
-      res = await budgetedFetch(`${finalOrigin}${path}`, { method: 'POST', headers, body: payload })
-    }
-  }
-  return res
+/** POST JSON with the caller's Supabase bearer token. */
+export async function apiPost(path: string, body: unknown): Promise<Response> {
+  return sendRepairingRedirect(path, {
+    method: 'POST',
+    headers: { ...(await authHeader()), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
 }
 
 // Read the API's { error } body into a thrown-Error message, with a
@@ -79,9 +92,11 @@ export async function apiError(res: Response, fallback: string): Promise<Error> 
     // UserFacingError so actionFailureMessage shows this verbatim instead of
     // replacing it with generic copy: it names the exact misconfiguration and the
     // exact fix, and whoever hits it is a developer or a tester on a bad build.
+    // Reaching here means sendRepairingRedirect already retried and still got a
+    // 405, so the base URL is wrong in a way one redirect hop cannot fix.
     return new UserFacingError(
       'The API rejected the request (405) — EXPO_PUBLIC_API_BASE_URL likely points at a ' +
-        'redirecting domain. Set it to the canonical one (e.g. https://www.gracechords.com).',
+        'redirecting domain. Set it to the canonical one (e.g. https://gracechords.com).',
     )
   }
   const body = (await res.json().catch(() => null)) as { error?: string } | null


### PR DESCRIPTION
## What was wrong

`EXPO_PUBLIC_API_BASE_URL` was set to `https://www.gracechords.com`, but **www 301-redirects to the apex** — the apex is what serves the site directly:

```
https://www.gracechords.com/api/telegram/link  →  301  →  https://gracechords.com/api/telegram/link
```

That redirect crosses origins, so `fetch` (and iOS URLSession) **drop the `Authorization` header**. Every authenticated `GET`/`DELETE` to the Pages Functions API arrived with no credentials and came back `401 {"error":"Missing bearer token"}`.

This was live in the shipped configuration, not just locally — the EAS `production` environment carried the same value.

## How it showed up

Telegram account linking on the Account screen. `fetchTelegramLink()` 401'd on every call, `AccountScreen.loadTelegram` swallowed it into a `console.error` (by design — "status is decoration on a settings row"), and state stayed at `UNLINKED`. So an account that *was* linked still rendered "Link Telegram", and the already-linked gate at `AccountScreen.tsx:313` never fired — tapping it minted a fresh link token instead of opening the unlink sheet. Unlink (`DELETE`) was broken the same way, and unreachable anyway.

POSTs survived by accident: the 301 rewrote them to GET, the API answered 405, and `apiPost`'s existing 405 retry re-issued them against the final origin. That's why linking, push and exports all worked while status silently lied.

No data was corrupted — the bot's link PATCH is idempotent for the same Telegram account.

## What changed

- **`api.ts`** — replaced the POST-only 405 retry with `sendRepairingRedirect`, shared by `apiRequest` and `apiPost`. It retries once against the response's final origin on **401 or 405**, but only when that origin differs from the one requested (proof a redirect happened). A genuine expired-token 401 hits the origin check, matches, and returns immediately — no extra request.
- **`.env.example`** — names the apex as canonical and documents both failure modes. The old comment had the direction backwards and asserted www *was* the canonical host, which is how this got set wrong in the first place.
- **405 hint string** (+ its assertion in `errors.test.ts`) — corrected to `https://gracechords.com`.

Config fixed out-of-band, not in this diff:
- EAS `production` via `eas env:set` — `eas env:list production` now reads `https://gracechords.com`
- local `apps/mobile/.env` (gitignored)

## Reviewer notes

- The base-URL fix alone resolves this; the `api.ts` change is a backstop so the failure can't recur silently. A stripped auth header presents as "not linked" / "not signed in", never as a misconfiguration — worth keeping the repair even once the config is right.
- `api.ts` has no unit test because it imports `./supabase`, which pulls in React Native and can't run headless under vitest. Making `sendRepairingRedirect` testable would mean extracting it to an RN-free module; happy to do that in a follow-up if you'd like coverage.
- The rest of the Telegram flow audited clean and is untouched: single-use 10-min link tokens inside Telegram's 64-char `[A-Za-z0-9_-]` start-payload limit, the `users_telegram_user_id_key` UNIQUE constraint refusing takeover rather than transferring, `409 needs_link` gating on `/api/telegram/push`, and the web profile path (same-origin relative fetch, never affected).

**Known, out of scope:** `preview` and `development` EAS environments have no `EXPO_PUBLIC_API_BASE_URL` at all — a cloud build on those profiles throws from `apiBase()`. And an invalid bearer token against `/api/telegram/link` returns an opaque Cloudflare `502` instead of the endpoint's JSON 401, so an expired token likely surfaces as `telegram_status_failed_502` rather than a clean re-auth signal.

## Testing

- `tsc --noEmit` clean
- 616/616 vitest tests pass (52 files)
- Endpoint behaviour confirmed against production: apex answers the function directly with no redirect hop; www 301s and arrives stripped

Requires a Metro restart to take effect locally — `EXPO_PUBLIC_*` values are inlined at bundle time. No native rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)